### PR TITLE
Properly fix linking issues around DXC on some platforms

### DIFF
--- a/cmake/dxc.cmake
+++ b/cmake/dxc.cmake
@@ -60,6 +60,11 @@ if(SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT)
     set(CLANG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
     set(HLSL_INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
     set(HLSL_DISABLE_SOURCE_GENERATION ON CACHE BOOL "" FORCE)
+    if(MSVC AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+        # DXC disables checked iterators by default on MSVC. Keep the
+        # embedded DXC/LLVM build aligned with the rest of the Debug link.
+        set(HLSL_ENABLE_DEBUG_ITERATORS ON CACHE BOOL "" FORCE)
+    endif()
     if(MSVC)
         set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded CACHE STRING "" FORCE)
     endif()

--- a/cmake/spirv-tools.cmake
+++ b/cmake/spirv-tools.cmake
@@ -12,15 +12,6 @@ if(EXISTS ${SPIRV_TOOLS_PATH}/CMakeLists.txt)
     if(NOT TARGET SPIRV-Tools)
         option(SPIRV_SKIP_TESTS "" ON)
         option(SPIRV_WERROR "" OFF)
-
-        if(MSVC AND SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT)
-            # DXC forces _ITERATOR_DEBUG_LEVEL=0 on MSVC builds unless
-            # HLSL_ENABLE_DEBUG_ITERATORS is enabled. Because DXC reuses the
-            # parent SPIRV-Tools targets when they already exist, align the
-            # reused SPIRV-Tools build with DXC to avoid LNK2038.
-            set(SPIRV_TOOLS_EXTRA_DEFINITIONS
-                "${SPIRV_TOOLS_EXTRA_DEFINITIONS} /D_ITERATOR_DEBUG_LEVEL=0")
-        endif()
         add_subdirectory(${SPIRV_TOOLS_PATH} spirv-tools SYSTEM EXCLUDE_FROM_ALL)
     endif()
 


### PR DESCRIPTION
That happens when compiling in debug mode