### PR TITLE
Add basic clang-tidy naming checker

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,11 @@
 #
-# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 Checks: >
     -*,
+    bugprone-use-after-move,
+    cppcoreguidelines-pro-type-cstyle-cast,
     cppcoreguidelines-virtual-class-destructor,
     google-build-namespaces,
     misc-definitions-in-headers,
@@ -39,6 +41,7 @@ Checks: >
     readability-delete-null-pointer,
     readability-duplicate-include,
     readability-else-after-return,
+    readability-identifier-naming,
     readability-inconsistent-declaration-parameter-name,
     readability-isolate-declaration,
     readability-make-member-function-const,
@@ -66,3 +69,10 @@ Checks: >
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*/scenario-runner/src/.*'
 FormatStyle: file
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.LocalVariableCase
+    value: camelBack
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -83,7 +83,7 @@ void Buffer::fillZero(const Context &ctx) const {
 void Buffer::store(const Context &ctx, const std::string &filename) const {
     _memoryManager->downloadData(ctx, _memoryOffset, size());
 
-    ScopeExit<void()> on_scope_exit_run([&] { _memoryManager->unmapStagingBufferMemory(); });
+    ScopeExit<void()> onScopeExitRun([&] { _memoryManager->unmapStagingBufferMemory(); });
     vgfutils::numpy::DataPtr data(
         reinterpret_cast<const char *>(_memoryManager->mapStagingBufferMemory(_memoryOffset, size())), {size()},
         vgfutils::numpy::DType('i', 1));

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -77,11 +77,11 @@ Context::Context(const ScenarioOptions &scenarioOptions, FamilyQueue familyQueue
     _instance = vk::raii::Instance(_ctx, instanceInfo);
 
     // Create physical device
-    auto _physicalDevices = vk::raii::PhysicalDevices(_instance);
+    auto physicalDevices = vk::raii::PhysicalDevices(_instance);
 
     // Sort physical devices prioritizing discrete GPUs
     _physicalDev =
-        *std::max_element(_physicalDevices.begin(), _physicalDevices.end(), [](const auto &left, const auto &right) {
+        *std::max_element(physicalDevices.begin(), physicalDevices.end(), [](const auto &left, const auto &right) {
             // Select discrete GPU
             std::map<vk::PhysicalDeviceType, int> priorityOrder = {
                 {vk::PhysicalDeviceType::eDiscreteGpu, 5},   //

--- a/src/hlsl_compiler.cpp
+++ b/src/hlsl_compiler.cpp
@@ -116,12 +116,12 @@ std::vector<DxcDefine> parsePreprocessorOptions(const std::string &options, std:
             defineStruct.Name = name.c_str();
             defineStruct.Value = nullptr;
         } else {
-            const size_t name_idx = storage.size();
+            const size_t nameIdx = storage.size();
             storage.emplace_back(stringToWstring(op.substr(0, equal)));
-            const size_t value_idx = storage.size();
+            const size_t valueIdx = storage.size();
             storage.emplace_back(stringToWstring(op.substr(equal + 1, op.size())));
-            defineStruct.Name = storage[name_idx].c_str();
-            defineStruct.Value = storage[value_idx].c_str();
+            defineStruct.Name = storage[nameIdx].c_str();
+            defineStruct.Value = storage[valueIdx].c_str();
         }
         defineStrings.push_back(defineStruct);
         start = end + 1;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -365,8 +365,8 @@ void Image::transitionLayout(const Context &ctx, vk::ImageLayout expectedLayout)
     auto cmdPool = ctx.device().createCommandPool(cmdPoolCreateInfo);
     const vk::CommandBufferAllocateInfo cmdBufferAllocInfo(*cmdPool, vk::CommandBufferLevel::ePrimary, 1);
     vk::raii::CommandBuffer cmdBuffer = std::move(ctx.device().allocateCommandBuffers(cmdBufferAllocInfo).front());
-    const vk::CommandBufferBeginInfo CmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
-    cmdBuffer.begin(CmdBufferBeginInfo);
+    const vk::CommandBufferBeginInfo cmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
+    cmdBuffer.begin(cmdBufferBeginInfo);
     addTransitionLayoutCommand(cmdBuffer, expectedLayout);
     cmdBuffer.end();
     vk::SubmitInfo submitInfo({}, {}, *cmdBuffer);
@@ -454,23 +454,23 @@ void Image::fillFromDescription(const Context &ctx, const ImageDesc &desc) {
     if ((_dataType == vk::Format::eR32Sfloat || _dataType == vk::Format::eD32Sfloat) &&
         fileFormat == vk::Format::eD32SfloatS8Uint) {
         // Depth stencil discarding
-        std::vector<uint8_t> bodge_data(dataSize());
-        bool has_stencil_data = false;
+        std::vector<uint8_t> bodgeData(dataSize());
+        bool hasStencilData = false;
         for (uint64_t i = 0; i < totalElementsFromShape(shape()); ++i) {
-            uint64_t depth_idx = i * elementSizeFromVkFormat(fileFormat);
-            uint64_t bodge_idx = i * elementSizeFromVkFormat(_dataType);
-            if (data[depth_idx + 4]) {
-                has_stencil_data = true;
+            uint64_t depthIdx = i * elementSizeFromVkFormat(fileFormat);
+            uint64_t bodgeIdx = i * elementSizeFromVkFormat(_dataType);
+            if (data[depthIdx + 4]) {
+                hasStencilData = true;
             }
-            bodge_data[bodge_idx + 0] = data[depth_idx + 0];
-            bodge_data[bodge_idx + 1] = data[depth_idx + 1];
-            bodge_data[bodge_idx + 2] = data[depth_idx + 2];
-            bodge_data[bodge_idx + 3] = data[depth_idx + 3];
+            bodgeData[bodgeIdx + 0] = data[depthIdx + 0];
+            bodgeData[bodgeIdx + 1] = data[depthIdx + 1];
+            bodgeData[bodgeIdx + 2] = data[depthIdx + 2];
+            bodgeData[bodgeIdx + 3] = data[depthIdx + 3];
         }
-        if (has_stencil_data) {
+        if (hasStencilData) {
             mlsdk::logging::warning("Ignoring stencil data");
         }
-        data = std::move(bodge_data);
+        data = std::move(bodgeData);
     }
 
     const auto elementSize = elementSizeFromVkFormat(_dataType);
@@ -518,8 +518,8 @@ void Image::fillFromDescription(const Context &ctx, const ImageDesc &desc) {
     auto cmdPool = ctx.device().createCommandPool(cmdPoolCreateInfo);
     const vk::CommandBufferAllocateInfo cmdBufferAllocInfo(*cmdPool, vk::CommandBufferLevel::ePrimary, 1);
     vk::raii::CommandBuffer cmdBuffer = std::move(ctx.device().allocateCommandBuffers(cmdBufferAllocInfo).front());
-    const vk::CommandBufferBeginInfo CmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
-    cmdBuffer.begin(CmdBufferBeginInfo);
+    const vk::CommandBufferBeginInfo cmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
+    cmdBuffer.begin(cmdBufferBeginInfo);
 
     cmdBuffer.pipelineBarrier2(vk::DependencyInfo((vk::DependencyFlags)0, memoryBarrier, {}, imageBarrier));
 
@@ -689,8 +689,8 @@ std::vector<char> Image::getImageData(const Context &ctx) {
     auto cmdPool = ctx.device().createCommandPool(cmdPoolCreateInfo);
     const vk::CommandBufferAllocateInfo cmdBufferAllocInfo(*cmdPool, vk::CommandBufferLevel::ePrimary, 1);
     vk::raii::CommandBuffer cmdBuffer = std::move(ctx.device().allocateCommandBuffers(cmdBufferAllocInfo).front());
-    const vk::CommandBufferBeginInfo CmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
-    cmdBuffer.begin(CmdBufferBeginInfo);
+    const vk::CommandBufferBeginInfo cmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
+    cmdBuffer.begin(cmdBufferBeginInfo);
     vk::BufferImageCopy region{};
     const vk::Extent3D extent(static_cast<uint32_t>(_imageInfo.shape[1]), static_cast<uint32_t>(_imageInfo.shape[2]),
                               static_cast<uint32_t>(_imageInfo.shape[3]));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,7 @@ void configureLogging() {
 
 int runScenarioRunner(int argc, const char **argv) {
     int retval = 0;
-    bool pause_on_exit = false;
+    bool pauseOnExit = false;
     try {
         argparse::ArgumentParser parser(argv[0], details::version);
 
@@ -248,7 +248,7 @@ int runScenarioRunner(int argc, const char **argv) {
             scenarioOptions.captureFrame = false;
         }
 
-        pause_on_exit = parser.get<bool>("--pause-on-exit");
+        pauseOnExit = parser.get<bool>("--pause-on-exit");
 
         ScenarioSpec scenarioSpec(&fstream, workDir, outputDir);
         mlsdk::logging::info("Scenario file parsed");
@@ -262,7 +262,7 @@ int runScenarioRunner(int argc, const char **argv) {
         mlsdk::logging::error(err.what());
         retval = -1;
     }
-    if (pause_on_exit) { // cppcheck-suppress-begin knownConditionTrueFalse
+    if (pauseOnExit) { // cppcheck-suppress-begin knownConditionTrueFalse
         mlsdk::logging::info("Press enter to continue...");
         std::ignore = getchar();
     }

--- a/src/pipeline_cache.hpp
+++ b/src/pipeline_cache.hpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#pragma once
+
 #include "context.hpp"
 #include "types.hpp"
 #include "vgf-utils/memory_map.hpp"

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -85,12 +85,12 @@ void Tensor::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> me
         }
     }
 
-    int64_t *strides_ptr = _strides.data();
+    int64_t *stridesPtr = _strides.data();
     if (_strides.empty()) {
-        strides_ptr = nullptr;
+        stridesPtr = nullptr;
     }
 
-    vk::TensorDescriptionARM description(_tiling, _dataType, rank, _shape.data(), strides_ptr, usageFlags);
+    vk::TensorDescriptionARM description(_tiling, _dataType, rank, _shape.data(), stridesPtr, usageFlags);
 
     vk::TensorCreateFlagsARM flags{};
     if (_descriptorBufferCaptureReplay) {

--- a/src/tests/json_parser_tests.cpp
+++ b/src/tests/json_parser_tests.cpp
@@ -1384,15 +1384,15 @@ TEST(JsonParser, ImageResource) {
         "tiling": "{TILING}"
     }
     )"";
-    const std::regex border_color("\\{BORDER_COLOR\\}");
-    const std::regex border_address_mode("\\{BORDER_ADDRESS_MODE\\}");
+    const std::regex borderColor("\\{BORDER_COLOR\\}");
+    const std::regex borderAddressMode("\\{BORDER_ADDRESS_MODE\\}");
     const std::regex tiling("\\{TILING\\}");
 
     {
 
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_color, "INT_TRANSPARENT_BLACK");
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "REPEAT");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "INT_TRANSPARENT_BLACK");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "REPEAT");
         jsonInput = std::regex_replace(jsonInput, tiling, "LINEAR");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);
@@ -1426,8 +1426,8 @@ TEST(JsonParser, ImageResource) {
 
     {
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "MIRRORED_REPEAT");
-        jsonInput = std::regex_replace(jsonInput, border_color, "INT_TRANSPARENT_BLACK");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "MIRRORED_REPEAT");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "INT_TRANSPARENT_BLACK");
         jsonInput = std::regex_replace(jsonInput, tiling, "LINEAR");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);
@@ -1437,8 +1437,8 @@ TEST(JsonParser, ImageResource) {
 
     {
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "CLAMP_EDGE");
-        jsonInput = std::regex_replace(jsonInput, border_color, "INT_TRANSPARENT_BLACK");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "CLAMP_EDGE");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "INT_TRANSPARENT_BLACK");
         jsonInput = std::regex_replace(jsonInput, tiling, "LINEAR");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);
@@ -1448,10 +1448,10 @@ TEST(JsonParser, ImageResource) {
 
     {
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "CLAMP_BORDER");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "CLAMP_BORDER");
         jsonInput = std::regex_replace(jsonInput, tiling, "LINEAR");
 
-        jsonInput = std::regex_replace(jsonInput, border_color, "INT_TRANSPARENT_BLACK");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "INT_TRANSPARENT_BLACK");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);
         ASSERT_TRUE(desc.borderColor.has_value());
@@ -1460,9 +1460,9 @@ TEST(JsonParser, ImageResource) {
 
     {
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "CLAMP_BORDER");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "CLAMP_BORDER");
         jsonInput = std::regex_replace(jsonInput, tiling, "LINEAR");
-        jsonInput = std::regex_replace(jsonInput, border_color, "INT_OPAQUE_BLACK");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "INT_OPAQUE_BLACK");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);
         ASSERT_TRUE(desc.borderColor.has_value());
@@ -1471,9 +1471,9 @@ TEST(JsonParser, ImageResource) {
 
     {
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "CLAMP_BORDER");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "CLAMP_BORDER");
         jsonInput = std::regex_replace(jsonInput, tiling, "LINEAR");
-        jsonInput = std::regex_replace(jsonInput, border_color, "INT_OPAQUE_WHITE");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "INT_OPAQUE_WHITE");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);
         ASSERT_TRUE(desc.borderColor.has_value());
@@ -1482,9 +1482,9 @@ TEST(JsonParser, ImageResource) {
 
     {
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "CLAMP_BORDER");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "CLAMP_BORDER");
         jsonInput = std::regex_replace(jsonInput, tiling, "LINEAR");
-        jsonInput = std::regex_replace(jsonInput, border_color, "FLOAT_TRANSPARENT_BLACK");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "FLOAT_TRANSPARENT_BLACK");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);
         ASSERT_TRUE(desc.borderColor.has_value());
@@ -1493,9 +1493,9 @@ TEST(JsonParser, ImageResource) {
 
     {
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "CLAMP_BORDER");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "CLAMP_BORDER");
         jsonInput = std::regex_replace(jsonInput, tiling, "LINEAR");
-        jsonInput = std::regex_replace(jsonInput, border_color, "FLOAT_OPAQUE_BLACK");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "FLOAT_OPAQUE_BLACK");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);
         ASSERT_TRUE(desc.borderColor.has_value());
@@ -1504,9 +1504,9 @@ TEST(JsonParser, ImageResource) {
 
     {
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "CLAMP_BORDER");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "CLAMP_BORDER");
         jsonInput = std::regex_replace(jsonInput, tiling, "LINEAR");
-        jsonInput = std::regex_replace(jsonInput, border_color, "FLOAT_OPAQUE_WHITE");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "FLOAT_OPAQUE_WHITE");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);
         ASSERT_TRUE(desc.borderColor.has_value());
@@ -1515,8 +1515,8 @@ TEST(JsonParser, ImageResource) {
 
     {
         std::string jsonInput = jsonInputTemplate;
-        jsonInput = std::regex_replace(jsonInput, border_color, "INT_TRANSPARENT_BLACK");
-        jsonInput = std::regex_replace(jsonInput, border_address_mode, "REPEAT");
+        jsonInput = std::regex_replace(jsonInput, borderColor, "INT_TRANSPARENT_BLACK");
+        jsonInput = std::regex_replace(jsonInput, borderAddressMode, "REPEAT");
         jsonInput = std::regex_replace(jsonInput, tiling, "OPTIMAL");
 
         auto desc = MakeFromJSON<ImageDesc>(jsonInput);

--- a/src/tools/dds_utils/main.cpp
+++ b/src/tools/dds_utils/main.cpp
@@ -454,8 +454,8 @@ bool compareDDSHeader(const DDSHeaderInfo &input, const DDSHeaderInfo &output) {
 }
 
 bool isFloat16NaN(uint16_t val) {
-    constexpr uint16_t FP16_EXPONENT = 0x7C00;
-    return (val & FP16_EXPONENT) == FP16_EXPONENT;
+    constexpr uint16_t fP16Exponent = 0x7C00;
+    return (val & fP16Exponent) == fP16Exponent;
 }
 
 bool compare(const std::string &input, const std::string &output, const std::string &elementDtype) {
@@ -492,7 +492,10 @@ int main(int argc, const char **argv) {
     try {
         argparse::ArgumentParser parser(argv[0]);
 
-        parser.add_argument("--action").choices("generate", "to_npy", "compare").help("Required action").required();
+        parser.add_argument("--action")
+            .choices("generate", "to_npy", "compare")
+            .help("Required action: generate, to_npy, or compare")
+            .required();
 
         parser.add_argument("--height").scan<'i', uint32_t>().help("Image height");
         parser.add_argument("--width").scan<'i', uint32_t>().help("Image width");

--- a/src/tools/png_utils/main.cpp
+++ b/src/tools/png_utils/main.cpp
@@ -81,7 +81,10 @@ int main(int argc, const char **argv) {
     try {
         argparse::ArgumentParser parser(argv[0]);
 
-        parser.add_argument("--action").choices("generate", "to_npy", "compare").help("Required action").required();
+        parser.add_argument("--action")
+            .choices("generate", "to_npy", "compare")
+            .help("Required action: generate, to_npy, or compare")
+            .required();
 
         parser.add_argument("--height").scan<'i', uint32_t>().help("Image height");
         parser.add_argument("--width").scan<'i', uint32_t>().help("Image width");

--- a/src/vulkan_memory_manager.hpp
+++ b/src/vulkan_memory_manager.hpp
@@ -125,8 +125,8 @@ class ResourceMemoryManager {
         auto cmdPool = ctx.device().createCommandPool(cmdPoolCreateInfo);
         const vk::CommandBufferAllocateInfo cmdBufferAllocInfo(*cmdPool, vk::CommandBufferLevel::ePrimary, 1);
         vk::raii::CommandBuffer cmdBuffer = std::move(ctx.device().allocateCommandBuffers(cmdBufferAllocInfo).front());
-        const vk::CommandBufferBeginInfo CmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
-        cmdBuffer.begin(CmdBufferBeginInfo);
+        const vk::CommandBufferBeginInfo cmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
+        cmdBuffer.begin(cmdBufferBeginInfo);
         vk::BufferCopy copyRegion{0, 0, size};
         cmdBuffer.copyBuffer(stagingBuffer, deviceBuffer, copyRegion);
         cmdBuffer.end();
@@ -163,8 +163,8 @@ class ResourceMemoryManager {
         auto cmdPool = ctx.device().createCommandPool(cmdPoolCreateInfo);
         const vk::CommandBufferAllocateInfo cmdBufferAllocInfo(*cmdPool, vk::CommandBufferLevel::ePrimary, 1);
         vk::raii::CommandBuffer cmdBuffer = std::move(ctx.device().allocateCommandBuffers(cmdBufferAllocInfo).front());
-        const vk::CommandBufferBeginInfo CmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
-        cmdBuffer.begin(CmdBufferBeginInfo);
+        const vk::CommandBufferBeginInfo cmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
+        cmdBuffer.begin(cmdBufferBeginInfo);
         vk::BufferCopy copyRegion{0, 0, size};
         cmdBuffer.copyBuffer(deviceBuffer, stagingBuffer, copyRegion);
         cmdBuffer.end();


### PR DESCRIPTION
- Fix clang-tidy issues.
- Add missing pragma once.
- Add argument help text to tools.

Change-Id: I010ff7d5e5504ef73a2d0c83086f41b4cf8288d3