### PR TITLE
Add optical flow core support

### DIFF
--- a/docs/source/json.rst
+++ b/docs/source/json.rst
@@ -82,8 +82,8 @@ The root of the JSON file has two blocks.
                    class buffer_barrier | class tensor_barrier | class image_barrier
                    | class graph_constant ],
       commands: [ class dispatch_compute | class dispatch_fragment | class dispatch_graph |
-                  class dispatch_spirv_graph |
-                  class dispatch_barrier | class mark_boundary ]
+            class dispatch_spirv_graph | class dispatch_optical_flow |
+            class dispatch_barrier | class mark_boundary ]
   }
 
 ``resources`` lists all the resources in the test case and each item in the
@@ -104,6 +104,7 @@ array can be any of the following types:
 * :ref:`dispatch_fragment`
 * :ref:`dispatch_graph`
 * :ref:`dispatch_spirv_graph`
+* :ref:`dispatch_optical_flow`
 * :ref:`dispatch_barrier`
 * :ref:`mark_boundary`
 
@@ -485,6 +486,45 @@ tensor data to the SPIR-V pipeline.
   }
 
 .. note:: ``graph_ref`` must reference a ``shader`` resource with ``type`` set to ``SPIR-V``. GLSL is not supported for this command.
+
+dispatch_optical_flow
+"""""""""""""""""""""
+
+The ``dispatch_optical_flow`` command dispatches the optical-flow pipeline.
+It consumes a search image and a template image, and writes motion vectors to
+an output image. Optional bindings can supply input hints and receive matching
+cost output.
+
+.. code-block::
+
+  dispatch_optical_flow: {
+      width: int, // dispatch width in pixels (must be >= 1)
+      height: int, // dispatch height in pixels (must be >= 1)
+      grid_size: enum = (1x1|2x2|4x4|8x8), // corresponds to VkDataGraphOpticalFlowGridSizeFlagBitsARM
+      performance_level: enum(default=medium) = (unknown|slow|medium|fast), // corresponds to VkDataGraphOpticalFlowPerformanceLevelARM
+      execution_flags: [enum(disable_temporal_hints|input_unchanged|reference_unchanged|input_is_previous_reference|reference_is_previous_input)](default=[]), // optional execution flags
+      mean_flow_l1_norm_hint: int(default=0), // optional mean-flow hint; 0 means no hint
+      implicit_barrier:boolean(default=true), // inclusion of implicit memory barrier
+      bindings: class optical_flow_bindings // image bindings for optical-flow inputs and outputs
+  }
+
+  optical_flow_bindings: {
+      search_image: class image_binding, // required binding for the current/input search image
+      template_image: class image_binding, // required binding for the reference/template image
+      output_image: class image_binding, // required binding for motion-vector output
+      hint_motion_vectors: class image_binding(default=), // optional binding for hint motion vectors
+      output_cost: class image_binding(default=) // optional binding for cost output
+  }
+
+  image_binding: {
+      id: int, // descriptor id in the set
+      set: int, // descriptor set id
+      resource_ref: string // named reference to the image resource to bind
+  }
+
+``width``, ``height``, ``grid_size``, and ``bindings`` are required.
+Within ``bindings``, ``search_image``, ``template_image``, and ``output_image``
+are required. Optional ``execution_flags`` values must be unique.
 
 dispatch_barrier
 """"""""""""""""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,5 @@ markers = [
     "spec_const",
     "repeated_runs",
     "png",
+    "optical_flow",
 ]

--- a/schema/command.dispatch_optical_flow.schema
+++ b/schema/command.dispatch_optical_flow.schema
@@ -1,0 +1,111 @@
+{
+    "$id": "urn:scenario:command:dispatch_optical_flow",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "width": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "height": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "grid_size": {
+            "type": "string",
+            "enum": ["1x1", "2x2", "4x4", "8x8"],
+            "description": "Corresponding to VkDataGraphOpticalFlowGridSizeFlagBitsARM."
+        },
+        "performance_level": {
+            "type": "string",
+            "enum": ["unknown", "slow", "medium", "fast"],
+            "default": "medium",
+            "description": "Corresponding to VkDataGraphOpticalFlowPerformanceLevelARM."
+        },
+        "execution_flags": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "disable_temporal_hints",
+                    "input_unchanged",
+                    "reference_unchanged",
+                    "input_is_previous_reference",
+                    "reference_is_previous_input"
+                ]
+            },
+            "uniqueItems": true,
+            "default": [],
+            "description": "Optional set of VkDataGraphOpticalFlowExecuteFlagsARM values."
+        },
+        "mean_flow_l1_norm_hint": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Corresponding to VkDataGraphPipelineOpticalFlowDispatchInfoARM::meanFlowL1NormHint. This is a mean-flow hint (not a direct block-match limit control). 0 means no hint."
+        },
+        "implicit_barrier": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to include an implicit memory barrier (defaults to true)."
+        },
+
+        "bindings": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "search_image": { "$ref": "#/$defs/image_binding" },
+                "template_image": {
+                    "$ref": "#/$defs/image_binding",
+                    "description": "Binding for optical-flow reference input image."
+                },
+                "output_image": { "$ref": "#/$defs/image_binding" },
+                "hint_motion_vectors": {
+                    "$ref": "#/$defs/image_binding",
+                    "description": "Optional."
+                },
+                "output_cost": {
+                    "$ref": "#/$defs/image_binding",
+                    "description": "Optional."
+                }
+            },
+            "required": [
+                "search_image",
+                "template_image",
+                "output_image"
+            ]
+        }
+    },
+    "required": [
+        "width",
+        "height",
+        "grid_size",
+        "bindings"
+    ],
+    "$defs": {
+        "image_binding": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "set": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "resource_ref": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            },
+            "required": [
+                "id",
+                "set",
+                "resource_ref"
+            ]
+        }
+    }
+}

--- a/schema/commands.schema
+++ b/schema/commands.schema
@@ -23,6 +23,9 @@
             },
             "mark_boundary": {
                 "$ref" : "urn:scenario:command:mark_boundary"
+            },
+            "dispatch_optical_flow": {
+                "$ref" : "urn:scenario:command:dispatch_optical_flow"
             }
         },
         "oneOf": [
@@ -43,6 +46,9 @@
             },
             {
                 "required": ["mark_boundary"]
+            },
+            {
+                "required": ["dispatch_optical_flow"]
             }
         ]
     }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -38,6 +38,12 @@ DispatchSpirvGraphDesc::DispatchSpirvGraphDesc() : CommandDesc(CommandType::Disp
 DispatchFragmentDesc::DispatchFragmentDesc() : CommandDesc(CommandType::DispatchFragment) {}
 
 /**
+ * @brief Construct a new Dispatch Optical Flow object
+ *
+ */
+DispatchOpticalFlowDesc::DispatchOpticalFlowDesc() : CommandDesc(CommandType::DispatchOpticalFlow) {}
+
+/**
  * @brief Construct a new Dispatch Barrier object
  *
  */

--- a/src/commands.hpp
+++ b/src/commands.hpp
@@ -18,6 +18,7 @@ enum class CommandType {
     Unknown,
     DispatchCompute,
     DispatchDataGraph,
+    DispatchOpticalFlow,
     DispatchSpirvGraph,
     DispatchFragment,
     DispatchBarrier,
@@ -25,6 +26,31 @@ enum class CommandType {
 };
 
 enum class DescriptorType { Unknown, Auto, StorageImage };
+
+enum class OpticalFlowGridSize : uint32_t {
+    Invalid = 0xFFFFFFFFu,
+    e1x1 = 0,
+    e2x2 = 1,
+    e4x4 = 2,
+    e8x8 = 3,
+};
+
+enum class OpticalFlowPerformanceLevel : uint32_t {
+    Invalid = 0xFFFFFFFFu,
+    Unknown = 0,
+    Slow = 1,
+    Medium = 2,
+    Fast = 3,
+};
+
+enum class OpticalFlowExecutionFlag : uint32_t {
+    Invalid = 0,
+    DisableTemporalHints = 0x1u,
+    InputUnchanged = 0x2u,
+    ReferenceUnchanged = 0x4u,
+    InputIsPreviousReference = 0x8u,
+    ReferenceIsPreviousInput = 0x10u,
+};
 
 /**
  * @brief Commands are executed by the ScenarioRunner. CommandDesc describes a Command.
@@ -138,6 +164,31 @@ struct DispatchSpirvGraphDesc : CommandDesc {
     std::vector<Guid> graphConstants;
     bool implicitBarrier{true};
     std::string entry{"main"};
+};
+
+/**
+ * @brief The DispatchOpticalFlow command dispatches an optical flow data graph pipeline to execute.
+ * DispatchOpticalFlowDesc describes a DispatchOpticalFlow command.
+ *
+ */
+struct DispatchOpticalFlowDesc : CommandDesc {
+    DispatchOpticalFlowDesc();
+
+    std::string debugName;
+    BindingDesc searchImage;
+    BindingDesc templateImage;
+    BindingDesc outputImage;
+    std::optional<BindingDesc> hintMotionVectors;
+    std::optional<BindingDesc> outputCost;
+
+    uint32_t width{0};
+    uint32_t height{0};
+    OpticalFlowGridSize gridSize{OpticalFlowGridSize::e1x1};
+    OpticalFlowPerformanceLevel performanceLevel{OpticalFlowPerformanceLevel::Medium};
+    uint32_t executionFlags{0};
+    uint32_t meanFlowL1NormHint{0};
+
+    bool implicitBarrier{true};
 };
 
 /**

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -223,6 +223,19 @@ void Compute::createPipeline(const PipelineCreateArguments &args, const ShaderIn
     (void)_pipelines.emplace_back(commonArgs, vertexShaderInfo, fragmentShaderInfo, colorAttachmentFormats);
 }
 
+void Compute::createPipeline(const PipelineCreateArguments &args, const DataManager &dataManager,
+                             const TypedBinding &inputSearch, const TypedBinding &inputTemplate,
+                             const TypedBinding &outputFlow, const std::optional<TypedBinding> &inputHintMV,
+                             const std::optional<TypedBinding> &outputCost,
+                             vk::DataGraphOpticalFlowPerformanceLevelARM performanceLevel,
+                             vk::DataGraphOpticalFlowGridSizeFlagsARM gridSize, uint32_t inputWidth,
+                             uint32_t inputHeight) {
+    const std::vector<TypedBinding> emptyBindings{};
+    const Pipeline::CommonArguments commonArgs{_ctx, args.debugName, emptyBindings, args.pipelineCache};
+    (void)_pipelines.emplace_back(commonArgs, dataManager, inputSearch, inputTemplate, outputFlow, inputHintMV,
+                                  outputCost, performanceLevel, gridSize, inputWidth, inputHeight);
+}
+
 void Compute::_registerPipelineFencedCommon(const DataManager &dataManager, const std::vector<TypedBinding> &bindings,
                                             const char *pushConstantData, size_t pushConstantSize) {
     const auto &pipeline = _pipelines.back();
@@ -250,9 +263,10 @@ void Compute::_registerPipelineFencedCommon(const DataManager &dataManager, cons
 
 void Compute::registerPipelineFenced(const DataManager &dataManager, const std::vector<TypedBinding> &bindings,
                                      const char *pushConstantData, size_t pushConstantSize, bool implicitBarriers,
-                                     ComputeDispatch computeDispatch) {
+                                     ComputeDispatch computeDispatch,
+                                     std::optional<OpticalFlowDispatchInfo> opticalFlowDispatchInfo) {
     _registerPipelineFencedCommon(dataManager, bindings, pushConstantData, pushConstantSize);
-    _addDispatch(computeDispatch);
+    _addDispatch(computeDispatch, opticalFlowDispatchInfo);
 
     if (implicitBarriers) {
         _addImplicitBarriers();
@@ -293,10 +307,15 @@ void Compute::_addPushConstants(const char *pushConstantData, const Pipeline &pi
     }
 }
 
-void Compute::_addDispatch(const ComputeDispatch &computeDispatch) {
+void Compute::_addDispatch(const ComputeDispatch &computeDispatch,
+                           const std::optional<OpticalFlowDispatchInfo> &dispatchInfo) {
     const auto &pipeline = _pipelines.back();
     if (pipeline.isDataGraphPipeline()) {
-        _commands.emplace_back(DataGraphDispatch{pipeline.session()});
+        DataGraphDispatch dispatch{pipeline.session()};
+        if (dispatchInfo.has_value()) {
+            dispatch.dispatchInfo = dispatchInfo;
+        }
+        _commands.emplace_back(dispatch);
     } else {
         _commands.emplace_back(computeDispatch);
     }
@@ -493,7 +512,19 @@ void Compute::_createCmdBuffer() {
         } else if (std::holds_alternative<DataGraphDispatch>(cmd)) {
             mlsdk::logging::info("Dispatch graph");
             auto &typedCmd = std::get<DataGraphDispatch>(cmd);
-            _cmdBufferArray.back().dispatchDataGraphARM(typedCmd.session);
+            if (typedCmd.dispatchInfo.has_value()) {
+                vk::DataGraphPipelineOpticalFlowDispatchInfoARM opticalFlowInfo{};
+                opticalFlowInfo.setFlags(typedCmd.dispatchInfo->opticalFlowFlags);
+                opticalFlowInfo.setMeanFlowL1NormHint(typedCmd.dispatchInfo->meanFlowL1NormHint);
+
+                vk::DataGraphPipelineDispatchInfoARM dispatchInfo{};
+                dispatchInfo.setFlags(vk::DataGraphPipelineDispatchFlagsARM{});
+                dispatchInfo.setPNext(&opticalFlowInfo);
+
+                _cmdBufferArray.back().dispatchDataGraphARM(typedCmd.session, &dispatchInfo);
+            } else {
+                _cmdBufferArray.back().dispatchDataGraphARM(typedCmd.session);
+            }
         } else if (std::holds_alternative<GraphicsDispatch>(cmd)) {
             mlsdk::logging::info("Dispatch graphics");
             auto &typedCmd = std::get<GraphicsDispatch>(cmd);

--- a/src/compute.hpp
+++ b/src/compute.hpp
@@ -10,6 +10,7 @@
 #include "pipeline.hpp"
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <variant>
 #include <vector>
@@ -87,6 +88,25 @@ class Compute {
     void createPipeline(const PipelineCreateArguments &args, const ShaderInfo &shaderInfo,
                         const DataManager &dataManager, const std::vector<GraphConstantInfo> &constants);
 
+    /// \brief Create an optical flow data graph pipeline.
+    ///
+    /// This builds a VkDataGraphPipelineOpticalFlow using image resources from the DataManager
+    /// and the provided bindings. The bindings are interpreted as:
+    ///  - sampled images for inputs (search/template/hint)
+    ///  - storage images for outputs (flow/cost)
+    void createPipeline(const PipelineCreateArguments &args, const DataManager &dataManager,
+                        const TypedBinding &inputSearch, const TypedBinding &inputTemplate,
+                        const TypedBinding &outputFlow, const std::optional<TypedBinding> &inputHintMV,
+                        const std::optional<TypedBinding> &outputCost,
+                        vk::DataGraphOpticalFlowPerformanceLevelARM performanceLevel,
+                        vk::DataGraphOpticalFlowGridSizeFlagsARM gridSize, uint32_t inputWidth, uint32_t inputHeight);
+
+    /// \brief Optional dispatch info for data graph pipelines.
+    struct OpticalFlowDispatchInfo {
+        vk::DataGraphOpticalFlowExecuteFlagsARM opticalFlowFlags{};
+        uint32_t meanFlowL1NormHint{0};
+    };
+
     /// \brief Register last created pipeline for execution with a fence synchronization
     /// in the end
     ///
@@ -96,9 +116,11 @@ class Compute {
     /// \param pushConstantSize Size of push constants data in bytes
     /// \param implicitBarriers True to enable implicit barriers
     /// \param computeDispatch (Optional) Workgroup count across dimension X, Y and Z. Defaults to: 1, 1 and 1.
+    /// \param opticalFlowDispatchInfo (Optional) Optical flow dispatch info (optical flow flags, mean flow hint).
     void registerPipelineFenced(const DataManager &dataManager, const std::vector<TypedBinding> &bindings,
                                 const char *pushConstantData, size_t pushConstantSize, bool implicitBarriers,
-                                ComputeDispatch computeDispatch = {});
+                                ComputeDispatch computeDispatch = {},
+                                std::optional<OpticalFlowDispatchInfo> opticalFlowDispatchInfo = std::nullopt);
     void registerPipelineFenced(const DataManager &dataManager, const std::vector<TypedBinding> &bindings,
                                 const char *pushConstantData, size_t pushConstantSize, bool implicitBarriers,
                                 const GraphicsDispatchInfo &graphicsDispatch);
@@ -155,6 +177,7 @@ class Compute {
 
     struct DataGraphDispatch {
         vk::DataGraphPipelineSessionARM session{nullptr};
+        std::optional<OpticalFlowDispatchInfo> dispatchInfo{};
     };
 
     struct MemoryBarrier {
@@ -246,7 +269,8 @@ class Compute {
 
     void _addPushConstants(const char *pushConstantData, const Pipeline &pipeline, size_t pushConstantSize);
 
-    void _addDispatch(const ComputeDispatch &computeDispatch);
+    void _addDispatch(const ComputeDispatch &computeDispatch,
+                      const std::optional<OpticalFlowDispatchInfo> &dispatchInfo);
 
     void _addGraphicsDispatch(const GraphicsDispatchInfo &graphicsDispatch);
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -127,6 +127,8 @@ Context::Context(const ScenarioOptions &scenarioOptions, FamilyQueue familyQueue
         hasExtension(extensions, VK_KHR_SHADER_BFLOAT16_EXTENSION_NAME, scenarioOptions.disabledExtensions);
     _optionals.shader_float8 =
         hasExtension(extensions, VK_EXT_SHADER_FLOAT8_EXTENSION_NAME, scenarioOptions.disabledExtensions);
+    _optionals.optical_flow =
+        hasExtension(extensions, VK_ARM_DATA_GRAPH_OPTICAL_FLOW_EXTENSION_NAME, scenarioOptions.disabledExtensions);
 
     // Create device
     const float queuePriority = 1.0f;
@@ -149,17 +151,25 @@ Context::Context(const ScenarioOptions &scenarioOptions, FamilyQueue familyQueue
         prevPNext = &physicalDevReplicateCompositesFeat;
     }
 
-    const auto availableFeatures =
-        _physicalDev
-            .getFeatures2<vk::PhysicalDeviceFeatures2, vk::PhysicalDeviceVulkan11Features,
-                          vk::PhysicalDeviceVulkan12Features, vk::PhysicalDeviceVulkan13Features,
-                          vk::PhysicalDeviceShaderBfloat16FeaturesKHR, vk::PhysicalDeviceShaderFloat8FeaturesEXT>();
+    const auto availableFeatures = _physicalDev.getFeatures2<
+        vk::PhysicalDeviceFeatures2, vk::PhysicalDeviceVulkan11Features, vk::PhysicalDeviceVulkan12Features,
+        vk::PhysicalDeviceVulkan13Features, vk::PhysicalDeviceShaderBfloat16FeaturesKHR,
+        vk::PhysicalDeviceShaderFloat8FeaturesEXT, vk::PhysicalDeviceDataGraphOpticalFlowFeaturesARM>();
 
     const auto &availableCoreFeatures = availableFeatures.template get<vk::PhysicalDeviceFeatures2>().features;
     const auto &[available11Features, available12Features, available13Features, availableBfloat16, availableFloat8] =
         availableFeatures.template get<vk::PhysicalDeviceVulkan11Features, vk::PhysicalDeviceVulkan12Features,
                                        vk::PhysicalDeviceVulkan13Features, vk::PhysicalDeviceShaderBfloat16FeaturesKHR,
                                        vk::PhysicalDeviceShaderFloat8FeaturesEXT>();
+
+    const auto &availableDataGraphOpticalFlow =
+        availableFeatures.template get<vk::PhysicalDeviceDataGraphOpticalFlowFeaturesARM>();
+    if (_optionals.optical_flow && !availableDataGraphOpticalFlow.dataGraphOpticalFlow) {
+        mlsdk::logging::warning("VK_ARM_data_graph_optical_flow extension is present, but "
+                                "dataGraphOpticalFlow feature is not supported. "
+                                "Disabling optical flow support.");
+        _optionals.optical_flow = false;
+    }
 
     const bool requiresDynamicRendering = familyQueue == FamilyQueue::Graphics;
     if (requiresDynamicRendering && !available13Features.dynamicRendering) {
@@ -202,6 +212,13 @@ Context::Context(const ScenarioOptions &scenarioOptions, FamilyQueue familyQueue
         float8Feat.shaderFloat8 = availableFloat8.shaderFloat8;
         float8Feat.pNext = featureChain;
         featureChain = &float8Feat;
+    }
+
+    vk::PhysicalDeviceDataGraphOpticalFlowFeaturesARM dataGraphOpticalFlowFeat{};
+    if (_optionals.optical_flow) {
+        dataGraphOpticalFlowFeat.dataGraphOpticalFlow = availableDataGraphOpticalFlow.dataGraphOpticalFlow;
+        dataGraphOpticalFlowFeat.pNext = featureChain;
+        featureChain = &dataGraphOpticalFlowFeat;
     }
 
     vk::PhysicalDeviceDataGraphFeaturesARM dataGraphFeat{};
@@ -248,6 +265,9 @@ Context::Context(const ScenarioOptions &scenarioOptions, FamilyQueue familyQueue
     }
     if (_optionals.shader_float8) {
         vulkanDeviceExtensions.push_back(VK_EXT_SHADER_FLOAT8_EXTENSION_NAME);
+    }
+    if (_optionals.optical_flow) {
+        vulkanDeviceExtensions.push_back(VK_ARM_DATA_GRAPH_OPTICAL_FLOW_EXTENSION_NAME);
     }
 #ifdef MOLTEN_VK_SUPPORT
     vulkanDeviceExtensions.push_back("VK_KHR_portability_subset");

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -21,6 +21,7 @@ struct OptionalExtensions {
     bool replicated_composites = false;
     bool shader_bfloat16 = false;
     bool shader_float8 = false;
+    bool optical_flow = false;
 };
 
 /// \brief Type of family queue to use

--- a/src/json_reader.cpp
+++ b/src/json_reader.cpp
@@ -16,9 +16,13 @@ namespace {
 
 const std::unordered_map<std::string_view, CommandType> &getCommandTypeByKey() {
     static const std::unordered_map<std::string_view, CommandType> commandTypeByKey = {
-        {"dispatch_compute", CommandType::DispatchCompute},   {"dispatch_graph", CommandType::DispatchDataGraph},
-        {"dispatch_fragment", CommandType::DispatchFragment}, {"dispatch_spirv_graph", CommandType::DispatchSpirvGraph},
-        {"dispatch_barrier", CommandType::DispatchBarrier},   {"mark_boundary", CommandType::MarkBoundary},
+        {"dispatch_compute", CommandType::DispatchCompute},
+        {"dispatch_graph", CommandType::DispatchDataGraph},
+        {"dispatch_fragment", CommandType::DispatchFragment},
+        {"dispatch_spirv_graph", CommandType::DispatchSpirvGraph},
+        {"dispatch_barrier", CommandType::DispatchBarrier},
+        {"mark_boundary", CommandType::MarkBoundary},
+        {"dispatch_optical_flow", CommandType::DispatchOpticalFlow},
     };
 
     return commandTypeByKey;
@@ -190,6 +194,26 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DescriptorType, {{DescriptorType::Unknown, nullptr}
 NLOHMANN_JSON_SERIALIZE_ENUM(Tiling,
                              {{Tiling::Unknown, nullptr}, {Tiling::Optimal, "OPTIMAL"}, {Tiling::Linear, "LINEAR"}})
 
+NLOHMANN_JSON_SERIALIZE_ENUM(OpticalFlowGridSize, {{OpticalFlowGridSize::Invalid, nullptr},
+                                                   {OpticalFlowGridSize::e1x1, "1x1"},
+                                                   {OpticalFlowGridSize::e2x2, "2x2"},
+                                                   {OpticalFlowGridSize::e4x4, "4x4"},
+                                                   {OpticalFlowGridSize::e8x8, "8x8"}})
+
+NLOHMANN_JSON_SERIALIZE_ENUM(OpticalFlowPerformanceLevel, {{OpticalFlowPerformanceLevel::Invalid, nullptr},
+                                                           {OpticalFlowPerformanceLevel::Unknown, "unknown"},
+                                                           {OpticalFlowPerformanceLevel::Slow, "slow"},
+                                                           {OpticalFlowPerformanceLevel::Medium, "medium"},
+                                                           {OpticalFlowPerformanceLevel::Fast, "fast"}})
+
+NLOHMANN_JSON_SERIALIZE_ENUM(OpticalFlowExecutionFlag,
+                             {{OpticalFlowExecutionFlag::Invalid, nullptr},
+                              {OpticalFlowExecutionFlag::DisableTemporalHints, "disable_temporal_hints"},
+                              {OpticalFlowExecutionFlag::InputUnchanged, "input_unchanged"},
+                              {OpticalFlowExecutionFlag::ReferenceUnchanged, "reference_unchanged"},
+                              {OpticalFlowExecutionFlag::InputIsPreviousReference, "input_is_previous_reference"},
+                              {OpticalFlowExecutionFlag::ReferenceIsPreviousInput, "reference_is_previous_input"}})
+
 void readJson(ScenarioSpec &scenarioSpec, std::istream *is) {
     json j;
     *is >> j;
@@ -274,6 +298,10 @@ void readJson(ScenarioSpec &scenarioSpec, std::istream *is) {
         case (CommandType::MarkBoundary): {
             auto markBoundary = commandJson.at("mark_boundary").get<MarkBoundaryDesc>();
             scenarioSpec.addCommand(std::make_unique<MarkBoundaryDesc>(std::move(markBoundary)));
+        } break;
+        case (CommandType::DispatchOpticalFlow): {
+            auto dispatchOpticalFlow = commandJson.at("dispatch_optical_flow").get<DispatchOpticalFlowDesc>();
+            scenarioSpec.addCommand(std::make_unique<DispatchOpticalFlowDesc>(std::move(dispatchOpticalFlow)));
         } break;
         default:
             throw std::runtime_error("Unknown Command type in commands");
@@ -390,6 +418,70 @@ void from_json(const json &j, DispatchSpirvGraphDesc &dispatchSpirvGraph) {
     }
     if (j.contains("implicit_barrier")) {
         dispatchSpirvGraph.implicitBarrier = j.at("implicit_barrier").get<bool>();
+    }
+}
+
+/**
+ * @brief De-serialize DispatchOpticalFlowDesc from JSON.
+ *
+ * @param j
+ * @param dispatchOpticalFlow
+ */
+void from_json(const json &j, DispatchOpticalFlowDesc &dispatchOpticalFlow) {
+    dispatchOpticalFlow.debugName = "dispatch_optical_flow";
+
+    dispatchOpticalFlow.width = j.at("width").get<uint32_t>();
+    dispatchOpticalFlow.height = j.at("height").get<uint32_t>();
+    dispatchOpticalFlow.gridSize = j.at("grid_size").get<OpticalFlowGridSize>();
+    if (dispatchOpticalFlow.gridSize == OpticalFlowGridSize::Invalid) {
+        throw std::runtime_error("Invalid optical flow grid_size value. Expected one of: 1x1, 2x2, 4x4, 8x8.");
+    }
+
+    if (j.contains("performance_level")) {
+        dispatchOpticalFlow.performanceLevel = j.at("performance_level").get<OpticalFlowPerformanceLevel>();
+        if (dispatchOpticalFlow.performanceLevel == OpticalFlowPerformanceLevel::Invalid) {
+            throw std::runtime_error(
+                "Invalid optical flow performance_level value. Expected one of: unknown, slow, medium, fast.");
+        }
+    }
+    dispatchOpticalFlow.meanFlowL1NormHint = j.value("mean_flow_l1_norm_hint", dispatchOpticalFlow.meanFlowL1NormHint);
+
+    if (dispatchOpticalFlow.width == 0 || dispatchOpticalFlow.height == 0) {
+        throw std::runtime_error("Optical flow width and height must be > 0");
+    }
+    if (dispatchOpticalFlow.meanFlowL1NormHint >= std::max(dispatchOpticalFlow.width, dispatchOpticalFlow.height)) {
+        throw std::runtime_error(
+            "Invalid optical flow mean_flow_l1_norm_hint value. Expected 0 or < max(width, height).");
+    }
+
+    if (j.contains("implicit_barrier")) {
+        dispatchOpticalFlow.implicitBarrier = j.at("implicit_barrier").get<bool>();
+    }
+
+    if (j.contains("execution_flags")) {
+        auto flags = j.at("execution_flags").get<std::vector<OpticalFlowExecutionFlag>>();
+        for (const auto flag : flags) {
+            if (flag == OpticalFlowExecutionFlag::Invalid) {
+                throw std::runtime_error("Invalid optical flow execution_flags value.");
+            }
+            dispatchOpticalFlow.executionFlags |= static_cast<uint32_t>(flag);
+        }
+    }
+    constexpr uint32_t validExecutionFlagsMask = 0x1Fu;
+    if ((dispatchOpticalFlow.executionFlags & ~validExecutionFlagsMask) != 0u) {
+        throw std::runtime_error("Invalid optical flow execution_flags value.");
+    }
+
+    const json &bindingsJson = j.at("bindings");
+    dispatchOpticalFlow.searchImage = bindingsJson.at("search_image").get<BindingDesc>();
+    dispatchOpticalFlow.templateImage = bindingsJson.at("template_image").get<BindingDesc>();
+    dispatchOpticalFlow.outputImage = bindingsJson.at("output_image").get<BindingDesc>();
+
+    if (bindingsJson.contains("hint_motion_vectors")) {
+        dispatchOpticalFlow.hintMotionVectors = bindingsJson.at("hint_motion_vectors").get<BindingDesc>();
+    }
+    if (bindingsJson.contains("output_cost")) {
+        dispatchOpticalFlow.outputCost = bindingsJson.at("output_cost").get<BindingDesc>();
     }
 }
 

--- a/src/json_reader.hpp
+++ b/src/json_reader.hpp
@@ -30,6 +30,9 @@ void from_json(const json &j, DispatchDataGraphDesc &dispatchDataGraph);
 // Function to de-serialize DispatchSpirvGraphDesc from JSON
 void from_json(const json &j, DispatchSpirvGraphDesc &dispatchSpirvGraph);
 
+// Function to de-serialize DispatchOpticalFlowDesc from JSON
+void from_json(const json &j, DispatchOpticalFlowDesc &dispatchOpticalFlow);
+
 // Function to de-serialize a BindingDesc from JSON
 void from_json(const json &j, BindingDesc &binding);
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -378,6 +378,123 @@ Pipeline::Pipeline(const CommonArguments &args, const uint32_t segmentIndex, con
     graphComputePipelineCommon(args.ctx, segmentIndex, vgfView, args.pipelineCache, resourceInfos);
 }
 
+Pipeline::Pipeline(const CommonArguments &args, const DataManager &dataManager, const TypedBinding &inputSearch,
+                   const TypedBinding &inputTemplate, const TypedBinding &outputFlow,
+                   const std::optional<TypedBinding> &inputHintMV, const std::optional<TypedBinding> &outputCost,
+                   vk::DataGraphOpticalFlowPerformanceLevelARM performanceLevel,
+                   vk::DataGraphOpticalFlowGridSizeFlagsARM gridSize, uint32_t inputWidth, uint32_t inputHeight)
+    : _type{PipelineType::GraphCompute}, _debugName(args.debugName), _opticalFlowSession(true) {
+
+    // Create descriptor set layouts from bindings
+    std::vector<TypedBinding> bindings;
+    bindings.reserve(5);
+    bindings.emplace_back(inputSearch);
+    bindings.emplace_back(inputTemplate);
+    bindings.emplace_back(outputFlow);
+    if (inputHintMV.has_value()) {
+        bindings.emplace_back(inputHintMV.value());
+    }
+    if (outputCost.has_value()) {
+        bindings.emplace_back(outputCost.value());
+    }
+    createDescriptorSetLayouts(args.ctx, bindings);
+    _pipelineLayout = createPipelineLayout(args.ctx, _descriptorSetLayouts);
+
+    const auto inputFormat = dataManager.getImage(inputSearch.resourceRef).dataType();
+    const auto flowFormat = dataManager.getImage(outputFlow.resourceRef).dataType();
+    vk::Format costFormat{};
+
+    // We expect all bindings to be images (sampled or storage)
+    vk::DataGraphOpticalFlowCreateFlagsARM flags{};
+    std::vector<vk::DataGraphPipelineResourceInfoARM> resourceInfos;
+    resourceInfos.reserve(bindings.size());
+
+    std::vector<vk::DataGraphPipelineResourceInfoImageLayoutARM> resourceImageInfos;
+    resourceImageInfos.reserve(bindings.size());
+
+    std::vector<vk::DataGraphPipelineSingleNodeConnectionARM> connections;
+    connections.reserve(bindings.size());
+
+    auto addConnection = [&](const TypedBinding &binding, vk::DataGraphPipelineNodeConnectionTypeARM connection) {
+        if (!dataManager.hasImage(binding.resourceRef)) {
+            throw std::runtime_error("Optical flow pipeline expects image resources for all bindings");
+        }
+        const auto layout = dataManager.getImage(binding.resourceRef).getImageLayout();
+
+        vk::DataGraphPipelineSingleNodeConnectionARM conn{};
+        conn.setSet(static_cast<uint32_t>(binding.set));
+        conn.setBinding(static_cast<uint32_t>(binding.id));
+        conn.setConnection(connection);
+        connections.emplace_back(conn);
+
+        vk::DataGraphPipelineResourceInfoImageLayoutARM imgInfo{};
+        imgInfo.setLayout(layout);
+        resourceImageInfos.emplace_back(imgInfo);
+
+        vk::DataGraphPipelineResourceInfoARM resInfo{};
+        resInfo.setDescriptorSet(static_cast<uint32_t>(binding.set));
+        resInfo.setBinding(static_cast<uint32_t>(binding.id));
+        resInfo.setArrayElement(0);
+        resInfo.setPNext(&resourceImageInfos.back());
+        resourceInfos.emplace_back(resInfo);
+    };
+
+    addConnection(inputSearch, vk::DataGraphPipelineNodeConnectionTypeARM::eOpticalFlowInput);
+    addConnection(inputTemplate, vk::DataGraphPipelineNodeConnectionTypeARM::eOpticalFlowReference);
+    addConnection(outputFlow, vk::DataGraphPipelineNodeConnectionTypeARM::eOpticalFlowFlowVector);
+    if (inputHintMV.has_value()) {
+        addConnection(inputHintMV.value(), vk::DataGraphPipelineNodeConnectionTypeARM::eOpticalFlowHint);
+        flags |= vk::DataGraphOpticalFlowCreateFlagBitsARM::eEnableHint;
+    }
+    if (outputCost.has_value()) {
+        addConnection(outputCost.value(), vk::DataGraphPipelineNodeConnectionTypeARM::eOpticalFlowCost);
+        flags |= vk::DataGraphOpticalFlowCreateFlagBitsARM::eEnableCost;
+        costFormat = dataManager.getImage(outputCost.value().resourceRef).dataType();
+    }
+
+    vk::DataGraphPipelineSingleNodeCreateInfoARM singleNodeInfo{};
+    singleNodeInfo.setNodeType(vk::DataGraphPipelineNodeTypeARM::eOpticalFlow);
+    singleNodeInfo.setConnectionCount(static_cast<uint32_t>(connections.size()));
+    singleNodeInfo.setPConnections(connections.data());
+
+    vk::DataGraphPipelineOpticalFlowCreateInfoARM opticalFlowCreateInfo{};
+    opticalFlowCreateInfo.setWidth(inputWidth);
+    opticalFlowCreateInfo.setHeight(inputHeight);
+    opticalFlowCreateInfo.setImageFormat(inputFormat);
+    opticalFlowCreateInfo.setFlowVectorFormat(flowFormat);
+    opticalFlowCreateInfo.setCostFormat(costFormat);
+    opticalFlowCreateInfo.setOutputGridSize(gridSize);
+    opticalFlowCreateInfo.setHintGridSize(gridSize);
+    opticalFlowCreateInfo.setPerformanceLevel(performanceLevel);
+    opticalFlowCreateInfo.setFlags(flags);
+    singleNodeInfo.setPNext(&opticalFlowCreateInfo);
+
+    const vk::raii::DeferredOperationKHR deferredOperation(nullptr);
+
+    vk::PipelineCreateFlags2KHR flags2{};
+    const vk::raii::PipelineCache *vkPipelineCache{nullptr};
+    if (args.pipelineCache) {
+        if (args.pipelineCache->failOnCacheMiss()) {
+            flags2 |= vk::PipelineCreateFlagBits2KHR::eFailOnPipelineCompileRequired;
+        }
+        insertAfter(&opticalFlowCreateInfo, args.pipelineCache->getCacheFeedbackCreateInfo());
+        vkPipelineCache = args.pipelineCache->get();
+    }
+
+    vk::DataGraphPipelineCreateInfoARM pipelineCreateInfo{};
+    pipelineCreateInfo.setFlags(flags2);
+    pipelineCreateInfo.setLayout(*_pipelineLayout);
+    pipelineCreateInfo.setResourceInfoCount(static_cast<uint32_t>(resourceInfos.size()));
+    pipelineCreateInfo.setPResourceInfos(resourceInfos.data());
+    pipelineCreateInfo.setPNext(&singleNodeInfo);
+
+    _pipeline = vk::raii::Pipeline(args.ctx.device(), deferredOperation, vkPipelineCache, pipelineCreateInfo);
+
+    trySetVkRaiiObjectDebugName(args.ctx, _pipeline, _debugName);
+
+    initSession(args.ctx);
+}
+
 void Pipeline::graphComputePipelineCommon(const Context &ctx, const ShaderInfo &shaderInfo,
                                           const std::vector<vk::DataGraphPipelineResourceInfoARM> &resourceInfos,
                                           const std::vector<vk::DataGraphPipelineConstantARM> &constantInfos,
@@ -445,6 +562,9 @@ void Pipeline::graphComputePipelineCommon(const Context &ctx, uint32_t segmentIn
 void Pipeline::initSession(const Context &ctx) {
     // Create session for the pipeline
     vk::DataGraphPipelineSessionCreateFlagsARM sessionFlags{};
+    if (_opticalFlowSession) {
+        sessionFlags |= vk::DataGraphPipelineSessionCreateFlagBitsARM::eOpticalFlowCache;
+    }
     vk::DataGraphPipelineSessionCreateInfoARM sessionCreateInfo{sessionFlags, *_pipeline};
 
     _session = vk::raii::DataGraphPipelineSessionARM{ctx.device(), sessionCreateInfo};

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -42,6 +42,21 @@ class Pipeline {
     Pipeline(const CommonArguments &args, const ShaderInfo &vertexShaderInfo, const ShaderInfo &fragmentShaderInfo,
              const std::vector<vk::Format> &colorAttachmentFormats);
 
+    /// \brief Optical flow data graph pipeline constructor
+    ///
+    /// Builds a VkDataGraphPipelineOpticalFlow using image resources from DataManager
+    /// and the provided TypedBinding list. The bindings are interpreted as:
+    ///  - sampled images for inputs (search/template/hint)
+    ///  - storage images for outputs (flow/cost)
+    ///
+    /// The optical flow specific parameters (performance level, enable hint/cost)
+    /// are passed via the dedicated create info struct.
+    Pipeline(const CommonArguments &args, const DataManager &dataManager, const TypedBinding &inputSearch,
+             const TypedBinding &inputTemplate, const TypedBinding &outputFlow,
+             const std::optional<TypedBinding> &inputHintMV, const std::optional<TypedBinding> &outputCost,
+             vk::DataGraphOpticalFlowPerformanceLevelARM performanceLevel,
+             vk::DataGraphOpticalFlowGridSizeFlagsARM gridSize, uint32_t inputWidth, uint32_t inputHeight);
+
     /// \brief Vulkan® pipeline accessor
     /// \return The underlying Vulkan® pipeline of the object
     const vk::Pipeline &pipeline() const { return *_pipeline; }
@@ -85,6 +100,7 @@ class Pipeline {
     std::string _debugName{};
     uint64_t _dataGraphPipelineMemoryRequirement{};
     vk::ShaderStageFlags _pushConstantStages{};
+    bool _opticalFlowSession{false};
 
     void initSession(const Context &ctx);
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -67,6 +67,25 @@ struct DispatchSpirvGraphData {
     bool implicitBarrier{true};
 };
 
+/// \brief Optical flow data graph with typed bindings
+struct DispatchOpticalFlowData {
+    std::string debugName;
+    TypedBinding searchImage;
+    TypedBinding templateImage;
+    TypedBinding outputImage;
+    std::optional<TypedBinding> hintMotionVectors;
+    std::optional<TypedBinding> outputCost;
+
+    uint32_t width{0};
+    uint32_t height{0};
+    OpticalFlowPerformanceLevel performanceLevel{OpticalFlowPerformanceLevel::Medium};
+    uint32_t executionFlags{0};
+    OpticalFlowGridSize gridSize{OpticalFlowGridSize::e1x1};
+    uint32_t meanFlowL1NormHint{0};
+
+    bool implicitBarrier{true};
+};
+
 namespace {
 std::vector<GraphConstantInfo> collectGraphConstants(const std::vector<Guid> &constantUids,
                                                      const std::vector<std::unique_ptr<ResourceDesc>> &resources) {
@@ -482,6 +501,31 @@ struct CommandDataFactory {
         return data;
     }
 
+    DispatchOpticalFlowData createData(const DispatchOpticalFlowDesc &dispatchOpticalFlow) {
+        DispatchOpticalFlowData data;
+        data.debugName = dispatchOpticalFlow.debugName;
+
+        data.searchImage = convertBinding(_dataManager, dispatchOpticalFlow.searchImage);
+        data.templateImage = convertBinding(_dataManager, dispatchOpticalFlow.templateImage);
+        data.outputImage = convertBinding(_dataManager, dispatchOpticalFlow.outputImage);
+        if (dispatchOpticalFlow.hintMotionVectors.has_value()) {
+            data.hintMotionVectors = convertBinding(_dataManager, dispatchOpticalFlow.hintMotionVectors.value());
+        }
+        if (dispatchOpticalFlow.outputCost.has_value()) {
+            data.outputCost = convertBinding(_dataManager, dispatchOpticalFlow.outputCost.value());
+        }
+
+        data.width = dispatchOpticalFlow.width;
+        data.height = dispatchOpticalFlow.height;
+        data.performanceLevel = dispatchOpticalFlow.performanceLevel;
+        data.executionFlags = dispatchOpticalFlow.executionFlags;
+        data.gridSize = dispatchOpticalFlow.gridSize;
+        data.meanFlowL1NormHint = dispatchOpticalFlow.meanFlowL1NormHint;
+
+        data.implicitBarrier = dispatchOpticalFlow.implicitBarrier;
+        return data;
+    }
+
     MarkBoundaryData createData(const MarkBoundaryDesc &markBoundary) {
         MarkBoundaryData data;
 
@@ -523,6 +567,39 @@ auto getFamilyQueue(const ScenarioSpec &spec) {
     }
     return FamilyQueue::DataGraph;
 }
+
+// Map performance level to Vulkan enum
+auto getOpticalFlowPerformanceLevel(OpticalFlowPerformanceLevel performanceLevel) {
+    switch (performanceLevel) {
+    case OpticalFlowPerformanceLevel::Unknown:
+        return vk::DataGraphOpticalFlowPerformanceLevelARM::eUnknown;
+    case OpticalFlowPerformanceLevel::Slow:
+        return vk::DataGraphOpticalFlowPerformanceLevelARM::eSlow;
+    case OpticalFlowPerformanceLevel::Medium:
+        return vk::DataGraphOpticalFlowPerformanceLevelARM::eMedium;
+    case OpticalFlowPerformanceLevel::Fast:
+        return vk::DataGraphOpticalFlowPerformanceLevelARM::eFast;
+    default:
+        throw std::runtime_error("Unrecognised performance level, expected unknown, slow, medium, or fast.");
+    }
+}
+
+// Map grid size to Vulkan enums
+auto getOpticalFlowGridSize(OpticalFlowGridSize gridSize) {
+    switch (gridSize) {
+    case OpticalFlowGridSize::e1x1:
+        return vk::DataGraphOpticalFlowGridSizeFlagBitsARM::e1X1;
+    case OpticalFlowGridSize::e2x2:
+        return vk::DataGraphOpticalFlowGridSizeFlagBitsARM::e2X2;
+    case OpticalFlowGridSize::e4x4:
+        return vk::DataGraphOpticalFlowGridSizeFlagBitsARM::e4X4;
+    case OpticalFlowGridSize::e8x8:
+        return vk::DataGraphOpticalFlowGridSizeFlagBitsARM::e8X8;
+    default:
+        throw std::runtime_error("Unrecognised grid size, expected 1x1, 2x2, 4x4, or 8x8.");
+    }
+}
+
 } // namespace
 
 Scenario::Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec)
@@ -775,6 +852,11 @@ void Scenario::setupCommands() {
             const auto &dispatchFragment = reinterpret_cast<DispatchFragmentDesc &>(*command);
             const auto data = factory.createData(dispatchFragment);
             createFragmentPipeline(data, nQueries);
+        } break;
+        case (CommandType::DispatchOpticalFlow): {
+            const auto &dispatchOpticalFlow = reinterpret_cast<DispatchOpticalFlowDesc &>(*command);
+            const auto data = factory.createData(dispatchOpticalFlow);
+            createOpticalFlowPipeline(data, nQueries);
         } break;
         case (CommandType::MarkBoundary): {
             const auto &markBoundary = reinterpret_cast<MarkBoundaryDesc &>(*command);
@@ -1091,6 +1173,47 @@ void Scenario::createSpirvGraphPipeline(const DispatchSpirvGraphData &dispatchSp
     _compute.registerPipelineFenced(_dataManager, sequenceBindings, nullptr, 0, dispatchSpirvGraph.implicitBarrier);
     _compute.registerWriteTimestamp(nQueries++, vk::PipelineStageFlagBits2::eDataGraphARM);
     mlsdk::logging::debug("Graph Pipeline: " + shaderInfo.debugName + " created");
+}
+
+void Scenario::createOpticalFlowPipeline(const DispatchOpticalFlowData &dispatchOpticalFlow, uint32_t &nQueries) {
+    const std::vector<TypedBinding> emptyBindings{};
+    const Compute::PipelineCreateArguments args{dispatchOpticalFlow.debugName, emptyBindings, _pipelineCache};
+
+    const auto perfLevel = getOpticalFlowPerformanceLevel(dispatchOpticalFlow.performanceLevel);
+    const auto gridSize = getOpticalFlowGridSize(dispatchOpticalFlow.gridSize);
+
+    PerfCounterGuard guard(_perfCounters, "Create Optical Flow Pipeline: " + dispatchOpticalFlow.debugName,
+                           "Pipeline Setup");
+
+    std::vector<TypedBinding> bindings;
+    bindings.reserve(5);
+    bindings.emplace_back(dispatchOpticalFlow.searchImage);
+    bindings.emplace_back(dispatchOpticalFlow.templateImage);
+    bindings.emplace_back(dispatchOpticalFlow.outputImage);
+    if (dispatchOpticalFlow.hintMotionVectors.has_value()) {
+        bindings.emplace_back(dispatchOpticalFlow.hintMotionVectors.value());
+    }
+    if (dispatchOpticalFlow.outputCost.has_value()) {
+        bindings.emplace_back(dispatchOpticalFlow.outputCost.value());
+    }
+    _compute.createPipeline(args, _dataManager, dispatchOpticalFlow.searchImage, dispatchOpticalFlow.templateImage,
+                            dispatchOpticalFlow.outputImage, dispatchOpticalFlow.hintMotionVectors,
+                            dispatchOpticalFlow.outputCost, perfLevel, gridSize, dispatchOpticalFlow.width,
+                            dispatchOpticalFlow.height);
+
+    // Optical flow is a data graph pipeline; profile it as such.
+    _compute.registerWriteTimestamp(nQueries++, vk::PipelineStageFlagBits2::eDataGraphARM);
+
+    Compute::OpticalFlowDispatchInfo dispatchInfo{};
+    dispatchInfo.opticalFlowFlags = vk::DataGraphOpticalFlowExecuteFlagsARM{dispatchOpticalFlow.executionFlags};
+    dispatchInfo.meanFlowL1NormHint = dispatchOpticalFlow.meanFlowL1NormHint;
+
+    _compute.registerPipelineFenced(_dataManager, bindings, nullptr, 0, dispatchOpticalFlow.implicitBarrier, {},
+                                    dispatchInfo);
+
+    _compute.registerWriteTimestamp(nQueries++, vk::PipelineStageFlagBits2::eDataGraphARM);
+
+    mlsdk::logging::debug("Optical Flow Pipeline: " + dispatchOpticalFlow.debugName + " created");
 }
 
 void Scenario::createPipeline(const uint32_t segmentIndex, const std::vector<TypedBinding> &sequenceBindings,

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -34,6 +34,7 @@ struct DispatchComputeData;
 struct DispatchDataGraphData;
 struct DispatchSpirvGraphData;
 struct DispatchFragmentData;
+struct DispatchOpticalFlowData;
 
 class Scenario {
   public:
@@ -48,6 +49,7 @@ class Scenario {
     void createDataGraphPipeline(const DispatchDataGraphData &dispatchDataGraph, uint32_t &nQueries);
     void createSpirvGraphPipeline(const DispatchSpirvGraphData &dispatchSpirvGraph, uint32_t &nQueries);
     void createFragmentPipeline(const DispatchFragmentData &dispatchFragment, uint32_t &nQueries);
+    void createOpticalFlowPipeline(const DispatchOpticalFlowData &dispatchOpticalFlow, uint32_t &nQueries);
 
     void createPipeline(uint32_t segmentIndex, const std::vector<TypedBinding> &sequenceBindings,
                         const VgfView &vgfView, const DispatchDataGraphData &dispatchDataGraph, uint32_t &nQueries);

--- a/src/tests/json/commands/dispatch_optical_flow/binding_missing_resource_ref.json
+++ b/src/tests/json/commands/dispatch_optical_flow/binding_missing_resource_ref.json
@@ -1,0 +1,30 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "mean_flow_l1_norm_hint": 2,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/binding_negative_id.json
+++ b/src/tests/json/commands/dispatch_optical_flow/binding_negative_id.json
@@ -1,0 +1,31 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "mean_flow_l1_norm_hint": 2,
+                "bindings": {
+                    "search_image": {
+                        "id": -1,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/binding_negative_set.json
+++ b/src/tests/json/commands/dispatch_optical_flow/binding_negative_set.json
@@ -1,0 +1,31 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "mean_flow_l1_norm_hint": 2,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": -1,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/invalid_mean_flow_l1_norm_hint.json
+++ b/src/tests/json/commands/dispatch_optical_flow/invalid_mean_flow_l1_norm_hint.json
@@ -1,0 +1,31 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "mean_flow_l1_norm_hint": -1,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/invalid_property.json
+++ b/src/tests/json/commands/dispatch_optical_flow/invalid_property.json
@@ -1,0 +1,32 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "mean_flow_l1_norm_hint": 2,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    }
+                },
+                "this_is_an_invalid_property": 1
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/missing_grid_size.json
+++ b/src/tests/json/commands/dispatch_optical_flow/missing_grid_size.json
@@ -1,0 +1,30 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "performance_level": "slow",
+                "mean_flow_l1_norm_hint": 2,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/missing_mean_flow_l1_norm_hint.json
+++ b/src/tests/json/commands/dispatch_optical_flow/missing_mean_flow_l1_norm_hint.json
@@ -1,0 +1,30 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/missing_output_image.json
+++ b/src/tests/json/commands/dispatch_optical_flow/missing_output_image.json
@@ -1,0 +1,26 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "mean_flow_l1_norm_hint": 2,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/missing_performance_level.json
+++ b/src/tests/json/commands/dispatch_optical_flow/missing_performance_level.json
@@ -1,0 +1,44 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "execution_flags": [
+                    "input_unchanged"
+                ],
+                "mean_flow_l1_norm_hint": 2,
+                "implicit_barrier": true,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    },
+                    "hint_motion_vectors": {
+                        "id": 3,
+                        "set": 0,
+                        "resource_ref": "input_hint_mv"
+                    },
+                    "output_cost": {
+                        "id": 4,
+                        "set": 0,
+                        "resource_ref": "output_cost"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/missing_search_image.json
+++ b/src/tests/json/commands/dispatch_optical_flow/missing_search_image.json
@@ -1,0 +1,26 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "mean_flow_l1_norm_hint": 2,
+                "bindings": {
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/missing_template_image.json
+++ b/src/tests/json/commands/dispatch_optical_flow/missing_template_image.json
@@ -1,0 +1,26 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "mean_flow_l1_norm_hint": 2,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json/commands/dispatch_optical_flow/reference.json
+++ b/src/tests/json/commands/dispatch_optical_flow/reference.json
@@ -1,0 +1,45 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 1920,
+                "height": 1080,
+                "grid_size": "4x4",
+                "performance_level": "slow",
+                "execution_flags": [
+                    "input_unchanged"
+                ],
+                "mean_flow_l1_norm_hint": 2,
+                "implicit_barrier": true,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    },
+                    "hint_motion_vectors": {
+                        "id": 3,
+                        "set": 0,
+                        "resource_ref": "input_hint_mv"
+                    },
+                    "output_cost": {
+                        "id": 4,
+                        "set": 0,
+                        "resource_ref": "output_cost"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": []
+}

--- a/src/tests/json_parser_tests.cpp
+++ b/src/tests/json_parser_tests.cpp
@@ -323,6 +323,161 @@ TEST(JsonParser, DataGraphInvalidSpecializationConstantsMapType) {
     ASSERT_THROW(MakeFromJSON<DataGraphDesc>(jsonInput), nlohmann::json::type_error);
 }
 
+TEST(JsonParser, DispatchOpticalFlowMeanFlowHintAcceptsLessThanMaxDimension) {
+    const std::string jsonInput =
+        R""(
+    {
+        "width": 8,
+        "height": 8,
+        "grid_size": "4x4",
+        "mean_flow_l1_norm_hint": 7,
+        "bindings": {
+            "search_image": {
+                "id": 0,
+                "set": 0,
+                "resource_ref": "input_search"
+            },
+            "template_image": {
+                "id": 1,
+                "set": 0,
+                "resource_ref": "input_template"
+            },
+            "output_image": {
+                "id": 2,
+                "set": 0,
+                "resource_ref": "output_flow"
+            }
+        }
+    }
+    )"";
+
+    const auto cmd = MakeFromJSON<DispatchOpticalFlowDesc>(jsonInput);
+    ASSERT_EQ(cmd.meanFlowL1NormHint, 7u);
+}
+
+TEST(JsonParser, DispatchOpticalFlowMeanFlowHintRejectsMaxDimension) {
+    const std::string jsonInput =
+        R""(
+    {
+        "width": 8,
+        "height": 8,
+        "grid_size": "4x4",
+        "mean_flow_l1_norm_hint": 8,
+        "bindings": {
+            "search_image": {
+                "id": 0,
+                "set": 0,
+                "resource_ref": "input_search"
+            },
+            "template_image": {
+                "id": 1,
+                "set": 0,
+                "resource_ref": "input_template"
+            },
+            "output_image": {
+                "id": 2,
+                "set": 0,
+                "resource_ref": "output_flow"
+            }
+        }
+    }
+    )"";
+
+    ASSERT_THROW(MakeFromJSON<DispatchOpticalFlowDesc>(jsonInput), std::runtime_error);
+}
+
+TEST(JsonParser, DispatchOpticalFlowRejectsIntegerGridSize) {
+    const std::string jsonInput =
+        R""(
+    {
+        "width": 8,
+        "height": 8,
+        "grid_size": 2,
+        "bindings": {
+            "search_image": {
+                "id": 0,
+                "set": 0,
+                "resource_ref": "input_search"
+            },
+            "template_image": {
+                "id": 1,
+                "set": 0,
+                "resource_ref": "input_template"
+            },
+            "output_image": {
+                "id": 2,
+                "set": 0,
+                "resource_ref": "output_flow"
+            }
+        }
+    }
+    )"";
+
+    ASSERT_THROW(MakeFromJSON<DispatchOpticalFlowDesc>(jsonInput), std::runtime_error);
+}
+
+TEST(JsonParser, DispatchOpticalFlowRejectsIntegerPerformanceLevel) {
+    const std::string jsonInput =
+        R""(
+    {
+        "width": 8,
+        "height": 8,
+        "grid_size": "4x4",
+        "performance_level": 2,
+        "bindings": {
+            "search_image": {
+                "id": 0,
+                "set": 0,
+                "resource_ref": "input_search"
+            },
+            "template_image": {
+                "id": 1,
+                "set": 0,
+                "resource_ref": "input_template"
+            },
+            "output_image": {
+                "id": 2,
+                "set": 0,
+                "resource_ref": "output_flow"
+            }
+        }
+    }
+    )"";
+
+    ASSERT_THROW(MakeFromJSON<DispatchOpticalFlowDesc>(jsonInput), std::runtime_error);
+}
+
+TEST(JsonParser, DispatchOpticalFlowRejectsIntegerExecutionFlag) {
+    const std::string jsonInput =
+        R""(
+    {
+        "width": 8,
+        "height": 8,
+        "grid_size": "4x4",
+        "execution_flags": [2],
+        "bindings": {
+            "search_image": {
+                "id": 0,
+                "set": 0,
+                "resource_ref": "input_search"
+            },
+            "template_image": {
+                "id": 1,
+                "set": 0,
+                "resource_ref": "input_template"
+            },
+            "output_image": {
+                "id": 2,
+                "set": 0,
+                "resource_ref": "output_flow"
+            }
+        }
+    }
+    )"";
+
+    ASSERT_THROW(MakeFromJSON<DispatchOpticalFlowDesc>(jsonInput), std::runtime_error);
+}
+
 // Test the JSON parser:
 // 1. Deserialize a JSON test case
 // 2. Validate the number of commands and resources

--- a/src/tests/resources/scenarios/test_optical_flow/optical_flow_dds.json
+++ b/src/tests/resources/scenarios/test_optical_flow/optical_flow_dds.json
@@ -1,0 +1,116 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 64,
+                "height": 64,
+                "grid_size": "4x4",
+                "performance_level": "medium",
+                "execution_flags": [
+                    "input_unchanged"
+                ],
+                "mean_flow_l1_norm_hint": 2,
+                "implicit_barrier": true,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    },
+                    "hint_motion_vectors": {
+                        "id": 3,
+                        "set": 0,
+                        "resource_ref": "input_hint_mv"
+                    },
+                    "output_cost": {
+                        "id": 4,
+                        "set": 0,
+                        "resource_ref": "output_cost"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": [
+        {
+            "image": {
+                "uid": "input_search",
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    1
+                ],
+                "format": "VK_FORMAT_R8G8B8A8_UNORM",
+                "shader_access": "readonly",
+                "src": "input_search.DDS"
+            }
+        },
+        {
+            "image": {
+                "uid": "input_template",
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    1
+                ],
+                "format": "VK_FORMAT_R8G8B8A8_UNORM",
+                "shader_access": "readonly",
+                "src": "input_template.DDS"
+            }
+        },
+        {
+            "image": {
+                "uid": "input_hint_mv",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16G16_SFLOAT",
+                "shader_access": "readonly",
+                "src": "input_mv.npy"
+            }
+        },
+        {
+            "image": {
+                "uid": "output_flow",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16G16_SFLOAT",
+                "shader_access": "writeonly",
+                "dst": "output_flow.dds"
+            }
+        },
+        {
+            "image": {
+                "uid": "output_cost",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "shader_access": "writeonly",
+                "dst": "output_cost.dds"
+            }
+        }
+    ]
+}

--- a/src/tests/resources/scenarios/test_optical_flow/optical_flow_png.json
+++ b/src/tests/resources/scenarios/test_optical_flow/optical_flow_png.json
@@ -1,0 +1,114 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 64,
+                "height": 64,
+                "grid_size": "4x4",
+                "execution_flags": [
+                    "input_unchanged"
+                ],
+                "implicit_barrier": true,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search"
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    },
+                    "hint_motion_vectors": {
+                        "id": 3,
+                        "set": 0,
+                        "resource_ref": "input_hint_mv"
+                    },
+                    "output_cost": {
+                        "id": 4,
+                        "set": 0,
+                        "resource_ref": "output_cost"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": [
+        {
+            "image": {
+                "uid": "input_search",
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    1
+                ],
+                "format": "VK_FORMAT_R8G8B8A8_UNORM",
+                "shader_access": "readonly",
+                "src": "input_search.png"
+            }
+        },
+        {
+            "image": {
+                "uid": "input_template",
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    1
+                ],
+                "format": "VK_FORMAT_R8G8B8A8_UNORM",
+                "shader_access": "readonly",
+                "src": "input_template.png"
+            }
+        },
+        {
+            "image": {
+                "uid": "input_hint_mv",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16G16_SFLOAT",
+                "shader_access": "readonly",
+                "src": "input_mv.npy"
+            }
+        },
+        {
+            "image": {
+                "uid": "output_flow",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16G16_SFLOAT",
+                "shader_access": "writeonly",
+                "dst": "output_flow.dds"
+            }
+        },
+        {
+            "image": {
+                "uid": "output_cost",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "shader_access": "writeonly",
+                "dst": "output_cost.dds"
+            }
+        }
+    ]
+}

--- a/src/tests/test_optical_flow.py
+++ b/src/tests/test_optical_flow.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.optical_flow
+
+
+def _generate_hint_motion_vectors(numpy_helper, height, width):
+    numpy_helper.generate(
+        [1, height, width, 2], dtype=np.float16, filename="input_mv.npy"
+    )
+
+
+def _assert_outputs(resources_helper):
+    output_flow = resources_helper.get_testenv_path("output_flow.dds")
+    output_cost = resources_helper.get_testenv_path("output_cost.dds")
+    assert output_flow.is_file()
+    assert output_cost.is_file()
+    assert output_flow.stat().st_size > 0
+    assert output_cost.stat().st_size > 0
+
+
+def test_optical_flow_png(sdk_tools, resources_helper, numpy_helper):
+    width, height = 64, 64
+    out_w, out_h = 16, 16
+
+    input_data = np.arange(width * height * 4, dtype=np.uint8).reshape(
+        (height, width, 4)
+    )
+    sdk_tools.generate_png_file(height, width, "input_search.png", input_data.tobytes())
+    sdk_tools.generate_png_file(
+        height, width, "input_template.png", input_data[::-1].tobytes()
+    )
+
+    _generate_hint_motion_vectors(numpy_helper, out_h, out_w)
+
+    sdk_tools.run_scenario("test_optical_flow/optical_flow_png.json")
+    _assert_outputs(resources_helper)
+
+
+def test_optical_flow_dds(sdk_tools, resources_helper, numpy_helper):
+    width, height = 64, 64
+    out_w, out_h = 16, 16
+
+    sdk_tools.generate_dds_file(
+        height,
+        width,
+        "uint8",
+        4,
+        "DXGI_FORMAT_R8G8B8A8_UNORM",
+        "input_search.DDS",
+    )
+    sdk_tools.generate_dds_file(
+        height,
+        width,
+        "uint8",
+        4,
+        "DXGI_FORMAT_R8G8B8A8_UNORM",
+        "input_template.DDS",
+    )
+
+    _generate_hint_motion_vectors(numpy_helper, out_h, out_w)
+
+    sdk_tools.run_scenario("test_optical_flow/optical_flow_dds.json")
+    _assert_outputs(resources_helper)

--- a/src/tests/test_scenario.py
+++ b/src/tests/test_scenario.py
@@ -95,6 +95,7 @@ commands_path = pathlib.Path("commands")
 dispatch_compute_path = commands_path / "dispatch_compute"
 dispatch_graph_path = commands_path / "dispatch_graph"
 dispatch_spirv_graph_path = commands_path / "dispatch_spirv_graph"
+dispatch_optical_flow_path = commands_path / "dispatch_optical_flow"
 dispatch_barrier_path = commands_path / "dispatch_barrier"
 dispatch_fragment_path = commands_path / "dispatch_fragment"
 mark_boundary_path = commands_path / "mark_boundary"
@@ -163,6 +164,20 @@ graph_constant_path = resources_path / "graph_constant"
         (RequiredProperty("resource_ref"),dispatch_graph_path/"binding_missing_resource_ref.json"),
         (RequiredMin(0), dispatch_graph_path/"binding_negative_id.json"),
         (RequiredMin(0), dispatch_graph_path/"binding_negative_set.json"),
+        # dispatch_optical_flow
+        (Ok(), dispatch_optical_flow_path/"reference.json"),
+        (UnexpectedProperty("this_is_an_invalid_property"), dispatch_optical_flow_path/"invalid_property.json"),
+        (RequiredProperty("grid_size"), dispatch_optical_flow_path/"missing_grid_size.json"),
+        (Ok(), dispatch_optical_flow_path/"missing_performance_level.json"),
+        (Ok(), dispatch_optical_flow_path/"missing_mean_flow_l1_norm_hint.json"),
+        (RequiredMin(0), dispatch_optical_flow_path/"invalid_mean_flow_l1_norm_hint.json"),
+        (RequiredProperty("search_image"), dispatch_optical_flow_path/"missing_search_image.json"),
+        (RequiredProperty("template_image"), dispatch_optical_flow_path/"missing_template_image.json"),
+        (RequiredProperty("output_image"), dispatch_optical_flow_path/"missing_output_image.json"),
+        # dispatch_optical_flow->bindings
+        (RequiredProperty("resource_ref"), dispatch_optical_flow_path/"binding_missing_resource_ref.json"),
+        (RequiredMin(0), dispatch_optical_flow_path/"binding_negative_id.json"),
+        (RequiredMin(0), dispatch_optical_flow_path/"binding_negative_set.json"),
         # dispatch_barrier
         (Ok(), dispatch_barrier_path/"reference.json"),
         (RequiredProperty("image_barrier_refs"), dispatch_barrier_path/"missing_image_barrier_refs.json"),


### PR DESCRIPTION
- Add new command ``dispatch_optical_flow`` to dispatch the optical flow pipeline, and add support for it in the JSON schema, JSON reader, and scenario runner. Add tests for the new command, including validation tests for invalid input and functional tests using a simple optical flow scenario.
- Update documentation to include the new command and its parameters.
- Update the command dispatching logic to handle the new command type.

Change-Id: I26a1035332c034c5c116ab052d2d57d3c66492bb