### PR TITLE
Fix docs generation with Clang

### DIFF
--- a/docs/docs.cmake
+++ b/docs/docs.cmake
@@ -24,20 +24,23 @@ add_custom_command(
 
 set(DOC_SRC_FILES_FULL_PATHS ${SCENARIO_RUNNER_ARG_HELP_TXT})
 # Copy MD files for inclusion into the published docs
-set(MD_FILES CONTRIBUTING.md README.md SECURITY.md)
-foreach(MD_FILE IN LISTS MD_FILES)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${MD_FILE} ${SPHINX_GEN_DIR}/${MD_FILE} COPYONLY)
-    list(APPEND DOC_SRC_FILES_FULL_PATHS ${SPHINX_GEN_DIR}/${MD_FILE})
-endforeach()
-
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CONTRIBUTING.md ${SPHINX_GEN_DIR}/CONTRIBUTING.md COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/README.md ${SPHINX_GEN_DIR}/README.md COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SECURITY.md ${SPHINX_GEN_DIR}/SECURITY.md COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/LICENSES/Apache-2.0.txt ${SPHINX_GEN_DIR}/LICENSES/Apache-2.0.txt COPYONLY)
 
+list(APPEND DOC_SRC_FILES_FULL_PATHS
+    ${SPHINX_GEN_DIR}/CONTRIBUTING.md
+    ${SPHINX_GEN_DIR}/README.md
+    ${SPHINX_GEN_DIR}/SECURITY.md)
+
+# Set source inputs list
 file(GLOB_RECURSE DOC_SRC_FILES CONFIGURE_DEPENDS RELATIVE ${SCEN_RUN_DOCS_SRC_DIR} ${SCEN_RUN_DOCS_SRC_DIR}/*)
 foreach(SRC_IN IN LISTS DOC_SRC_FILES)
-    set(DOC_SRC_FILE "${SCEN_RUN_DOCS_SRC_DIR}/${SRC_IN}")
-    set(DOC_IN_FILE "${SPHINX_SRC_DIR}/${SRC_IN}")
-    configure_file(${DOC_SRC_FILE} ${DOC_IN_FILE} COPYONLY)
-    list(APPEND DOC_SRC_FILES_FULL_PATHS ${DOC_IN_FILE})
+    set(DOC_SOURCE_FILE_IN "${SCEN_RUN_DOCS_SRC_DIR}/${SRC_IN}")
+    set(DOC_SOURCE_FILE "${SPHINX_SRC_DIR}/${SRC_IN}")
+    configure_file(${DOC_SOURCE_FILE_IN} ${DOC_SOURCE_FILE} COPYONLY)
+    list(APPEND DOC_SRC_FILES_FULL_PATHS ${DOC_SOURCE_FILE})
 endforeach()
 
 add_custom_command(
@@ -50,4 +53,4 @@ add_custom_command(
 )
 
 # Main target to build the docs
-add_custom_target(scenario_runner_doc ALL DEPENDS scenario_runner_doxy_doc scenario_runner_sphx_doc)
+add_custom_target(scenario_runner_doc ALL DEPENDS scenario_runner_doxy_doc scenario_runner_sphx_doc SOURCES "${SPHINX_SRC_DIR}/index.rst")


### PR DESCRIPTION
Doc folder would be insufficiently generated when using Clang

Change-Id: Ic388548c368c1c42a25f9ea65fd39d2f2793a6b0