### PR TITLE
Move pipelines container to Compute class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ markers = [
     "vgf_shader",
     "tiling",
     "spec_const",
+    "repeated_runs",
 ]

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -132,23 +132,20 @@ void Pipeline::computePipelineCommon(const Context &ctx, const ShaderInfo &shade
     trySetVkRaiiObjectDebugName(ctx, _pipeline, _debugName);
 }
 
-Pipeline::Pipeline(const CommonArguments &args, const uint32_t *spvCode, const size_t spvSize,
-                   const ShaderInfo &shaderInfo)
+Pipeline::Pipeline(const CommonArguments &args, const ShaderInfo &shaderInfo, const uint32_t *spvCode,
+                   const size_t spvSize)
     : _type{PipelineType::Compute}, _debugName(args.debugName) {
 
-    validateShaderModule(spvCode, spvSize);
+    if ((spvCode != nullptr) && (spvSize > 0)) {
+        validateShaderModule(spvCode, spvSize);
 
-    _shader = createShaderModuleFromCode(args.ctx, spvCode, spvSize);
-    trySetVkRaiiObjectDebugName(args.ctx, _shader, _debugName + " shader");
+        _shader = createShaderModuleFromCode(args.ctx, spvCode, spvSize);
+        trySetVkRaiiObjectDebugName(args.ctx, _shader, _debugName + " shader");
+    } else {
+        _shader = createShaderModule(args.ctx, shaderInfo);
 
-    createDescriptorSetLayouts(args.ctx, args.bindings);
-    computePipelineCommon(args.ctx, shaderInfo, args.pipelineCache);
-}
-
-Pipeline::Pipeline(const CommonArguments &args, const ShaderInfo &shaderInfo)
-    : _type{PipelineType::Compute}, _shader(createShaderModule(args.ctx, shaderInfo)), _debugName(args.debugName) {
-
-    trySetVkRaiiObjectDebugName(args.ctx, _shader, shaderInfo.debugName);
+        trySetVkRaiiObjectDebugName(args.ctx, _shader, shaderInfo.debugName);
+    }
 
     createDescriptorSetLayouts(args.ctx, args.bindings);
     computePipelineCommon(args.ctx, shaderInfo, args.pipelineCache);

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -29,9 +29,9 @@ class Pipeline {
     ///
     /// \param args Common arguments struct
     /// \param shaderInfo Shader related meta-data
-    Pipeline(const CommonArguments &args, const ShaderInfo &shaderInfo);
-
-    Pipeline(const CommonArguments &args, const uint32_t *spvCode, size_t spvSize, const ShaderInfo &shaderInfo);
+    /// \param spvCode Pointer to SPIR-V code
+    /// \param spvSize Size of SPIR-V code in number of uint32_t
+    Pipeline(const CommonArguments &args, const ShaderInfo &shaderInfo, const uint32_t *spvCode, size_t spvSize);
 
     Pipeline(const CommonArguments &args, uint32_t segmentIndex, const VgfView &vgfView,
              const DataManager &dataManager);

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -10,11 +10,9 @@
 #include "data_manager.hpp"
 #include "group_manager.hpp"
 #include "guid.hpp"
-#include "pipeline.hpp"
 #include "scenario_desc.hpp"
 #include "types.hpp"
 
-#include <list>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -69,7 +67,6 @@ class Scenario {
     Context _ctx;
     DataManager _dataManager;
     ScenarioSpec &_scenarioSpec;
-    std::list<Pipeline> _pipelines{};
     std::optional<PipelineCache> _pipelineCache{};
     Compute _compute;
     std::vector<PerformanceCounter> _perfCounters{};

--- a/src/tests/test_repeated_runs.py
+++ b/src/tests/test_repeated_runs.py
@@ -17,6 +17,8 @@ DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000
 VK_FORMAT_R8_SINT = 14
 pretendVulkanHeaderVersion = 123
 
+pytestmark = pytest.mark.repeated_runs
+
 
 def test_chained_shaders_execution_count_times(sdk_tools, numpy_helper):
     input1 = numpy_helper.generate([10], dtype=np.float32, filename="inBufferA.npy")

--- a/src/tests/vulkan_startup_tests.cpp
+++ b/src/tests/vulkan_startup_tests.cpp
@@ -7,7 +7,6 @@
 #include "commands.hpp"
 #include "compute.hpp"
 #include "glsl_compiler.hpp"
-#include "pipeline.hpp"
 #include "scenario.hpp"
 
 #include <vector>
@@ -103,20 +102,20 @@ TEST(VulkanStartUp, RunShader) { // cppcheck-suppress syntaxError
     binding.resourceRef = guidOut;
     bindings.push_back(binding);
 
+    // Create compute orchestrator to run commands
+    Compute compute(ctx);
+
     // Create compute pipeline
     std::optional<PipelineCache> pipelineCache{};
-    const Pipeline::CommonArguments args{ctx, "test_pipeline", bindings, pipelineCache};
+    const Compute::PipelineCreateArguments args{"test_pipeline", bindings, pipelineCache};
     ShaderInfo shaderInfo;
     shaderInfo.debugName = "add_shader";
     shaderInfo.src = addShaderSPIRV;
     shaderInfo.entry = "main";
     shaderInfo.shaderType = ShaderType::SPIR_V;
-    Pipeline pipe(args, shaderInfo);
-
-    // Create compute orchestrator to run commands
-    Compute compute(ctx);
+    compute.createPipeline(args, shaderInfo);
     bool implicitBarriers = true;
-    compute.registerPipelineFenced(pipe, dataManager, bindings, nullptr, 0, implicitBarriers, {numElements, 1, 1});
+    compute.registerPipelineFenced(dataManager, bindings, nullptr, 0, implicitBarriers, {numElements, 1, 1});
 
     // Run and wait on fence
     compute.submitAndWaitOnFence();


### PR DESCRIPTION
Remove constructor overload in Pipeline to align
with usage in Compute class.
Add missing pytest marker

Change-Id: Ia0c7a7eb516465fc079e269cc5676de895c9b292