### PR TITLE
Do not transition image layout when saving image data

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -569,7 +569,6 @@ std::vector<char> Image::getImageData(Context &ctx) {
     region.imageOffset = offset;
     region.imageExtent = extent;
 
-    addTransitionLayoutCommand(cmdBuffer, vk::ImageLayout::eGeneral);
     cmdBuffer.copyImageToBuffer(_image, vk::ImageLayout::eGeneral, _stagingBuffer, {region});
     cmdBuffer.end();
 


### PR DESCRIPTION
this fixes the validaion error [ VUID-vkCmdDraw-None-09600 ]


Change-Id: Ie2fcbb3fa784ff923dbefbb626446b03d934b18b