### PR TITLE
Add support for memory offset in aliased resources

### DIFF
--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -17,11 +17,9 @@ class Buffer : public Resource {
     /// \brief Constructor
     ///
     /// \param ctx  Contextual information about the Vulkan instance
-    /// \param debugName Debug name
-    /// \param size Total size of buffer in bytes
+    /// \param bufferInfo buffer Information
     /// \param memoryManager Information about (possibly shared) underlying memory
-    Buffer(const Context &ctx, const std::string &debugName, uint32_t size,
-           std::shared_ptr<ResourceMemoryManager> memoryManager);
+    Buffer(const Context &ctx, const BufferInfo &bufferInfo, std::shared_ptr<ResourceMemoryManager> memoryManager);
     Buffer() = default;
 
     /// \brief Buffer accessor
@@ -61,6 +59,7 @@ class Buffer : public Resource {
     uint32_t _size{0};
     std::string _debugName{};
     std::shared_ptr<ResourceMemoryManager> _memoryManager;
+    uint64_t _memoryOffset{0};
 };
 
 } // namespace mlsdk::scenariorunner

--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -22,19 +22,18 @@ namespace mlsdk::scenariorunner {
 DataManager::DataManager(Context &ctx) : _ctx(ctx) {}
 
 void DataManager::createBuffer(Guid guid, const BufferInfo &info) {
-    _buffers.insert({guid, Buffer(_ctx, info.debugName, info.size, getOrCreateMemoryManager(guid))});
+    _buffers.insert({guid, Buffer(_ctx, info, getOrCreateMemoryManager(guid))});
 }
 
 void DataManager::createBuffer(Guid guid, const BufferInfo &info, std::vector<char> &values) {
-    _buffers.insert({guid, Buffer(_ctx, info.debugName, info.size, getOrCreateMemoryManager(guid))});
+    createBuffer(guid, info);
     auto &buffer = getBufferMut(guid);
     buffer.allocateMemory(_ctx);
     buffer.fill(values.data(), values.size());
 }
 
 void DataManager::createTensor(Guid guid, const TensorInfo &info) {
-    _tensors.insert({guid, Tensor(_ctx, info.debugName, info.format, info.shape, info.isAliasedWithImage,
-                                  Tensor::convertTiling(info.tiling), getOrCreateMemoryManager(guid), false)});
+    _tensors.insert({guid, Tensor(_ctx, info, getOrCreateMemoryManager(guid))});
 }
 
 void DataManager::createImage(Guid guid, const ImageInfo &info) {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -13,7 +13,8 @@
 namespace mlsdk::scenariorunner {
 
 Image::Image(Context &ctx, const ImageInfo &imageInfo, std::shared_ptr<ResourceMemoryManager> memoryManager)
-    : _imageInfo(imageInfo), _memoryManager(std::move(memoryManager)), _mips(imageInfo.mips) {
+    : _imageInfo(imageInfo), _memoryManager(std::move(memoryManager)), _mips(imageInfo.mips),
+      _memoryOffset(imageInfo.memoryOffset) {
     // Create image
 
     if (_mips == 0) {
@@ -129,7 +130,7 @@ Image::Image(Context &ctx, const ImageInfo &imageInfo, std::shared_ptr<ResourceM
     _sampler = vk::raii::Sampler(ctx.device(), samplerCreateInfo);
 
     vk::MemoryRequirements memoryRequirements = _image.getMemoryRequirements();
-    _memoryManager->updateMemSize(memoryRequirements.size);
+    _memoryManager->updateMemSize(memoryRequirements.size + _memoryOffset);
     _memoryManager->updateMemType(memoryRequirements.memoryTypeBits);
 
     vk::ImageSubresource targetSubresource(getImageAspectMaskForVkFormat(_dataType));
@@ -252,7 +253,7 @@ void Image::allocateMemory(Context &ctx) {
     }
 
     // Bind image to memory
-    const vk::BindImageMemoryInfo bindInfo(*_image, *_memoryManager->getDeviceMemory());
+    const vk::BindImageMemoryInfo bindInfo(*_image, *_memoryManager->getDeviceMemory(), _memoryOffset);
     ctx.device().bindImageMemory2(vk::ArrayProxy<vk::BindImageMemoryInfo>(bindInfo));
 
     const vk::ImageAspectFlags aspectMask = getImageAspectMaskForVkFormat(_dataType);

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -42,8 +42,8 @@ class Image : public Resource {
     /// \return Size of image packed data in bytes
     uint64_t dataSize() const;
 
-    /// \brief Get image allocated memory size in bytes
-    /// \return Size of image memory in bytes
+    /// \brief Get total size of memory object associated with this tensor
+    /// \return Size of memory in bytes
     uint64_t memSize() const;
 
     /// \brief Get image data type
@@ -100,6 +100,7 @@ class Image : public Resource {
     vk::ImageLayout _initialLayout{};
     vk::ImageLayout _targetLayout{};
     vk::ImageTiling _tiling{};
+    uint64_t _memoryOffset{0};
 };
 
 } // namespace mlsdk::scenariorunner

--- a/src/json_reader.cpp
+++ b/src/json_reader.cpp
@@ -339,7 +339,7 @@ void from_json(const json &j, PushConstantMap &pushConstantMap) {
 void from_json(const json &j, MemoryGroup &group) {
     group.memoryUid = j.at("id");
     if (j.count("offset") != 0) {
-        group.offset = j.at("offset").get<int>();
+        group.offset = j.at("offset").get<uint64_t>();
     }
 }
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -186,9 +186,6 @@ Pipeline::Pipeline(Context &ctx, const std::string &debugName, const uint32_t se
         }
 
         const Tensor &tensor = dataManager->getTensor(resourceRef);
-        if (tensor.isConstant()) {
-            throw std::runtime_error("Cannot bind a constant Tensor");
-        }
 
         const int64_t *strides_ptr = tensor.dimStrides().data();
         if (tensor.dimStrides().empty()) {

--- a/src/resource_desc.hpp
+++ b/src/resource_desc.hpp
@@ -30,7 +30,7 @@ enum class ResourceType {
 
 struct MemoryGroup {
     Guid memoryUid;
-    int offset{};
+    uint64_t offset{};
 };
 
 /**

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -208,6 +208,9 @@ void Scenario::setupResources() {
             BufferInfo info;
             info.debugName = buffer->guidStr;
             info.size = buffer->size;
+            if (buffer->memoryGroup.has_value()) {
+                info.memoryOffset = buffer->memoryGroup->offset;
+            }
             _dataManager.createBuffer(resource->guid, info);
         } break;
         case (ResourceType::RawData): {
@@ -280,6 +283,10 @@ void Scenario::setupResources() {
             if (info.targetFormat == vk::Format::eR32Sfloat && info.format == vk::Format::eD32SfloatS8Uint) {
                 // Convert depth type to single channel color type, dropping stencil component
                 info.format = info.targetFormat;
+            }
+
+            if (image->memoryGroup.has_value()) {
+                info.memoryOffset = image->memoryGroup->offset;
             }
 
             for (const auto &[group, resources] : _dataManager.getResourceMemoryGroups()) {
@@ -359,6 +366,9 @@ void Scenario::setupResources() {
 
             TensorInfo info;
             info.debugName = tensor->guidStr;
+            if (tensor->memoryGroup.has_value()) {
+                info.memoryOffset = tensor->memoryGroup->offset;
+            }
             for (const auto &[group, resources] : _dataManager.getResourceMemoryGroups()) {
                 if (resources.find(tensor->guid) != resources.end() && resources.size() != 1) {
                     for (const auto &maybeImage : resources) {

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -18,16 +18,9 @@ class Tensor : public Resource {
     /// \brief Constructor
     ///
     /// \param ctx                    Contextual information about the Vulkan instance
-    /// \param debugName              Debug name
-    /// \param dataType               Tensor data type
-    /// \param shape                  Tensor shape
-    /// \param isAliasedWithImage     True if tensor is aliasing with an image
-    /// \param tiling                 Tensor tiling type default to Linear
+    /// \param tensorInfo             Tensor info
     /// \param memoryManager          Memory manager for this resource
-    /// \param isConstant             True if tensor is constant
-    Tensor(Context &ctx, const std::string &debugName, vk::Format dataType, const std::vector<int64_t> &shape,
-           bool isAliasedWithImage, vk::TensorTilingARM tiling, std::shared_ptr<ResourceMemoryManager> memoryManager,
-           bool isConstant = false);
+    Tensor(Context &ctx, const TensorInfo &tensorInfo, std::shared_ptr<ResourceMemoryManager> memoryManager);
     Tensor() = default;
 
     /// \brief Tensor accessor
@@ -38,8 +31,8 @@ class Tensor : public Resource {
     /// \return The underlying Vulkan tensor view
     const vk::TensorViewARM &tensorView() const;
 
-    /// \brief Get tensor memory size in bytes
-    /// \return Size of tensor memory in bytes
+    /// \brief Get total size of memory object associated with this tensor
+    /// \return Size of memory in bytes
     uint64_t memSize() const;
 
     /// \brief Get tensor packed data size in bytes
@@ -69,9 +62,6 @@ class Tensor : public Resource {
     /// \brief Un-maps a buffer from the host
     void unmap();
 
-    /// \brief checks if tensor is a constant tensor resource
-    bool isConstant() const { return _isConstant; };
-
     /// \brief checks if tensor's shape has been converted from dims=[] to dims=[1]
     bool isRankConverted() const { return _rankConverted; };
 
@@ -100,7 +90,7 @@ class Tensor : public Resource {
     std::vector<int64_t> _strides{};
     std::shared_ptr<ResourceMemoryManager> _memoryManager{nullptr};
     vk::TensorTilingARM _tiling = vk::TensorTilingARM::eLinear;
-    bool _isConstant{false};
+    uint64_t _memoryOffset{0};
     bool _rankConverted{false};
 };
 

--- a/src/tests/resources/scenarios/test_memory_aliasing/image_to_tensor_aliasing_aliased_tensor_plus_ten_shader_offset_outputs.json
+++ b/src/tests/resources/scenarios/test_memory_aliasing/image_to_tensor_aliasing_aliased_tensor_plus_ten_shader_offset_outputs.json
@@ -1,0 +1,124 @@
+{
+    "commands": [
+        {
+            "dispatch_compute": {
+                "bindings": [
+                    {
+                        "set": 0,
+                        "id": 0,
+                        "resource_ref": "_inputTensor"
+                    },
+                    {
+                        "set": 0,
+                        "id": 1,
+                        "resource_ref": "_outputTensor0"
+                    }
+                ],
+                "shader_ref": "plus_ten_tensor",
+                "rangeND": [
+                    16,
+                    64,
+                    2
+                ]
+            }
+        }
+    ],
+    "resources": [
+        {
+            "shader": {
+                "uid": "plus_ten_tensor",
+                "src": "plus_ten_tensor.spv",
+                "entry": "main",
+                "type": "SPIR-V"
+            }
+        },
+        {
+            "image": {
+                "shader_access": "readonly",
+                "dims": [
+                    1,
+                    64,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16G16_SFLOAT",
+                "min_filter": "LINEAR",
+                "mag_filter": "LINEAR",
+                "mip_filter": "NEAREST",
+                "src": "temp.dds",
+                "uid": "_inputImage",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    64,
+                    2
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_inputTensor",
+                "dst": "input.npy",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    64,
+                    2
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_outputTensor0",
+                "memory_group": {
+                    "id": "memoryGroup1"
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    32,
+                    2
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_outputTensor1",
+                "dst": "output0.npy",
+                "memory_group": {
+                    "id": "memoryGroup1"
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    32,
+                    2
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_outputTensor2",
+                "dst": "output1.npy",
+                "memory_group": {
+                    "id": "memoryGroup1",
+                    "offset": 2048
+                }
+            }
+        }
+    ]
+}

--- a/src/tests/resources/scenarios/test_memory_aliasing/input_buffer_output_buffer_buffer_offset.json
+++ b/src/tests/resources/scenarios/test_memory_aliasing/input_buffer_output_buffer_buffer_offset.json
@@ -1,0 +1,39 @@
+{
+    "commands": [],
+    "resources": [
+        {
+            "buffer": {
+                "shader_access": "readwrite",
+                "size": 256,
+                "src": "inBuffer.npy",
+                "uid": "inBuffer",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "buffer": {
+                "shader_access": "readwrite",
+                "size": 128,
+                "dst": "outBuffer0.npy",
+                "uid": "outBuffer0",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "buffer": {
+                "shader_access": "readwrite",
+                "size": 128,
+                "dst": "outBuffer1.npy",
+                "uid": "outBuffer1",
+                "memory_group": {
+                    "id": "memoryGroup0",
+                    "offset": 128
+                }
+            }
+        }
+    ]
+}

--- a/src/tests/resources/scenarios/test_memory_aliasing/input_image_output_tensor_tensor_offset.json
+++ b/src/tests/resources/scenarios/test_memory_aliasing/input_image_output_tensor_tensor_offset.json
@@ -1,0 +1,57 @@
+{
+    "commands": [],
+    "resources": [
+        {
+            "image": {
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    1
+                ],
+                "shader_access": "image_read",
+                "format": "VK_FORMAT_R16G16_SFLOAT",
+                "uid": "inImage",
+                "src": "inImage.dds",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    32,
+                    64,
+                    2
+                ],
+                "format": "VK_FORMAT_R16_SINT",
+                "uid": "outTensor0",
+                "dst": "outTensor0.npy",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    32,
+                    64,
+                    2
+                ],
+                "format": "VK_FORMAT_R16_SINT",
+                "uid": "outTensor1",
+                "dst": "outTensor1.npy",
+                "memory_group": {
+                    "id": "memoryGroup0",
+                    "offset": 8192
+                }
+            }
+        }
+    ]
+}

--- a/src/tests/resources/scenarios/test_memory_aliasing/input_tensor_output_buffer_image_offset.json
+++ b/src/tests/resources/scenarios/test_memory_aliasing/input_tensor_output_buffer_image_offset.json
@@ -1,0 +1,51 @@
+{
+    "commands": [],
+    "resources": [
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    2
+                ],
+                "format": "VK_FORMAT_R16_SINT",
+                "uid": "inTensor",
+                "src": "inTensor.npy",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "buffer": {
+                "shader_access": "readwrite",
+                "size": 8192,
+                "dst": "outBuffer0.npy",
+                "uid": "outBuffer0",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "image": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    64,
+                    32,
+                    1
+                ],
+                "format": "VK_FORMAT_R16G16_SFLOAT",
+                "dst": "outImage1.dds",
+                "uid": "outImage1",
+                "memory_group": {
+                    "id": "memoryGroup0",
+                    "offset": 8192
+                }
+            }
+        }
+    ]
+}

--- a/src/tests/resources/scenarios/test_memory_aliasing/tensor_offset_tensor_shader_tensor.json
+++ b/src/tests/resources/scenarios/test_memory_aliasing/tensor_offset_tensor_shader_tensor.json
@@ -1,0 +1,107 @@
+{
+    "commands": [
+        {
+            "dispatch_compute": {
+                "bindings": [
+                    {
+                        "set": 0,
+                        "id": 0,
+                        "resource_ref": "_inputTensor0"
+                    },
+                    {
+                        "set": 0,
+                        "id": 1,
+                        "resource_ref": "_inputTensor1"
+                    },
+                    {
+                        "set": 0,
+                        "id": 2,
+                        "resource_ref": "_outputTensor"
+                    }
+                ],
+                "shader_ref": "shader",
+                "rangeND": [
+                    16,
+                    16,
+                    1
+                ]
+            }
+        }
+    ],
+    "resources": [
+        {
+            "shader": {
+                "uid": "shader",
+                "src": "add_tensor_shader_two_inputs.spv",
+                "entry": "main",
+                "type": "SPIR-V"
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    2,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_inputTensorFile",
+                "src": "input.npy",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_inputTensor0",
+                "dst": "input0.npy",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_inputTensor1",
+                "dst": "input1.npy",
+                "memory_group": {
+                    "id": "memoryGroup0",
+                    "offset": 2048
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_outputTensor",
+                "dst": "output.npy"
+            }
+        }
+    ]
+}

--- a/src/tests/resources/scenarios/test_memory_aliasing/tensor_shader_tensor_offset_tensor.json
+++ b/src/tests/resources/scenarios/test_memory_aliasing/tensor_shader_tensor_offset_tensor.json
@@ -1,0 +1,90 @@
+{
+    "commands": [
+        {
+            "dispatch_compute": {
+                "bindings": [
+                    {
+                        "set": 0,
+                        "id": 0,
+                        "resource_ref": "_inputTensor"
+                    },
+                    {
+                        "set": 0,
+                        "id": 1,
+                        "resource_ref": "_outputTensor0"
+                    },
+                    {
+                        "set": 0,
+                        "id": 2,
+                        "resource_ref": "_outputTensor1"
+                    }
+                ],
+                "shader_ref": "shader",
+                "rangeND": [
+                    16,
+                    16,
+                    1
+                ]
+            }
+        }
+    ],
+    "resources": [
+        {
+            "shader": {
+                "uid": "shader",
+                "src": "copy_tensor_shader_two_outputs.spv",
+                "entry": "main",
+                "type": "SPIR-V"
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_inputTensor",
+                "src": "input.npy"
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_outputTensor0",
+                "dst": "output0.npy",
+                "memory_group": {
+                    "id": "memoryGroup0"
+                }
+            }
+        },
+        {
+            "tensor": {
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "uid": "_outputTensor1",
+                "dst": "output1.npy",
+                "memory_group": {
+                    "id": "memoryGroup0",
+                    "offset": 2048
+                }
+            }
+        }
+    ]
+}

--- a/src/tests/resources/shaders/test_memory_aliasing/add_tensor_shader_two_inputs.comp
+++ b/src/tests/resources/shaders/test_memory_aliasing/add_tensor_shader_two_inputs.comp
@@ -1,0 +1,22 @@
+/*
+* SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+* SPDX-License-Identifier: Apache-2.0
+*/
+#version 450
+#extension GL_ARM_tensors : require
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+
+layout(set=0, binding=0) uniform tensorARM<uint16_t, 4> _InputTensor0;
+layout(set=0, binding=1) uniform tensorARM<uint16_t, 4> _InputTensor1;
+layout(set=0, binding=2) uniform tensorARM<uint16_t, 4> _OutputTensor;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main()
+{
+    uint coords[4] = uint[](0, gl_GlobalInvocationID.x, gl_GlobalInvocationID.y, gl_GlobalInvocationID.z);
+    uint16_t val0;
+    uint16_t val1;
+    tensorReadARM(_InputTensor0, coords, val0);
+    tensorReadARM(_InputTensor1, coords, val1);
+    tensorWriteARM(_OutputTensor, coords, val0+val1);
+}

--- a/src/tests/resources/shaders/test_memory_aliasing/copy_tensor_shader_two_outputs.comp
+++ b/src/tests/resources/shaders/test_memory_aliasing/copy_tensor_shader_two_outputs.comp
@@ -1,0 +1,21 @@
+/*
+* SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+* SPDX-License-Identifier: Apache-2.0
+*/
+#version 450
+#extension GL_ARM_tensors : require
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+
+layout(set=0, binding=0) uniform tensorARM<uint16_t, 4> _InputTensor;
+layout(set=0, binding=1) uniform tensorARM<uint16_t, 4> _OutputTensor0;
+layout(set=0, binding=2) uniform tensorARM<uint16_t, 4> _OutputTensor1;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main()
+{
+    uint coords[4] = uint[](0, gl_GlobalInvocationID.x, gl_GlobalInvocationID.y, gl_GlobalInvocationID.z);
+    uint16_t val[4];
+    tensorReadARM(_InputTensor, coords, val);
+    tensorWriteARM(_OutputTensor0, coords, val);
+    tensorWriteARM(_OutputTensor1, coords, val);
+}

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -108,6 +108,7 @@ struct DDSHeaderInfo {
 struct BufferInfo {
     std::string debugName;
     uint32_t size;
+    uint64_t memoryOffset{};
 };
 
 /// \brief Structure that describes N-dimensional data
@@ -122,6 +123,7 @@ struct TensorInfo {
     int64_t sparsityDimension{-1};
     bool isAliasedWithImage{false};
     Tiling tiling{Tiling::Linear};
+    uint64_t memoryOffset{};
 };
 
 /// @brief Structure that describes the sampler of an image
@@ -151,6 +153,7 @@ struct ImageInfo {
     bool isSampled{false};
     bool isStorage{false};
     std::optional<Tiling> tiling;
+    uint64_t memoryOffset{};
 };
 
 /// @brief Structure that describes the image barrier


### PR DESCRIPTION
Allow the data start point of an aliased resource in memory to be offset from the start point of the shared memory object.

Also simplify Buffer/Tensor constructors

Change-Id: Ic46a06cb3d97ef632335700325cbdfa8d38e31d2