### PR TITLE
Change pipeline cache type from std::optional to std::shared_ptr

### DIFF
--- a/src/compute.hpp
+++ b/src/compute.hpp
@@ -55,7 +55,7 @@ class Compute {
     struct PipelineCreateArguments {
         const std::string &debugName;
         const std::vector<TypedBinding> &bindings;
-        std::optional<PipelineCache> &pipelineCache;
+        std::shared_ptr<PipelineCache> pipelineCache;
     };
 
     /// \brief Create a pipeline

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -22,7 +22,7 @@ class Pipeline {
         const Context &ctx;
         const std::string &debugName;
         const std::vector<TypedBinding> &bindings;
-        std::optional<PipelineCache> &pipelineCache;
+        std::shared_ptr<PipelineCache> pipelineCache;
     };
 
     /// \brief Constructor
@@ -76,10 +76,10 @@ class Pipeline {
     void createDescriptorSetLayouts(const Context &ctx, const std::vector<TypedBinding> &bindings);
 
     void computePipelineCommon(const Context &ctx, const ShaderInfo &shaderInfo,
-                               std::optional<PipelineCache> &pipelineCache);
+                               std::shared_ptr<PipelineCache> pipelineCache);
 
     void graphComputePipelineCommon(const Context &ctx, uint32_t segmentIndex, const VgfView &vgfView,
-                                    std::optional<PipelineCache> &pipelineCache,
+                                    std::shared_ptr<PipelineCache> pipelineCache,
                                     const std::vector<vk::DataGraphPipelineResourceInfoARM> &resourceInfos);
 };
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -615,8 +615,8 @@ void Scenario::setupCommands(int iteration) {
             .emplace_back("Load Pipeline Cache. Iteration: " + std::to_string(iteration + 1), "Load Pipeline Cache",
                           true)
             .start();
-        _pipelineCache =
-            PipelineCache(_ctx, _opts.pipelineCachePath, _opts.clearPipelineCache, _opts.failOnPipelineCacheMiss);
+        _pipelineCache = std::make_shared<PipelineCache>(_ctx, _opts.pipelineCachePath, _opts.clearPipelineCache,
+                                                         _opts.failOnPipelineCacheMiss);
         _perfCounters.back().stop();
     }
     // Setup commands
@@ -892,9 +892,9 @@ void Scenario::saveProfilingData(int iteration, int repeatCount) {
 }
 
 void Scenario::saveResults(bool dryRun) {
-    if (_pipelineCache.has_value()) {
+    if (_pipelineCache) {
         _perfCounters.emplace_back("Save Pipeline Cache", "Save Pipeline Cache").start();
-        _pipelineCache.value().save();
+        _pipelineCache->save();
         _perfCounters.back().stop();
     }
 

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -67,7 +67,7 @@ class Scenario {
     Context _ctx;
     DataManager _dataManager;
     ScenarioSpec &_scenarioSpec;
-    std::optional<PipelineCache> _pipelineCache{};
+    std::shared_ptr<PipelineCache> _pipelineCache{};
     Compute _compute;
     std::vector<PerformanceCounter> _perfCounters{};
     GroupManager _groupManager;

--- a/src/tests/vulkan_startup_tests.cpp
+++ b/src/tests/vulkan_startup_tests.cpp
@@ -106,8 +106,7 @@ TEST(VulkanStartUp, RunShader) { // cppcheck-suppress syntaxError
     Compute compute(ctx);
 
     // Create compute pipeline
-    std::optional<PipelineCache> pipelineCache{};
-    const Compute::PipelineCreateArguments args{"test_pipeline", bindings, pipelineCache};
+    const Compute::PipelineCreateArguments args{"test_pipeline", bindings, nullptr};
     ShaderInfo shaderInfo;
     shaderInfo.debugName = "add_shader";
     shaderInfo.src = addShaderSPIRV;


### PR DESCRIPTION
* This fixes the ASAN error which is most likly caused by the optional going out of scope causing dangling reference

Change-Id: Ic0d78b3c8ed2281007cd241dc4b9faca505b564f