### PR TITLE
Add clamping of mipLevels

### DIFF
--- a/src/image.hpp
+++ b/src/image.hpp
@@ -83,6 +83,7 @@ class Image : public Resource {
 
   private:
     std::vector<char> getImageData(Context &ctx);
+    uint32_t getFormatMaxMipLevels(const Context &ctx, vk::ImageTiling tiling, vk::ImageUsageFlags usageFlags);
 
     vk::raii::Image _image{nullptr};
     vk::raii::Buffer _stagingBuffer{nullptr};

--- a/src/tests/resources/scenarios/test_tiling/invalid_optimal_tiling_mip_level.json
+++ b/src/tests/resources/scenarios/test_tiling/invalid_optimal_tiling_mip_level.json
@@ -1,0 +1,20 @@
+{
+    "resources": [
+        {
+            "image": {
+                "uid": "imageX",
+                "dims": [
+                    1,
+                    10000000,
+                    10000000,
+                    1
+                ],
+                "format": "VK_FORMAT_R32_UINT",
+                "shader_access": "readonly",
+                "tiling": "OPTIMAL",
+                "mips" : 20
+            }
+        }
+    ],
+    "commands": []
+}

--- a/src/tests/test_tiling.py
+++ b/src/tests/test_tiling.py
@@ -301,3 +301,18 @@ def test_tensor_image_tiling_mismatch_should_fail(sdk_tools, capfd):
 
         print("Captured combined output:\n", combined)
         assert "Aliased resources must have identical tiling" in combined
+
+
+def test_image_format_and_mipmap_tiling_support(sdk_tools, capfd):
+    scenario_file = "test_tiling/invalid_optimal_tiling_mip_level.json"
+
+    try:
+        sdk_tools.run_scenario(scenario_file)
+        assert False, "Expected CalledProcessError due to high mip level"
+    except subprocess.CalledProcessError:
+        # Capture both stdout and stderr that pytest sees
+        out, err = capfd.readouterr()
+        combined = out + err
+
+        print("Captured combined output:\n", combined)
+        assert "mip level provided is not supported" in combined


### PR DESCRIPTION
This patch addresses a validation layer and subsequent unsupported format error where the set mipmap level exceeds the supported level for that format and physical device

Change-Id: I10fdaf5da9ddb6059b9f03f63267e954f44799e6