### PR TITLE
Disconnect resource creation from memory management

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -9,11 +9,11 @@
 
 namespace mlsdk::scenariorunner {
 
-Buffer::Buffer(const BufferInfo &bufferInfo, std::shared_ptr<ResourceMemoryManager> memoryManager)
-    : _buffer(nullptr), _size(bufferInfo.size), _debugName(bufferInfo.debugName),
-      _memoryManager(std::move(memoryManager)), _memoryOffset(bufferInfo.memoryOffset) {}
+Buffer::Buffer(const BufferInfo &bufferInfo)
+    : _size(bufferInfo.size), _debugName(bufferInfo.debugName), _memoryOffset(bufferInfo.memoryOffset) {}
 
-void Buffer::setup(const Context &ctx) {
+void Buffer::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> memoryManager) {
+    _memoryManager = std::move(memoryManager);
     vk::BufferCreateInfo bufferCreateInfo{
         vk::BufferCreateFlags(), _size,  vk::BufferUsageFlagBits::eStorageBuffer, vk::SharingMode::eExclusive,
         ctx.familyQueueIdx(),    nullptr};

--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -16,13 +16,14 @@ class Buffer {
     /// \brief Constructor
     ///
     /// \param bufferInfo buffer Information
-    /// \param memoryManager Information about (possibly shared) underlying memory
-    Buffer(const BufferInfo &bufferInfo, std::shared_ptr<ResourceMemoryManager> memoryManager);
+    explicit Buffer(const BufferInfo &bufferInfo);
     Buffer() = default;
 
     /// \brief Setup instance, assumes all aliasing objects have been constructed
-    /// \param ctx                    Contextual information about the Vulkan instance
-    void setup(const Context &ctx);
+    /// \param ctx           Contextual information about the Vulkan instance
+    /// \param memoryManager Information about (possibly shared) underlying memory
+    void setup(const Context &ctx,
+               std::shared_ptr<ResourceMemoryManager> memoryManager = std::make_shared<ResourceMemoryManager>());
 
     /// \brief Buffer accessor
     /// \return The underlying Vulkan buffer

--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -8,19 +8,11 @@
 
 namespace mlsdk::scenariorunner {
 
-void DataManager::createBuffer(Guid guid, const BufferInfo &info,
-                               std::shared_ptr<ResourceMemoryManager> memoryManager) {
-    _buffers.insert({guid, Buffer(info, std::move(memoryManager))});
-}
+void DataManager::createBuffer(Guid guid, const BufferInfo &info) { _buffers.insert({guid, Buffer(info)}); }
 
-void DataManager::createTensor(Guid guid, const TensorInfo &info,
-                               std::shared_ptr<ResourceMemoryManager> memoryManager) {
-    _tensors.insert({guid, Tensor(info, std::move(memoryManager))});
-}
+void DataManager::createTensor(Guid guid, const TensorInfo &info) { _tensors.insert({guid, Tensor(info)}); }
 
-void DataManager::createImage(Guid guid, const ImageInfo &info, std::shared_ptr<ResourceMemoryManager> memoryManager) {
-    _images.insert({guid, Image(info, std::move(memoryManager))});
-}
+void DataManager::createImage(Guid guid, const ImageInfo &info) { _images.insert({guid, Image(info)}); }
 
 void DataManager::createVgfView(Guid guid, const std::string &src) {
     _vgfViews.insert({guid, VgfView::createVgfView(src)});

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -18,12 +18,9 @@ namespace mlsdk::scenariorunner {
 
 class DataManager {
   public:
-    void createBuffer(Guid guid, const BufferInfo &info,
-                      std::shared_ptr<ResourceMemoryManager> memoryManager = std::make_shared<ResourceMemoryManager>());
-    void createTensor(Guid guid, const TensorInfo &info,
-                      std::shared_ptr<ResourceMemoryManager> memoryManager = std::make_shared<ResourceMemoryManager>());
-    void createImage(Guid guid, const ImageInfo &info,
-                     std::shared_ptr<ResourceMemoryManager> memoryManager = std::make_shared<ResourceMemoryManager>());
+    void createBuffer(Guid guid, const BufferInfo &info);
+    void createTensor(Guid guid, const TensorInfo &info);
+    void createImage(Guid guid, const ImageInfo &info);
     void createRawData(Guid guid, const std::string &debugName, const std::string &src);
     void createVgfView(Guid guid, const std::string &src);
     void createImageBarrier(Guid guid, const ImageBarrierData &data);

--- a/src/group_manager.cpp
+++ b/src/group_manager.cpp
@@ -25,7 +25,7 @@ size_t GroupManager::getAliasCount(const Guid &resource) const {
 
 bool GroupManager::isAliased(const Guid &resource) const { return getAliasCount(resource) > 0; }
 
-bool GroupManager::isAliasedTo(const Guid &resource, ResourceIdType resourceIdType) const {
+bool GroupManager::hasAliasOfType(const Guid &resource, ResourceIdType resourceIdType) const {
     const auto it = _resourceToGroup.find(resource);
     if (it != _resourceToGroup.end()) {
         // Group found, look for requested type

--- a/src/group_manager.hpp
+++ b/src/group_manager.hpp
@@ -33,7 +33,7 @@ class GroupManager {
     bool isAliased(const Guid &resource) const;
 
     ///  Returns true if resource is aliased with any resource of type
-    bool isAliasedTo(const Guid &resource, ResourceIdType resourceIdType) const;
+    bool hasAliasOfType(const Guid &resource, ResourceIdType resourceIdType) const;
 
     const std::unordered_map<Guid, std::set<std::pair<Guid, ResourceIdType>>> &getGroupResources() const {
         return _groupResources;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "image.hpp"
 #include "dds_reader.hpp"
 #include "logging.hpp"
 #include "resource_desc.hpp"
 #include "utils.hpp"
 #include "vulkan_debug_utils.hpp"
-#include "vulkan_memory_manager.hpp"
 
 #include <cmath>
 
@@ -87,12 +87,12 @@ constexpr vk::ImageTiling convertTiling(const Tiling tiling) {
 
 } // namespace
 
-Image::Image(const ImageInfo &imageInfo, std::shared_ptr<ResourceMemoryManager> memoryManager)
-    : _imageInfo(imageInfo), _memoryManager(std::move(memoryManager)) {}
+Image::Image(const ImageInfo &imageInfo) : _imageInfo(imageInfo) {}
 
-void Image::setup(const Context &ctx) {
+void Image::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> memoryManager) {
+    _memoryManager = std::move(memoryManager);
+
     // Create image
-
     if (_imageInfo.mips == 0) {
         throw std::runtime_error("Number of mips cannot be 0");
     }

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -8,23 +8,23 @@
 #include "context.hpp"
 #include "resource_desc.hpp"
 #include "types.hpp"
+#include "vulkan_memory_manager.hpp"
 
 namespace mlsdk::scenariorunner {
-
-class ResourceMemoryManager;
 
 class Image {
   public:
     /// \brief Constructor
     ///
     /// \param imageInfo ImageInfo struct
-    /// \param memoryManager Memory manager for this resource
-    Image(const ImageInfo &imageInfo, std::shared_ptr<ResourceMemoryManager> memoryManager);
+    explicit Image(const ImageInfo &imageInfo);
     Image() = default;
 
     /// \brief Setup instance, assumes all aliasing objects have been constructed
-    /// \param ctx                    Contextual information about the Vulkan instance
-    void setup(const Context &ctx);
+    /// \param ctx           Contextual information about the Vulkan instance
+    /// \param memoryManager Memory manager for this resource
+    void setup(const Context &ctx,
+               std::shared_ptr<ResourceMemoryManager> memoryManager = std::make_shared<ResourceMemoryManager>());
 
     /// \brief Image accessor
     /// \return The underlying Vulkan® image

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -136,7 +136,7 @@ struct ResourceInfoFactory {
         if (tensor.memoryGroup.has_value()) {
             info.memoryOffset = tensor.memoryGroup->offset;
         }
-        info.isAliasedWithImage = _groupManager.isAliasedTo(tensor.guid, ResourceIdType::Image);
+        info.isAliasedWithImage = _groupManager.hasAliasOfType(tensor.guid, ResourceIdType::Image);
         info.format = getVkFormatFromString(tensor.format);
         info.shape.resize(tensor.dims.size());
         std::copy(tensor.dims.begin(), tensor.dims.end(), info.shape.begin());
@@ -437,7 +437,7 @@ void Scenario::setupResources() {
         case (ResourceType::Buffer): {
             const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
             const auto info = resourceInfoFactory.createInfo(*buffer);
-            _dataManager.createBuffer(resource->guid, info, _groupManager.getMemoryManager(resource->guid));
+            _dataManager.createBuffer(resource->guid, info);
         } break;
         case (ResourceType::RawData): {
             const auto &rawData = reinterpret_cast<const std::unique_ptr<RawDataDesc> &>(resource);
@@ -446,7 +446,7 @@ void Scenario::setupResources() {
         case (ResourceType::Image): {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
             const auto info = resourceInfoFactory.createInfo(*image);
-            _dataManager.createImage(resource->guid, info, _groupManager.getMemoryManager(resource->guid));
+            _dataManager.createImage(resource->guid, info);
         } break;
         case (ResourceType::DataGraph): {
             const auto &dataGraph = reinterpret_cast<const std::unique_ptr<DataGraphDesc> &>(resource);
@@ -457,7 +457,7 @@ void Scenario::setupResources() {
         case (ResourceType::Tensor): {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
             const auto info = resourceInfoFactory.createInfo(*tensor);
-            _dataManager.createTensor(resource->guid, info, _groupManager.getMemoryManager(resource->guid));
+            _dataManager.createTensor(resource->guid, info);
         } break;
         default:
             // Skip the other types of resources
@@ -471,11 +471,11 @@ void Scenario::setupResources() {
         switch (resource->resourceType) {
         case (ResourceType::Buffer): {
             auto &bufferRef = _dataManager.getBufferMut(resource->guid);
-            bufferRef.setup(_ctx);
+            bufferRef.setup(_ctx, _groupManager.getMemoryManager(resource->guid));
         } break;
         case (ResourceType::Image): {
             auto &imageRef = _dataManager.getImageMut(resource->guid);
-            imageRef.setup(_ctx);
+            imageRef.setup(_ctx, _groupManager.getMemoryManager(resource->guid));
         } break;
         default:
             break; // No action
@@ -486,7 +486,7 @@ void Scenario::setupResources() {
     for (const auto &resource : _scenarioSpec.resources) {
         if (resource->resourceType == ResourceType::Tensor) {
             auto &tensorRef = _dataManager.getTensorMut(resource->guid);
-            tensorRef.setup(_ctx);
+            tensorRef.setup(_ctx, _groupManager.getMemoryManager(resource->guid));
         }
     }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -23,12 +23,13 @@ constexpr vk::TensorTilingARM convertTiling(const Tiling tiling) {
 
 } // namespace
 
-Tensor::Tensor(const TensorInfo &tensorInfo, std::shared_ptr<ResourceMemoryManager> memoryManager)
+Tensor::Tensor(const TensorInfo &tensorInfo)
     : _debugName(tensorInfo.debugName), _shape(tensorInfo.shape), _dataType(tensorInfo.format),
-      _memoryManager(std::move(memoryManager)), _tiling(convertTiling(tensorInfo.tiling)),
-      _memoryOffset(tensorInfo.memoryOffset), _isAliasedWithImage(tensorInfo.isAliasedWithImage) {}
+      _tiling(convertTiling(tensorInfo.tiling)), _memoryOffset(tensorInfo.memoryOffset),
+      _isAliasedWithImage(tensorInfo.isAliasedWithImage) {}
 
-void Tensor::setup(const Context &ctx) {
+void Tensor::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> memoryManager) {
+    _memoryManager = std::move(memoryManager);
 
     // implicitly convert rank=[] to rank=[1]
     if (_shape.empty()) {

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -17,13 +17,14 @@ class Tensor {
     /// \brief Constructor
     ///
     /// \param tensorInfo             Tensor info
-    /// \param memoryManager          Memory manager for this resource
-    Tensor(const TensorInfo &tensorInfo, std::shared_ptr<ResourceMemoryManager> memoryManager);
+    explicit Tensor(const TensorInfo &tensorInfo);
     Tensor() = default;
 
     /// \brief Setup instance, assumes all aliasing objects have been constructed
     /// \param ctx                    Contextual information about the Vulkan instance
-    void setup(const Context &ctx);
+    /// \param memoryManager          Memory manager for this resource
+    void setup(const Context &ctx,
+               std::shared_ptr<ResourceMemoryManager> memoryManager = std::make_shared<ResourceMemoryManager>());
 
     /// \brief Tensor accessor
     /// \return The underlying Vulkan tensor
@@ -86,7 +87,7 @@ class Tensor {
     vk::Format _dataType{vk::Format::eUndefined};
     std::vector<int64_t> _strides;
     std::shared_ptr<ResourceMemoryManager> _memoryManager{nullptr};
-    vk::TensorTilingARM _tiling = vk::TensorTilingARM::eLinear;
+    vk::TensorTilingARM _tiling{vk::TensorTilingARM::eLinear};
     vk::DeviceSize _size{0};
     uint64_t _memoryOffset{0};
     bool _isAliasedWithImage{false};

--- a/src/tests/group_manager_tests.cpp
+++ b/src/tests/group_manager_tests.cpp
@@ -19,17 +19,17 @@ TEST(GroupManager, GroupHandling) {
     ASSERT_TRUE(gm.isAliased(tensor0));
     ASSERT_EQ(gm.getAliasCount(image0), 0U);
     ASSERT_FALSE(gm.isAliased(image0));
-    ASSERT_FALSE(gm.isAliasedTo(tensor0, ResourceIdType::Image));
-    ASSERT_FALSE(gm.isAliasedTo(image0, ResourceIdType::Tensor));
-    ASSERT_FALSE(gm.isAliasedTo(group0, ResourceIdType::Tensor));
+    ASSERT_FALSE(gm.hasAliasOfType(tensor0, ResourceIdType::Image));
+    ASSERT_FALSE(gm.hasAliasOfType(image0, ResourceIdType::Tensor));
+    ASSERT_FALSE(gm.hasAliasOfType(group0, ResourceIdType::Tensor));
 
     gm.addResourceToGroup(group0, image0, ResourceIdType::Image);
     ASSERT_EQ(gm.getAliasCount(tensor0), 2U);
     ASSERT_TRUE(gm.isAliased(tensor0));
     ASSERT_EQ(gm.getAliasCount(image0), 2U);
     ASSERT_TRUE(gm.isAliased(image0));
-    ASSERT_TRUE(gm.isAliasedTo(tensor0, ResourceIdType::Image));
-    ASSERT_TRUE(gm.isAliasedTo(image0, ResourceIdType::Tensor));
+    ASSERT_TRUE(gm.hasAliasOfType(tensor0, ResourceIdType::Image));
+    ASSERT_TRUE(gm.hasAliasOfType(image0, ResourceIdType::Tensor));
 
     auto mmTensor = gm.getMemoryManager(tensor0);
     auto mmImage = gm.getMemoryManager(image0);

--- a/src/vulkan_memory_manager.hpp
+++ b/src/vulkan_memory_manager.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "context.hpp"
-#include "image.hpp"
 #include "types.hpp"
 #include "utils.hpp"
 
@@ -13,8 +12,6 @@ namespace mlsdk::scenariorunner {
 
 class ResourceMemoryManager {
   public:
-    ResourceMemoryManager() {}
-
     bool isInitalized() const { return _initalized; }
 
     void allocateDeviceMemory(const Context &ctx, vk::MemoryPropertyFlags flags) {


### PR DESCRIPTION
Handle shared memory as part of resource setup
instead of att creation.
Rename function.

Change-Id: I790307ebffb6642a362626337fc14cac19c90d45