### PR TITLE
Move types

### DIFF
--- a/src/barrier.hpp
+++ b/src/barrier.hpp
@@ -9,6 +9,38 @@
 
 namespace mlsdk::scenariorunner {
 
+/// @brief Base structure that describes a barrier
+struct BaseBarrierData {
+    std::string debugName;
+    MemoryAccess srcAccess;
+    MemoryAccess dstAccess;
+    std::vector<PipelineStage> srcStages;
+    std::vector<PipelineStage> dstStages;
+};
+
+/// @brief Structure that describes the image barrier
+struct ImageBarrierData : BaseBarrierData {
+    ImageLayout oldLayout;
+    ImageLayout newLayout;
+    vk::Image image;
+    SubresourceRange imageRange;
+};
+
+/// @brief Structure that describes the tensor barrier
+struct TensorBarrierData : BaseBarrierData {
+    vk::TensorARM tensor;
+};
+
+/// @brief Structure that describes the memory barrier
+struct MemoryBarrierData : BaseBarrierData {};
+
+/// @brief Structure that describes the buffer barrier
+struct BufferBarrierData : BaseBarrierData {
+    uint64_t offset;
+    uint64_t size;
+    vk::Buffer buffer;
+};
+
 class VulkanImageBarrier {
   public:
     /// \brief Constructor

--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -21,7 +21,7 @@ class Buffer {
 
     /// \brief Setup instance, assumes all aliasing objects have been constructed
     /// \param ctx           Contextual information about the Vulkan instance
-    /// \param memoryManager Information about (possibly shared) underlying memory
+    /// \param memoryManager Memory manager for this resource
     void setup(const Context &ctx,
                std::shared_ptr<ResourceMemoryManager> memoryManager = std::make_shared<ResourceMemoryManager>());
 

--- a/src/commands.hpp
+++ b/src/commands.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "guid.hpp"
-#include "types.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -56,6 +55,26 @@ struct DispatchComputeDesc : CommandDesc {
     Guid shaderRef;
     bool implicitBarrier{true};
     std::optional<Guid> pushDataRef;
+};
+
+/**
+ * @brief Maps the raw data resource containing push constants data
+ * to the shader node in the graph which consumes these
+ *
+ */
+struct PushConstantMap {
+    Guid pushDataRef;
+    Guid shaderTarget;
+};
+
+/**
+ * @brief Describes a placeholder shader node in the graph that will be substituted with an actual shader
+ * implementation
+ *
+ */
+struct ShaderSubstitution {
+    Guid shaderRef;
+    std::string target;
 };
 
 /**

--- a/src/compute.hpp
+++ b/src/compute.hpp
@@ -16,6 +16,22 @@
 
 namespace mlsdk::scenariorunner {
 
+/// \brief Typed barriers
+struct DispatchBarrierData {
+    std::vector<Guid> memoryBarriers;
+    std::vector<Guid> imageBarriers;
+    std::vector<Guid> tensorBarriers;
+    std::vector<Guid> bufferBarriers;
+};
+
+/// \brief Typed resources
+struct MarkBoundaryData {
+    std::vector<Guid> buffers;
+    std::vector<Guid> images;
+    std::vector<Guid> tensors;
+    uint64_t frameId{};
+};
+
 /// @brief Compute command orchestrator
 ///
 /// @note At the moment each compute handles a single shader

--- a/src/dds_reader.hpp
+++ b/src/dds_reader.hpp
@@ -35,6 +35,55 @@ enum DxgiFormat {
     DXGI_FORMAT_R8G8B8_SINT_CUSTOM = 134
 };
 
+/// \brief Structure that describes DDS pixel data layout
+struct DDSPixelFormat {
+    uint32_t size{32};
+    uint32_t flags{};
+    uint32_t fourCC{};
+    uint32_t rgbBitCount{};
+    uint32_t rBitMask{};
+    uint32_t gBitMask{};
+    uint32_t bBitMask{};
+    uint32_t aBitMask{};
+};
+
+/// \brief Structure that describes main part of header from DDS file
+///
+/// \note Order of members and presence of "Reserved" data allow memcpy to work on file data
+struct DDSHeader {
+    uint32_t size{124};
+    uint32_t flags{};
+    uint32_t height{};
+    uint32_t width{};
+    uint32_t pitchOrLinearSize{};
+    uint32_t depth{};
+    uint32_t mipMapCount{};
+    uint32_t reserved[11]{};
+    DDSPixelFormat pixelFormat{};
+    uint32_t caps{};
+    uint32_t caps2{};
+    uint32_t caps3{};
+    uint32_t caps4{};
+    uint32_t reserved2{};
+};
+
+/// \brief Structure that describes optional extension to DDS header format
+struct DDSHeaderDX10 {
+    uint32_t dxgiFormat{};
+    uint32_t resourceDimension{};
+    uint32_t miscFlag{};
+    uint32_t arraySize{};
+    uint32_t miscFlags2{};
+};
+
+/// \brief Structure that stores all non-pixel data from DDS file
+struct DDSHeaderInfo {
+    uint32_t magicWord{};
+    DDSHeader header{};
+    DDSHeaderDX10 header10{};
+    bool isDx10{};
+};
+
 /// \brief Load data from a DDS file
 ///
 /// \param filename DDS file to load

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -548,7 +548,7 @@ void Image::fillFromDescription(const Context &ctx, const ImageDesc &desc) {
     }
 }
 
-std::vector<char> Image::getImageData(Context &ctx) {
+std::vector<char> Image::getImageData(const Context &ctx) {
     // Use staging buffer to get image data
     const vk::CommandPoolCreateInfo cmdPoolCreateInfo({vk::CommandPoolCreateFlagBits::eResetCommandBuffer},
                                                       ctx.familyQueueIdx());
@@ -585,13 +585,13 @@ std::vector<char> Image::getImageData(Context &ctx) {
     }
 
     std::vector<char> data(dataSize());
-    void *pBufferDeviceMemory = _stagingBufferDeviceMemory.mapMemory(0, data.size());
+    const void *pBufferDeviceMemory = _stagingBufferDeviceMemory.mapMemory(0, data.size());
     std::memcpy(data.data(), pBufferDeviceMemory, data.size());
     _stagingBufferDeviceMemory.unmapMemory();
     return data;
 }
 
-void Image::store(Context &ctx, const std::string &filename) {
+void Image::store(const Context &ctx, const std::string &filename) {
     auto data = getImageData(ctx);
     saveDataToDDS(filename, *this, data);
 }

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -62,7 +62,7 @@ class Image {
 
     void fillFromDescription(const Context &ctx, const ImageDesc &desc);
 
-    void store(Context &ctx, const std::string &filename);
+    void store(const Context &ctx, const std::string &filename);
 
     bool isSampled() const;
 
@@ -74,7 +74,7 @@ class Image {
     const ImageInfo &getInfo() const { return _imageInfo; }
 
   private:
-    std::vector<char> getImageData(Context &ctx);
+    std::vector<char> getImageData(const Context &ctx);
     uint32_t getFormatMaxMipLevels(const Context &ctx, vk::ImageTiling tiling, vk::ImageUsageFlags usageFlags);
 
     vk::raii::Image _image{nullptr};

--- a/src/json_writer.cpp
+++ b/src/json_writer.cpp
@@ -21,10 +21,10 @@ struct CommandTimestamps {
                       const float timestampPeriod, const int iteration = 1)
         : type(commandType), timestamps(commandTimestamps), period(timestampPeriod), iteration(iteration) {}
 
-    std::string type = {};
-    std::vector<uint64_t> timestamps = {};
-    float period = {};
-    int iteration;
+    std::string type;
+    std::vector<uint64_t> timestamps;
+    float period{};
+    int iteration{};
 };
 
 void to_json(json &j, const CommandTimestamps &commandTimestamps) {
@@ -95,7 +95,7 @@ void writePerfCounters(std::vector<PerformanceCounter> &perfCounters, std::files
 
 void writeProfilingData(const std::vector<uint64_t> &timestamps, const float timestampPeriod,
                         const std::vector<std::string> &profiledCommands, const std::filesystem::path &path,
-                        const int &iteration, const int &repeatCount) {
+                        const int iteration, const int repeatCount) {
     if (profiledCommands.size() * 2 != timestamps.size()) {
         throw std::runtime_error("Cannot map all timestamps to their respective commands");
     }

--- a/src/json_writer.hpp
+++ b/src/json_writer.hpp
@@ -16,5 +16,5 @@ void writePerfCounters(std::vector<PerformanceCounter> &perfCounters, std::files
 
 void writeProfilingData(const std::vector<uint64_t> &timestamps, const float timestampPeriod,
                         const std::vector<std::string> &profiledCommands, const std::filesystem::path &path,
-                        const int &iteration, const int &repeatCount);
+                        int iteration, int repeatCount);
 } // namespace mlsdk::scenariorunner

--- a/src/perf_counter.hpp
+++ b/src/perf_counter.hpp
@@ -8,8 +8,6 @@
 #include <string>
 #include <vector>
 
-using Clock = std::chrono::high_resolution_clock;
-
 namespace mlsdk::scenariorunner {
 
 class PerformanceCounter {
@@ -36,6 +34,8 @@ class PerformanceCounter {
     bool isPartOfTimeToInference() const { return _isPartOfTimeToInference; }
 
   private:
+    using Clock = std::chrono::high_resolution_clock;
+
     std::chrono::time_point<Clock> _startTimePoint;
     std::chrono::microseconds _elapsedTime;
     std::string _name;

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -16,8 +16,6 @@
 
 namespace mlsdk::scenariorunner {
 
-enum class PipelineType { Unknown, Compute, GraphCompute };
-
 class Pipeline {
   public:
     /// \brief Constructor
@@ -61,6 +59,8 @@ class Pipeline {
     const std::string &debugName() const;
 
   private:
+    enum class PipelineType { Unknown, Compute, GraphCompute };
+
     PipelineType _type{PipelineType::Unknown};
     std::vector<vk::raii::DescriptorSetLayout> _descriptorSetLayouts;
     vk::raii::PipelineLayout _pipelineLayout{nullptr};

--- a/src/pipeline_cache.cpp
+++ b/src/pipeline_cache.cpp
@@ -38,7 +38,7 @@ bool PipelineCache::isValidPipelineCache(const std::vector<unsigned char> &cache
     return true;
 }
 
-PipelineCache::PipelineCache(Context &ctx, const std::filesystem::path &pipelineCachePath, bool clearCache,
+PipelineCache::PipelineCache(const Context &ctx, const std::filesystem::path &pipelineCachePath, bool clearCache,
                              bool failOnMiss)
     : _pipelineCachePath(pipelineCachePath), _failOnMiss(failOnMiss) {
     vk::PipelineCacheCreateInfo cacheCreateInfo;

--- a/src/pipeline_cache.hpp
+++ b/src/pipeline_cache.hpp
@@ -14,7 +14,7 @@ namespace mlsdk::scenariorunner {
 
 class PipelineCache {
   public:
-    explicit PipelineCache(Context &ctx, const std::filesystem::path &pipelineCachePath, bool clearCache,
+    explicit PipelineCache(const Context &ctx, const std::filesystem::path &pipelineCachePath, bool clearCache,
                            bool failOnMiss);
     void save();
 

--- a/src/resource_desc.hpp
+++ b/src/resource_desc.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "barrier.hpp"
 #include "commands.hpp"
 #include "guid.hpp"
 #include "types.hpp"

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -15,6 +15,25 @@
 #include <unordered_set>
 
 namespace mlsdk::scenariorunner {
+/// \brief Compute data with typed bindings
+struct DispatchComputeData {
+    std::string debugName;
+    std::vector<TypedBinding> bindings;
+    ComputeDispatch computeDispatch{};
+    Guid shaderRef;
+    bool implicitBarrier{true};
+    std::optional<Guid> pushDataRef;
+};
+
+/// \brief Compute data graph with typed bindings
+struct DispatchDataGraphData {
+    Guid dataGraphRef;
+    std::string debugName;
+    std::vector<TypedBinding> bindings;
+    std::vector<PushConstantMap> pushConstants;
+    std::vector<ShaderSubstitution> shaderSubstitutions;
+    bool implicitBarrier{true};
+};
 
 namespace // unnamed namespace
 {
@@ -317,9 +336,7 @@ struct CommandDataFactory {
         data.debugName = dispatchDataGraph.debugName;
         data.bindings = convertBindings(_dataManager, dispatchDataGraph.bindings);
         data.pushConstants = dispatchDataGraph.pushConstants;
-        for (const auto &substitution : dispatchDataGraph.shaderSubstitutions) {
-            data.shaderSubstitutions.push_back({substitution.shaderRef, substitution.target});
-        }
+        data.shaderSubstitutions = dispatchDataGraph.shaderSubstitutions;
         data.implicitBarrier = dispatchDataGraph.implicitBarrier;
         return data;
     }

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -34,6 +34,9 @@ struct ScenarioOptions {
     std::vector<std::string> disabledExtensions{};
 };
 
+struct DispatchComputeData;
+struct DispatchDataGraphData;
+
 class Scenario {
   public:
     /// \brief Constructor

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -52,55 +52,6 @@ struct SubresourceRange {
 /// \brief A variant of the potential custom border colors */
 using CustomColorValue = std::variant<std::array<float, 4>, std::array<int32_t, 4>>;
 
-/// \brief Structure that describes DDS pixel data layout
-struct DDSPixelFormat {
-    uint32_t size{32};
-    uint32_t flags{};
-    uint32_t fourCC{};
-    uint32_t rgbBitCount{};
-    uint32_t rBitMask{};
-    uint32_t gBitMask{};
-    uint32_t bBitMask{};
-    uint32_t aBitMask{};
-};
-
-/// \brief Structure that describes main part of header from DDS file
-///
-/// \note Order of members and presence of "Reserved" data allow memcpy to work on file data
-struct DDSHeader {
-    uint32_t size{124};
-    uint32_t flags{};
-    uint32_t height{};
-    uint32_t width{};
-    uint32_t pitchOrLinearSize{};
-    uint32_t depth{};
-    uint32_t mipMapCount{};
-    uint32_t reserved[11]{};
-    DDSPixelFormat pixelFormat{};
-    uint32_t caps{};
-    uint32_t caps2{};
-    uint32_t caps3{};
-    uint32_t caps4{};
-    uint32_t reserved2{};
-};
-
-/// \brief Structure that describes optional extension to DDS header format
-struct DDSHeaderDX10 {
-    uint32_t dxgiFormat{};
-    uint32_t resourceDimension{};
-    uint32_t miscFlag{};
-    uint32_t arraySize{};
-    uint32_t miscFlags2{};
-};
-
-/// \brief Structure that stores all non-pixel data from DDS file
-struct DDSHeaderInfo {
-    uint32_t magicWord{};
-    DDSHeader header{};
-    DDSHeaderDX10 header10{};
-    bool isDx10{};
-};
-
 /// \brief Structure that describes 1-dimensional buffer data
 ///
 /// \note We don't account for any specialized meta-data like
@@ -157,38 +108,6 @@ struct ImageInfo {
     uint64_t memoryOffset{};
 };
 
-/// @brief Base structure that describes a barrier
-struct BaseBarrierData {
-    std::string debugName;
-    MemoryAccess srcAccess;
-    MemoryAccess dstAccess;
-    std::vector<PipelineStage> srcStages;
-    std::vector<PipelineStage> dstStages;
-};
-
-/// @brief Structure that describes the image barrier
-struct ImageBarrierData : BaseBarrierData {
-    ImageLayout oldLayout;
-    ImageLayout newLayout;
-    vk::Image image;
-    SubresourceRange imageRange;
-};
-
-/// @brief Structure that describes the tensor barrier
-struct TensorBarrierData : BaseBarrierData {
-    vk::TensorARM tensor;
-};
-
-/// @brief Structure that describes the memory barrier
-struct MemoryBarrierData : BaseBarrierData {};
-
-/// @brief Structure that describes the image barrier
-struct BufferBarrierData : BaseBarrierData {
-    uint64_t offset;
-    uint64_t size;
-    vk::Buffer buffer;
-};
-
 /// \brief Constant structure
 ///
 /// Used for specialization constants
@@ -212,56 +131,6 @@ struct ComputeDispatch {
     uint32_t gwcx{1};
     uint32_t gwcy{1};
     uint32_t gwcz{1};
-};
-
-/// \brief Compute data with typed bindings
-struct DispatchComputeData {
-    std::string debugName;
-    std::vector<TypedBinding> bindings;
-    ComputeDispatch computeDispatch{};
-    Guid shaderRef;
-    bool implicitBarrier{true};
-    std::optional<Guid> pushDataRef;
-};
-
-/// \brief Typed barriers
-struct DispatchBarrierData {
-    std::vector<Guid> memoryBarriers;
-    std::vector<Guid> imageBarriers;
-    std::vector<Guid> tensorBarriers;
-    std::vector<Guid> bufferBarriers;
-};
-
-/// \brief Maps the raw data resource containing push constants data to the shader node in the graph which consumes
-/// these
-struct PushConstantMap {
-    Guid pushDataRef;
-    Guid shaderTarget;
-};
-
-/// \brief Describes a placeholder shader node in the graph that will be substituted with an actual shader
-/// implementation
-struct ShaderSubstitution {
-    Guid shaderRef;
-    std::string target;
-};
-
-/// \brief Compute data graph with typed bindings
-struct DispatchDataGraphData {
-    Guid dataGraphRef;
-    std::string debugName;
-    std::vector<TypedBinding> bindings;
-    std::vector<PushConstantMap> pushConstants;
-    std::vector<ShaderSubstitution> shaderSubstitutions;
-    bool implicitBarrier{true};
-};
-
-/// \brief Typed resources
-struct MarkBoundaryData {
-    std::vector<Guid> buffers;
-    std::vector<Guid> images;
-    std::vector<Guid> tensors;
-    uint64_t frameId{};
 };
 
 } // namespace mlsdk::scenariorunner


### PR DESCRIPTION
Hide private types.
Move types to files actually using them.
Add const and avoid pointless references.

Change-Id: I6e0a1df1b9cfaaf1099bb9264ae85d889aab5160