### PR TITLE
Update JNI entrypoint for renamed package

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -347,8 +347,9 @@ jint runScenarioRunnerFromJni(JNIEnv *env, jobjectArray args) {
 }
 } // namespace
 
-extern "C" JNIEXPORT jint JNICALL Java_com_arm_aiml_scenariorunner_Main_runScenarioRunner(JNIEnv *env, jobject /*thiz*/,
-                                                                                          jobjectArray args) {
+extern "C" JNIEXPORT jint JNICALL Java_com_arm_ai_1ml_1sdk_1scenario_1runner_Main_runScenarioRunner(JNIEnv *env,
+                                                                                                    jobject /*thiz*/,
+                                                                                                    jobjectArray args) {
     return runScenarioRunnerFromJni(env, args);
 }
 #endif


### PR DESCRIPTION
Adjust the exported JNI symbol to match the updated Java package/class name so the native entry point can be resolved correctly at runtime.

This change preserves the existing scenario runner behavior while restoring compatibility with the renamed SDK package.


Change-Id: I7c08df7edd287dc3685436583fb36660f3183b41