### PR TITLE
Enable HLSL support automatically on supported platforms in build.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
         exclude: \.cp?p?$
       - id: trailing-whitespace
         stages: [pre-commit]
+        exclude: '\.patch$'
       - id: mixed-line-ending
         args: ['--fix=lf']
         description: Forces to replace line ending by the UNIX 'lf' character.

--- a/patches/dxc-static-link.patch
+++ b/patches/dxc-static-link.patch
@@ -5,7 +5,7 @@ index 95cc56a..c96b5e7 100644
 @@ -13,6 +13,11 @@
  #ifndef __DXC_API__
  #define __DXC_API__
-
+ 
 +#ifdef DXC_STATIC_LINK
 +#ifndef DXC_API_IMPORT
 +#define DXC_API_IMPORT
@@ -19,9 +19,9 @@ index 95cc56a..c96b5e7 100644
  #endif
  #endif
 +#endif
-
+ 
  #ifdef _WIN32
-
+ 
 diff --git a/tools/clang/tools/dxcompiler/CMakeLists.txt b/tools/clang/tools/dxcompiler/CMakeLists.txt
 index c69e276..d896721 100644
 --- a/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -31,17 +31,17 @@ index c69e276..d896721 100644
    OUTPUT_NAME "dxcompiler"
    VERSION ${LIBCLANG_LIBRARY_VERSION}
    DEFINE_SYMBOL _CINDEX_LIB_)
-
+ 
  if (WIN32)
    set(install_dest RUNTIME DESTINATION bin)
  else()
    set(install_dest LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX})
  endif()
-
+ 
  install(TARGETS dxcompiler
    ${install_dest}
    COMPONENT dxcompiler)
-
+ 
  add_custom_target(install-dxcompiler
    DEPENDS dxcompiler
    COMMAND "${CMAKE_COMMAND}"

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -74,7 +74,6 @@ class Builder:
         self.experimental_image_format_support = (
             args.enable_experimental_image_format_support
         )
-        self.enable_hlsl_support = args.enable_hlsl_support
 
         self.package_dir = args.package_dir or self.build_dir
         self.package_tgz = "tgz" in args.package_type
@@ -102,15 +101,14 @@ class Builder:
                 cmake_cmd.append(
                     f"-DCMAKE_TOOLCHAIN_FILE={CMAKE_TOOLCHAIN_PATH / 'gcc.cmake'}"
                 )
-                if self.enable_hlsl_support:
-                    cmake_cmd.append("-DSCENARIO_RUNNER_ENABLE_HLSL_SUPPORT=ON")
+                cmake_cmd.append("-DSCENARIO_RUNNER_ENABLE_HLSL_SUPPORT=ON")
                 return True
+
             if system == "Darwin":
                 cmake_cmd.append(
                     f"-DCMAKE_TOOLCHAIN_FILE={CMAKE_TOOLCHAIN_PATH / 'clang.cmake'}"
                 )
                 cmake_cmd.append("-DMOLTEN_VK_SUPPORT=ON")
-
                 return True
 
             if system == "Windows":
@@ -118,8 +116,7 @@ class Builder:
                     f"-DCMAKE_TOOLCHAIN_FILE={CMAKE_TOOLCHAIN_PATH / 'windows-msvc.cmake'}"
                 )
                 cmake_cmd.append("-DMSVC=ON")
-                if self.enable_hlsl_support:
-                    cmake_cmd.append("-DSCENARIO_RUNNER_ENABLE_HLSL_SUPPORT=ON")
+                cmake_cmd.append("-DSCENARIO_RUNNER_ENABLE_HLSL_SUPPORT=ON")
                 return True
 
             print(f"Unsupported host platform {system}", file=sys.stderr)
@@ -135,9 +132,9 @@ class Builder:
             cmake_cmd.append(
                 f"-DCMAKE_TOOLCHAIN_FILE={CMAKE_TOOLCHAIN_PATH / 'clang.cmake'}"
             )
-            if self.enable_hlsl_support:
-                cmake_cmd.append("-DSCENARIO_RUNNER_ENABLE_HLSL_SUPPORT=ON")
+            cmake_cmd.append("-DSCENARIO_RUNNER_ENABLE_HLSL_SUPPORT=ON")
             return True
+
         if self.target_platform == "aarch64":
             cmake_cmd.append(
                 f"-DCMAKE_TOOLCHAIN_FILE={CMAKE_TOOLCHAIN_PATH / 'linux-aarch64-gcc.cmake'}"
@@ -151,10 +148,6 @@ class Builder:
             cmake_cmd.append("-DBUILD_WSI_WAYLAND_SUPPORT=OFF")
             cmake_cmd.append("-DBUILD_WSI_XLIB_SUPPORT=OFF")
             cmake_cmd.append("-DBUILD_WSI_XCB_SUPPORT=OFF")
-            if self.enable_hlsl_support:
-                print(
-                    "WARNING: Ignoring 'enable hlsl support' option not available for the selected platform."
-                )
             return True
 
         if self.target_platform == "android":
@@ -178,11 +171,6 @@ class Builder:
             cmake_cmd.append("-DANDROID_PIE=ON")
             if self.force_no_debug_symbols_android_build:
                 cmake_cmd.append("-DCMAKE_CXX_FLAGS_RELEASE=-g0")
-
-            if self.enable_hlsl_support:
-                print(
-                    "WARNING: Ignoring 'enable hlsl support' option not available for the selected platform."
-                )
             return True
 
         print(
@@ -411,7 +399,7 @@ class Builder:
                         "--spirv-val",
                         f"{self.install}/bin/spirv-val{exe_ext}",
                     ]
-                    if self.enable_hlsl_support and platform.system() in [
+                    if platform.system() in [
                         "Linux",
                         "Windows",
                     ]:
@@ -434,7 +422,7 @@ class Builder:
                         "--spirv-val",
                         f"{self.build_dir}/spirv-tools/tools/spirv-val{exe_ext}",
                     ]
-                    if self.enable_hlsl_support and platform.system() in [
+                    if platform.system() in [
                         "Linux",
                         "Windows",
                     ]:
@@ -720,12 +708,6 @@ def parse_arguments():
     parser.add_argument(
         "--enable-experimental-image-format-support",
         help=("Enable experimental image format support in DDS reader"),
-        action="store_true",
-        default=False,
-    )
-    parser.add_argument(
-        "--enable-hlsl-support",
-        help=("Enable HLSL to SPIRV compilation"),
         action="store_true",
         default=False,
     )

--- a/src/hlsl_compiler.cpp
+++ b/src/hlsl_compiler.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <fstream>
 #include <mutex>
+#include <new>
 #include <stdexcept>
 
 #include <dxc/Support/Global.h>
@@ -20,16 +21,29 @@
 
 #include <dxc/dxcapi.h>
 
-#if defined(SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT) && !defined(_WIN32)
+#if defined(SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT)
 namespace hlsl {
 HRESULT SetupRegistryPassForHLSL();
 HRESULT SetupRegistryPassForPIX();
-namespace options {
-std::error_code initHlslOptTable();
-} // namespace options
 } // namespace hlsl
 
 HRESULT DxilLibInitialize();
+#endif
+
+#if defined(_WIN32) && defined(SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT) && !defined(DXC_DISABLE_ALLOCATOR_OVERRIDES)
+void *__CRTDECL operator new(std::size_t size) noexcept(false) {
+    void *ptr = DxcNew(size);
+    if (ptr == nullptr) {
+        throw std::bad_alloc();
+    }
+    return ptr;
+}
+
+void *__CRTDECL operator new(std::size_t size, const std::nothrow_t &) throw() { return DxcNew(size); }
+
+void __CRTDECL operator delete(void *ptr) throw() { DxcDelete(ptr); }
+
+void __CRTDECL operator delete(void *ptr, const std::nothrow_t &) throw() { DxcDelete(ptr); }
 #endif
 
 namespace mlsdk::scenariorunner {
@@ -56,7 +70,7 @@ std::wstring stringToWstring(const std::string &inputString) {
 
     for (size_t i = 0; i < inputString.size();) {
         int cp = 0;
-        unsigned char c = static_cast<unsigned char>(inputString[i]);
+        auto c = static_cast<unsigned char>(inputString[i]);
 
         if (c < 0x80) {
             cp = c;
@@ -93,7 +107,7 @@ std::vector<DxcDefine> parsePreprocessorOptions(const std::string &options, std:
         }
         std::string op = options.substr(start + 2, end - (start + 2)); // +2 skips the -D
         // split the name and the value and create a DxcDefine object
-        const size_t equal = op.find_first_of("=");
+        const size_t equal = op.find_first_of('=');
         DxcDefine defineStruct{};
         // name and value have to also be stored in a separate vector to avoid dangling pointers
         if (equal == std::string::npos) {
@@ -117,7 +131,7 @@ std::vector<DxcDefine> parsePreprocessorOptions(const std::string &options, std:
 
 } // namespace
 
-#if defined(SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT) && !defined(_WIN32)
+#if defined(SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT)
 namespace {
 void ensureStaticDxcInitialized() {
     static std::once_flag initFlag;
@@ -184,15 +198,21 @@ std::pair<std::string, std::vector<uint32_t>> HlslCompiler::compile(const std::s
                                                                     const std::string &debugName,
                                                                     const std::string &preprocessorOptions,
                                                                     const std::vector<std::string> &shaderDirs) {
-#if defined(SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT) && !defined(_WIN32)
+#if defined(SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT)
     ensureStaticDxcInitialized();
 #endif
 
     // Create DXC instances for the IDxcUtils and IDxcCompiler interfaces
     CComPtr<IDxcUtils> utils;
     CComPtr<IDxcCompiler3> compiler;
-    DxcCreateInstance(CLSID_DxcUtils, IID_PPV_ARGS(&utils));
-    DxcCreateInstance(CLSID_DxcCompiler, IID_PPV_ARGS(&compiler));
+    HRESULT hr = DxcCreateInstance(CLSID_DxcUtils, IID_PPV_ARGS(&utils));
+    if (FAILED(hr) || !utils) {
+        throw std::runtime_error("Failed to create IDxcUtils instance.");
+    }
+    hr = DxcCreateInstance(CLSID_DxcCompiler, IID_PPV_ARGS(&compiler));
+    if (FAILED(hr) || !compiler) {
+        throw std::runtime_error("Failed to create IDxcCompiler3 instance.");
+    }
 
     DxcBuffer buffer;
     buffer.Ptr = source.data();

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -357,11 +357,17 @@ class SDKTools:
     ) -> Path:
         """Compile the shader and return path to the SPIR-V module."""
         suffix = Path(shader).suffix
-        shader = self.resources_helper.prepare_shader(shader, replacements, output)
+        staged_shader_name = None
+        if output:
+            staged_shader_name = Path(output).with_suffix(suffix).name
+
+        shader = self.resources_helper.prepare_shader(
+            shader, replacements, staged_shader_name
+        )
         logger.debug("Shader code:\n%s", shader.read_text())
 
         compiled_shader_path = self.resources_helper.get_testenv_path(
-            shader.stem + ".spv"
+            output or (shader.stem + ".spv")
         )
 
         extra_opts = []


### PR DESCRIPTION
Also ensure DXC initialization on all platforms.

Fix the patch file which was failing to apply on all platforms due to trailing whitespaces removed by pre-commit.

Fix bug in hlslc compiler invocation in pytest.

Cleanup clang-tidy errors.