### PR TITLE
Fix spelling in docs

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,7 +14,7 @@ Resource memory aliasing
 
 It is useful for some resources to share the same underlying memory. Sharing memory allows resources to share inputs or outputs between shaders and VGF workloads.
 
-To enable the resource memory aliasing feature, in the scenario json file, a tensor must have a ``memory_group`` field with the ``uid`` contained inside naming the unique memory object that the resources will use. Only one resource in a single ``memory_group`` can have a ``src`` file.
+To enable the resource memory aliasing feature, in the scenario json file, a tensor must have a ``memory_group`` field with the ``id`` contained inside naming the unique memory object that the resources will use. Only one resource in a single ``memory_group`` can have a ``src`` file.
 
 The following example shows you how to setup a tensor resource that alias an image resource.
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -75,7 +75,7 @@ vk::raii::DescriptorSetLayout createDescriptorSetLayout(const Context &ctx,
 std::vector<std::vector<ResolvedBindingDesc>> splitOutSets(const std::vector<ResolvedBindingDesc> &allBindings) {
     std::vector<std::vector<ResolvedBindingDesc>> setBindings;
 
-    for (auto &bindingDesc : allBindings) {
+    for (const auto &bindingDesc : allBindings) {
         while (setBindings.size() <= static_cast<size_t>(bindingDesc.set)) {
             setBindings.emplace_back(0);
         }

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -356,8 +356,7 @@ void Scenario::setupResources() {
 
     // Needed for old-style memory aliasing
     for (const auto &resource : _scenarioSpec.resources) {
-        switch (resource->resourceType) {
-        case (ResourceType::Tensor): {
+        if (resource->resourceType == ResourceType::Tensor) {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
             if (tensor->memoryGroup.has_value()) {
                 for (const auto &image : _scenarioSpec.resources) {
@@ -366,10 +365,6 @@ void Scenario::setupResources() {
                     }
                 }
             }
-        } break;
-        default:
-            // Skip the other types of resources
-            continue;
         }
     }
 
@@ -544,7 +539,7 @@ void Scenario::setupCommands(int iteration) {
 
 bool Scenario::hasAliasedOptimalTensors() const {
     // If any tensors in any memgroup have optimal tiling
-    for ([[maybe_unused]] const auto &[group, resources] : _dataManager.getResourceMemoryGroups()) {
+    for ([[maybe_unused]] const auto &[_, resources] : _dataManager.getResourceMemoryGroups()) {
         if (resources.size() <= 1)
             continue;
         for (auto resource : resources) {
@@ -560,7 +555,7 @@ bool Scenario::hasAliasedOptimalTensors() const {
 void Scenario::handleAliasedLayoutTransitions() {
 
     // Validation pass: ensure all resources in a group have the same tiling type
-    for (const auto &[group, resources] : _dataManager.getResourceMemoryGroups()) {
+    for ([[maybe_unused]] const auto &[_, resources] : _dataManager.getResourceMemoryGroups()) {
         bool allLinear = true;
         bool allOptimal = true;
         for (auto resource : resources) {

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -36,6 +36,10 @@ uint32_t bufferSize(const vgflib::DataView<int64_t> &shape) {
         std::abs(std::accumulate(shape.begin(), shape.end(), int64_t(1), std::multiplies<int64_t>())));
 }
 
+constexpr vgflib::DescriptorType DESCRIPTOR_TYPE_UNKNOWN = 0;
+constexpr vgflib::DescriptorType DESCRIPTOR_TYPE_STORAGE_BUFFER_EXT = 6;
+constexpr vgflib::DescriptorType DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000;
+
 } // namespace
 
 VgfView::VgfView(std::unique_ptr<MemoryMap> mapped, std::unique_ptr<vgflib::ModuleTableDecoder> moduleTableDecoder,
@@ -200,9 +204,6 @@ void VgfView::validateResource(const DataManager &dataManager, uint32_t vgfMrtIn
         throw std::runtime_error("Descriptor type not found from VGF file");
     }
 
-    constexpr vgflib::DescriptorType DESCRIPTOR_TYPE_STORAGE_BUFFER_EXT = 6;
-    constexpr vgflib::DescriptorType DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000;
-
     switch (expectedType.value()) {
     case DESCRIPTOR_TYPE_STORAGE_BUFFER_EXT: {
         // Check if resource types match
@@ -254,10 +255,6 @@ void VgfView::validateResource(const DataManager &dataManager, uint32_t vgfMrtIn
 
 void VgfView::createIntermediateResources(const Context &ctx, DataManager &dataManager) const {
     // Iterate over all VGF Resources, create intermediates
-    constexpr vgflib::DescriptorType DESCRIPTOR_TYPE_UNKNOWN = 0;
-    constexpr vgflib::DescriptorType DESCRIPTOR_TYPE_STORAGE_BUFFER_EXT = 6;
-    constexpr vgflib::DescriptorType DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000;
-
     size_t numResources = resourceTableDecoder->size();
     for (uint32_t resourceIndex = 0; resourceIndex < numResources; ++resourceIndex) {
         auto resourceCategory = resourceTableDecoder->getCategory(resourceIndex);


### PR DESCRIPTION
Tiny code polish.
Make constants common. Use if statement.

Change-Id: I345fcb72c0d2ba7e5c0e39ebf66a86f06bfc539b