### PR TITLE
Fix MarkBoundary for repeat runs

### DIFF
--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -44,6 +44,10 @@ struct ScenarioSpec {
 
     void addCommand(std::unique_ptr<CommandDesc> command);
 
+    bool isLastCommand(CommandType type) const;
+
+    uint64_t commandCount(CommandType type) const;
+
     std::vector<std::unique_ptr<ResourceDesc>> resources{};
     std::vector<std::unique_ptr<CommandDesc>> commands{};
     std::unordered_map<Guid, uint32_t> resourceRefs{};


### PR DESCRIPTION
Two different cases of scenarios containing
MarkBoundaries were working incorrectly with
repeat runs. This patch addresses this.

Change-Id: Ie4efb74351324e59db126c6f205de8c8a3cb78d2
Signed-off-by: Erik Andersson <erik.andersson@arm.com>