### PR TITLE
Simplify json parsing

### DIFF
--- a/src/json_reader.cpp
+++ b/src/json_reader.cpp
@@ -9,63 +9,9 @@
 #include "scenario_desc.hpp"
 
 #include <string_view>
-#include <unordered_map>
 
 namespace mlsdk::scenariorunner {
 namespace {
-
-const std::unordered_map<std::string_view, CommandType> &getCommandTypeByKey() {
-    static const std::unordered_map<std::string_view, CommandType> commandTypeByKey = {
-        {"dispatch_compute", CommandType::DispatchCompute},
-        {"dispatch_graph", CommandType::DispatchDataGraph},
-        {"dispatch_fragment", CommandType::DispatchFragment},
-        {"dispatch_spirv_graph", CommandType::DispatchSpirvGraph},
-        {"dispatch_barrier", CommandType::DispatchBarrier},
-        {"mark_boundary", CommandType::MarkBoundary},
-        {"dispatch_optical_flow", CommandType::DispatchOpticalFlow},
-    };
-
-    return commandTypeByKey;
-}
-
-const std::unordered_map<std::string_view, ResourceType> &getResourceTypeByKey() {
-    static const std::unordered_map<std::string_view, ResourceType> resourceTypeByKey = {
-        {"shader", ResourceType::Shader},
-        {"buffer", ResourceType::Buffer},
-        {"graph", ResourceType::DataGraph},
-        {"raw_data", ResourceType::RawData},
-        {"tensor", ResourceType::Tensor},
-        {"image", ResourceType::Image},
-        {"image_barrier", ResourceType::ImageBarrier},
-        {"memory_barrier", ResourceType::MemoryBarrier},
-        {"tensor_barrier", ResourceType::TensorBarrier},
-        {"buffer_barrier", ResourceType::BufferBarrier},
-        {"graph_constant", ResourceType::GraphConstant},
-    };
-
-    return resourceTypeByKey;
-}
-
-template <typename EnumType>
-EnumType parseSingleKeyObjectType(const json &j, const std::unordered_map<std::string_view, EnumType> &typeByKey,
-                                  std::string_view entryName) {
-    if (!j.is_object()) {
-        throw std::runtime_error(std::string(entryName) + " entry must be a JSON object");
-    }
-
-    if (j.size() != 1) {
-        throw std::runtime_error(std::string(entryName) + " entry must contain exactly one top-level key");
-    }
-
-    const auto key = std::string_view(j.begin().key());
-    const auto it = typeByKey.find(key);
-    if (it == typeByKey.end()) {
-        throw std::runtime_error(std::string("Unknown ") + std::string(entryName) + " type");
-    }
-
-    return it->second;
-}
-
 void parseOptionalPipelineStages(const json &j, std::string_view fieldName, std::vector<PipelineStage> &stages) {
     const auto stagesIter = j.find(fieldName);
     if (stagesIter == j.end()) {
@@ -126,6 +72,28 @@ void from_json(const json &j, SubresourceRange &subresourceRange);
 
 //==============
 // Enums
+NLOHMANN_JSON_SERIALIZE_ENUM(ResourceType, {{ResourceType::Unknown, nullptr},
+                                            {ResourceType::Shader, "shader"},
+                                            {ResourceType::Buffer, "buffer"},
+                                            {ResourceType::DataGraph, "graph"},
+                                            {ResourceType::RawData, "raw_data"},
+                                            {ResourceType::Tensor, "tensor"},
+                                            {ResourceType::Image, "image"},
+                                            {ResourceType::ImageBarrier, "image_barrier"},
+                                            {ResourceType::MemoryBarrier, "memory_barrier"},
+                                            {ResourceType::TensorBarrier, "tensor_barrier"},
+                                            {ResourceType::BufferBarrier, "buffer_barrier"},
+                                            {ResourceType::GraphConstant, "graph_constant"}})
+
+NLOHMANN_JSON_SERIALIZE_ENUM(CommandType, {{CommandType::Unknown, nullptr},
+                                           {CommandType::DispatchCompute, "dispatch_compute"},
+                                           {CommandType::DispatchDataGraph, "dispatch_graph"},
+                                           {CommandType::DispatchSpirvGraph, "dispatch_spirv_graph"},
+                                           {CommandType::DispatchFragment, "dispatch_fragment"},
+                                           {CommandType::DispatchBarrier, "dispatch_barrier"},
+                                           {CommandType::DispatchOpticalFlow, "dispatch_optical_flow"},
+                                           {CommandType::MarkBoundary, "mark_boundary"}})
+
 // Map ShaderType values to JSON as strings
 NLOHMANN_JSON_SERIALIZE_ENUM(ShaderType, {{ShaderType::Unknown, nullptr},
                                           {ShaderType::SPIR_V, "SPIR-V"},
@@ -214,13 +182,22 @@ NLOHMANN_JSON_SERIALIZE_ENUM(OpticalFlowExecutionFlag,
                               {OpticalFlowExecutionFlag::InputIsPreviousReference, "input_is_previous_reference"},
                               {OpticalFlowExecutionFlag::ReferenceIsPreviousInput, "reference_is_previous_input"}})
 
-void readJson(ScenarioSpec &scenarioSpec, std::istream *is) {
-    json j;
-    *is >> j;
+void readJsonImpl(ScenarioSpec &scenarioSpec, const json &j);
 
+void readJson(ScenarioSpec &scenarioSpec, std::istream &is) {
+    const auto j = json::parse(is);
+    readJsonImpl(scenarioSpec, j);
+}
+
+void readJson(ScenarioSpec &scenarioSpec, const std::string &jsonStr) {
+    const auto j = json::parse(jsonStr);
+    readJsonImpl(scenarioSpec, j);
+}
+
+void readJsonImpl(ScenarioSpec &scenarioSpec, const json &j) {
     const json &resourcesJson = j.at("resources");
     for (const auto &resourceJson : resourcesJson) {
-        const auto resourceType = parseSingleKeyObjectType(resourceJson, getResourceTypeByKey(), "Resource");
+        const auto resourceType = json(resourceJson.begin().key()).get<ResourceType>();
         switch (resourceType) {
         case (ResourceType::Shader): {
             auto shader = resourceJson.at("shader").get<ShaderDesc>();
@@ -273,7 +250,7 @@ void readJson(ScenarioSpec &scenarioSpec, std::istream *is) {
 
     const json &commandsJson = j.at("commands");
     for (const auto &commandJson : commandsJson) {
-        const auto commandType = parseSingleKeyObjectType(commandJson, getCommandTypeByKey(), "Command");
+        const auto commandType = json(commandJson.begin().key()).get<CommandType>();
         switch (commandType) {
         case (CommandType::DispatchCompute): {
             auto dispatchCompute = commandJson.at("dispatch_compute").get<DispatchComputeDesc>();

--- a/src/json_reader.hpp
+++ b/src/json_reader.hpp
@@ -17,7 +17,8 @@ struct ScenarioSpec;
 
 using json = nlohmann::json;
 
-void readJson(ScenarioSpec &scenarioSpec, std::istream *is);
+void readJson(ScenarioSpec &scenarioSpec, std::istream &is);
+void readJson(ScenarioSpec &scenarioSpec, const std::string &jsonStr);
 
 //==============
 // Commands

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "version.hpp"
 
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <vector>
 
@@ -164,13 +165,9 @@ int runScenarioRunner(int argc, const char **argv) {
             setDefaultLogLevel(logLevel);
         }
 
-        auto scenarioFile = parser.get("--scenario");
-        std::filesystem::path workDir = std::filesystem::path(scenarioFile).remove_filename();
-        std::ifstream fstream(scenarioFile);
-        if (!fstream) {
-            throw std::runtime_error("Error while opening scenario file " + scenarioFile);
-        }
-
+        const auto scenarioArg = parser.get("--scenario");
+        const auto scenarioFile = std::filesystem::path(scenarioArg);
+        std::filesystem::path workDir = scenarioFile.parent_path();
         std::filesystem::path outputDir = workDir;
         if (parser.is_used("--output")) {
             outputDir = std::filesystem::path(parser.get("--output"));
@@ -188,8 +185,7 @@ int runScenarioRunner(int argc, const char **argv) {
             if (!std::filesystem::is_directory(cacheDir)) {
                 throw std::runtime_error("Invalid cache directory: " + cacheDir.string());
             }
-            scenarioOptions.pipelineCachePath =
-                cacheDir / std::filesystem::path(scenarioFile).filename().replace_extension("cache");
+            scenarioOptions.pipelineCachePath = cacheDir / scenarioFile.filename().replace_extension("cache");
         }
 
         scenarioOptions.enableGPUDebugMarkers = parser.get<bool>("--enable-gpu-debug-markers");
@@ -250,7 +246,7 @@ int runScenarioRunner(int argc, const char **argv) {
 
         pauseOnExit = parser.get<bool>("--pause-on-exit");
 
-        ScenarioSpec scenarioSpec(&fstream, workDir, outputDir);
+        ScenarioSpec scenarioSpec(scenarioFile, workDir, outputDir);
         mlsdk::logging::info("Scenario file parsed");
         Scenario scenario(scenarioOptions, scenarioSpec);
         if (parser.get<bool>("--wait-for-key-stroke-before-run")) {

--- a/src/scenario_desc.cpp
+++ b/src/scenario_desc.cpp
@@ -5,14 +5,26 @@
 
 #include "scenario_desc.hpp"
 #include "json_reader.hpp"
-#include <filesystem>
+
+#include <fstream>
 #include <iostream>
 
 namespace mlsdk::scenariorunner {
 
-ScenarioSpec::ScenarioSpec(std::istream *is, const std::filesystem::path &workDir,
+ScenarioSpec::ScenarioSpec(const std::string &jsonStr, const std::filesystem::path &workDir,
                            const std::filesystem::path &outputDir)
     : _workDir(workDir), _outputDir(outputDir) {
+    readJson(*this, jsonStr);
+}
+
+ScenarioSpec::ScenarioSpec(const std::filesystem::path &jsonFile, const std::filesystem::path &workDir,
+                           const std::filesystem::path &outputDir)
+    : _workDir(workDir), _outputDir(outputDir) {
+    std::ifstream is(jsonFile);
+    if (!is) {
+        throw std::runtime_error("Error while opening scenario file " + jsonFile.string());
+    }
+
     readJson(*this, is);
 }
 

--- a/src/scenario_desc.hpp
+++ b/src/scenario_desc.hpp
@@ -9,7 +9,6 @@
 #include "resource_desc.hpp"
 
 #include <filesystem>
-#include <fstream>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -17,7 +16,10 @@
 namespace mlsdk::scenariorunner {
 
 struct ScenarioSpec {
-    ScenarioSpec(std::istream *is, const std::filesystem::path &workDir, const std::filesystem::path &outputDir = {});
+    explicit ScenarioSpec(const std::string &jsonStr, const std::filesystem::path &workDir = {},
+                          const std::filesystem::path &outputDir = {});
+    ScenarioSpec(const std::filesystem::path &jsonFile, const std::filesystem::path &workDir,
+                 const std::filesystem::path &outputDir = {});
 
     /// \brief Add resource and resolve paths
     void addResource(std::unique_ptr<ResourceDesc> resource);

--- a/src/tests/json_parser_tests.cpp
+++ b/src/tests/json_parser_tests.cpp
@@ -10,9 +10,7 @@
 #include "resource_desc.hpp"
 #include "scenario_desc.hpp"
 
-#include <fstream>
 #include <regex>
-#include <sstream>
 
 /**
  * @brief Test the JSON parser.
@@ -20,6 +18,7 @@
  */
 
 using namespace mlsdk::scenariorunner;
+using namespace nlohmann::json_literals;
 
 namespace {
 const std::string jsonData =
@@ -226,15 +225,17 @@ const std::string jsonData =
 }
 )"";
 
-// Helper utility to create an object from a json string.
-template <typename T> T MakeFromJSON(const std::string &s) {
-    json j;
-    std::istringstream iss(s);
-    iss >> j;
-
+// Helper utility to parse a json object.
+template <typename T> T MakeFromJSON(const json &j) {
     T obj;
     from_json(j, obj);
     return obj;
+}
+
+// Helper utility to create an object from a json string.
+template <typename T> T MakeFromJSON(const std::string &s) {
+    const auto j = json::parse(s);
+    return MakeFromJSON<T>(j);
 }
 
 } // namespace
@@ -254,71 +255,70 @@ TEST(JsonParser, MarkBoundaryInvalidResourcesType) {
     }
     )"";
 
-    std::istringstream iss(jsonScenario);
-    ASSERT_THROW(ScenarioSpec(&iss, {}), nlohmann::json::type_error);
+    ASSERT_THROW(ScenarioSpec{jsonScenario}, nlohmann::json::type_error);
 }
 
 TEST(JsonParser, DispatchComputeInvalidShaderRefType) {
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "bindings": [],
         "rangeND": [1, 1, 1],
         "shader_ref": 123
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchComputeDesc>(jsonInput), nlohmann::json::type_error);
 }
 
 TEST(JsonParser, DispatchComputeInvalidPushDataRefType) {
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "bindings": [],
         "rangeND": [1, 1, 1],
         "shader_ref": "shader",
         "push_data_ref": 5
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchComputeDesc>(jsonInput), nlohmann::json::type_error);
 }
 
 TEST(JsonParser, DispatchDataGraphInvalidGraphRefType) {
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "bindings": [],
         "graph_ref": 10
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchDataGraphDesc>(jsonInput), nlohmann::json::type_error);
 }
 
 TEST(JsonParser, DispatchDataGraphPushConstantsInvalidType) {
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "bindings": [],
         "graph_ref": "graph1",
         "push_constants": {}
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchDataGraphDesc>(jsonInput), nlohmann::json::type_error);
 }
 
 TEST(JsonParser, DataGraphInvalidSpecializationConstantsMapType) {
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "uid": "g",
         "src": "./graphs/g.vgf",
         "specialization_constants_map": 5
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DataGraphDesc>(jsonInput), nlohmann::json::type_error);
 }
@@ -482,8 +482,7 @@ TEST(JsonParser, DispatchOpticalFlowRejectsIntegerExecutionFlag) {
 // 1. Deserialize a JSON test case
 // 2. Validate the number of commands and resources
 TEST(JsonParser, DeSerialization) {
-    std::istringstream iss(jsonData);
-    ScenarioSpec spec{&iss, {}};
+    ScenarioSpec spec{jsonData};
 
     ASSERT_TRUE(spec.commands.size() == 2);
     ASSERT_TRUE(spec.resources.size() == 10);
@@ -492,11 +491,9 @@ TEST(JsonParser, DeSerialization) {
 using namespace mlsdk::scenariorunner;
 
 TEST(JsonParser, Empty) {
-    std::istringstream empty1("{ \"resources\": [], \"commands\": [] }");
-    ASSERT_NO_THROW(ScenarioSpec(&empty1, {}));
+    ASSERT_NO_THROW(ScenarioSpec("{ \"resources\": [], \"commands\": [] }"));
 
-    std::istringstream empty2("");
-    ASSERT_THROW(ScenarioSpec(&empty2, {}), nlohmann::json_abi_v3_11_3::detail::parse_error);
+    ASSERT_THROW(ScenarioSpec(""), nlohmann::json_abi_v3_11_3::detail::parse_error);
 }
 
 TEST(JsonParser, NoCommands) {
@@ -516,8 +513,7 @@ TEST(JsonParser, NoCommands) {
     }
     )"";
 
-    std::istringstream iss(jsonInput);
-    ASSERT_THROW(ScenarioSpec(&iss, {}), nlohmann::json_abi_v3_11_3::detail::out_of_range);
+    ASSERT_THROW(ScenarioSpec{jsonInput}, nlohmann::json_abi_v3_11_3::detail::out_of_range);
 }
 
 TEST(JsonParser, NoResources) {
@@ -541,8 +537,7 @@ TEST(JsonParser, NoResources) {
     }
     )"";
 
-    std::istringstream iss(jsonInput);
-    ASSERT_THROW(ScenarioSpec(&iss, {}), nlohmann::json_abi_v3_11_3::detail::out_of_range);
+    ASSERT_THROW(ScenarioSpec{jsonInput}, nlohmann::json_abi_v3_11_3::detail::out_of_range);
 }
 
 TEST(JsonParser, UnknownResource) {
@@ -563,8 +558,7 @@ TEST(JsonParser, UnknownResource) {
     }
     )"";
 
-    std::istringstream iss(jsonInput);
-    ASSERT_THROW(ScenarioSpec(&iss, {}), std::runtime_error); // "Unknown Resource type"
+    ASSERT_THROW(ScenarioSpec{jsonInput}, std::runtime_error); // "Unknown Resource type"
 }
 
 TEST(JsonParser, UnknownCommand) {
@@ -589,8 +583,7 @@ TEST(JsonParser, UnknownCommand) {
     }
     )"";
 
-    std::istringstream iss(jsonInput);
-    ASSERT_THROW(ScenarioSpec(&iss, {}), std::runtime_error); // "Unknown Command type"
+    ASSERT_THROW(ScenarioSpec{jsonInput}, std::runtime_error); // "Unknown Command type"
 }
 
 TEST(JsonParser, Resources) {
@@ -619,8 +612,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::Buffer);
         auto &buffer = reinterpret_cast<std::unique_ptr<BufferDesc> &>(resource);
@@ -643,8 +635,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::Image);
         auto &resourcePtr = reinterpret_cast<std::unique_ptr<ImageDesc> &>(resource);
@@ -665,8 +656,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::Tensor);
         auto &resourcePtr = reinterpret_cast<std::unique_ptr<TensorDesc> &>(resource);
@@ -685,8 +675,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::RawData);
     }
@@ -705,8 +694,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::Shader);
         auto &resourcePtr = reinterpret_cast<std::unique_ptr<ShaderDesc> &>(resource);
@@ -725,8 +713,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::DataGraph);
     }
@@ -746,8 +733,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::MemoryBarrier);
         auto &resourcePtr = reinterpret_cast<std::unique_ptr<MemoryBarrierDesc> &>(resource);
@@ -772,8 +758,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::BufferBarrier);
         auto &resourcePtr = reinterpret_cast<std::unique_ptr<BufferBarrierDesc> &>(resource);
@@ -803,8 +788,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::ImageBarrier);
         auto &resourcePtr = reinterpret_cast<std::unique_ptr<ImageBarrierDesc> &>(resource);
@@ -827,8 +811,7 @@ TEST(JsonParser, Resources) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &resource = scenarioSpec.resources.at(0);
         ASSERT_TRUE(resource->resourceType == ResourceType::TensorBarrier);
         auto &resourcePtr = reinterpret_cast<std::unique_ptr<TensorBarrierDesc> &>(resource);
@@ -873,8 +856,7 @@ TEST(JsonParser, Commands) {
 
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &command = scenarioSpec.commands.at(0);
         ASSERT_TRUE(command->commandType == CommandType::DispatchDataGraph);
         auto &commandPtr = reinterpret_cast<std::unique_ptr<DispatchDataGraphDesc> &>(command);
@@ -933,10 +915,10 @@ TEST(JsonParser, Commands) {
 
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &command = scenarioSpec.commands.at(0);
         ASSERT_TRUE(command->commandType == CommandType::DispatchCompute);
+        ASSERT_TRUE(scenarioSpec.useComputeFamilyQueue);
         auto &commandPtr = reinterpret_cast<std::unique_ptr<DispatchComputeDesc> &>(command);
 
         auto &binding1 = commandPtr->bindings.at(1);
@@ -974,8 +956,7 @@ TEST(JsonParser, Commands) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &command = scenarioSpec.commands.at(0);
         ASSERT_TRUE(command->commandType == CommandType::DispatchBarrier);
         auto &commandPtr = reinterpret_cast<std::unique_ptr<DispatchBarrierDesc> &>(command);
@@ -997,8 +978,7 @@ TEST(JsonParser, Commands) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &command = scenarioSpec.commands.at(0);
         ASSERT_TRUE(command->commandType == CommandType::MarkBoundary);
         auto &commandPtr = reinterpret_cast<std::unique_ptr<MarkBoundaryDesc> &>(command);
@@ -1017,8 +997,7 @@ TEST(JsonParser, Commands) {
         }
         )"");
 
-        std::istringstream iss(jsonInput);
-        ScenarioSpec scenarioSpec{&iss, {}};
+        ScenarioSpec scenarioSpec{jsonInput};
         auto &command = scenarioSpec.commands.at(0);
         ASSERT_TRUE(command->commandType == CommandType::MarkBoundary);
         auto &commandPtr = reinterpret_cast<std::unique_ptr<MarkBoundaryDesc> &>(command);
@@ -1028,8 +1007,8 @@ TEST(JsonParser, Commands) {
 }
 
 TEST(JsonParser, DispatchDataGraph) {
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "bindings": [
             {
@@ -1040,7 +1019,7 @@ TEST(JsonParser, DispatchDataGraph) {
         ],
         "graph_ref": "graph1"
     }
-    )"";
+    )"_json;
 
     auto desc = MakeFromJSON<DispatchDataGraphDesc>(jsonInput);
 
@@ -1054,8 +1033,8 @@ TEST(JsonParser, DispatchDataGraph) {
 
 TEST(JsonParser, DipatchCompute) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "bindings": [
             {
@@ -1078,7 +1057,7 @@ TEST(JsonParser, DipatchCompute) {
         "rangeND": [10, 1, 1],
         "shader_ref": "add_shader"
     }
-    )"";
+    )"_json;
 
     auto desc = MakeFromJSON<DispatchComputeDesc>(jsonInput);
 
@@ -1099,8 +1078,8 @@ TEST(JsonParser, DipatchCompute) {
 }
 
 TEST(JsonParser, DispatchSpirvGraph) {
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "bindings": [
             {
@@ -1116,7 +1095,7 @@ TEST(JsonParser, DispatchSpirvGraph) {
         ],
         "graph_ref": "graph1"
     }
-    )"";
+    )"_json;
 
     auto desc = MakeFromJSON<DispatchSpirvGraphDesc>(jsonInput);
 
@@ -1133,65 +1112,65 @@ TEST(JsonParser, DispatchSpirvGraph) {
 }
 
 TEST(JsonParser, DispatchSpirvGraphInvalidGraphRefType) {
-    const std::string jsonInput =
+    const auto jsonInput =
         R"(
     {
         "bindings": [],
         "graph_ref": 1
     }
-    )";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchSpirvGraphDesc>(jsonInput), nlohmann::json::type_error);
 }
 
 TEST(JsonParser, DispatchSpirvGraphMissingBindings) {
-    const std::string jsonInput =
+    const auto jsonInput =
         R"(
     {
         "graph_ref": "graph1"
     }
-    )";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchSpirvGraphDesc>(jsonInput), nlohmann::json_abi_v3_11_3::detail::out_of_range);
 }
 
 TEST(JsonParser, DispatchSpirvGraphGraphConstantsInvalidType) {
-    const std::string jsonInput =
+    const auto jsonInput =
         R"(
     {
         "bindings": [],
         "graph_ref": "graph1",
         "graph_constants": "const0"
     }
-    )";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchSpirvGraphDesc>(jsonInput), nlohmann::json::type_error);
 }
 
 TEST(JsonParser, DispatchSpirvGraphGraphConstantsItemsInvalidType) {
-    const std::string jsonInput =
+    const auto jsonInput =
         R"(
     {
         "bindings": [],
         "graph_ref": "graph1",
         "graph_constants": [1]
     }
-    )";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchSpirvGraphDesc>(jsonInput), nlohmann::json::type_error);
 }
 
 TEST(JsonParser, BufferResource) {
     {
-        const std::string jsonInput =
-            R""(
+        const auto jsonInput =
+            R"(
         {
             "shader_access": "readonly",
             "size": 48,
             "src": "./shader_data/inbuffer2.npy",
             "uid": "InBuffer2"
         }
-        )"";
+        )"_json;
 
         auto desc = MakeFromJSON<BufferDesc>(jsonInput);
 
@@ -1204,15 +1183,15 @@ TEST(JsonParser, BufferResource) {
     }
 
     {
-        const std::string jsonInput =
-            R""(
+        const auto jsonInput =
+            R"(
         {
             "shader_access": "writeonly",
             "size": 52,
             "dst": "./shader_data/outbuffer.npy",
             "uid": "OutBuffer"
         }
-        )"";
+        )"_json;
 
         auto desc = MakeFromJSON<BufferDesc>(jsonInput);
 
@@ -1225,14 +1204,14 @@ TEST(JsonParser, BufferResource) {
     }
 
     {
-        const std::string jsonInput =
-            R""(
+        const auto jsonInput =
+            R"(
         {
             "shader_access": "readwrite",
             "size": 16,
             "uid": "InOutBuffer"
         }
-        )"";
+        )"_json;
 
         auto desc = MakeFromJSON<BufferDesc>(jsonInput);
 
@@ -1244,14 +1223,14 @@ TEST(JsonParser, BufferResource) {
     }
 
     {
-        const std::string jsonInput =
-            R""(
+        const auto jsonInput =
+            R"(
         {
             "shader_access": "something not recognised",
             "size": 16,
             "uid": "InOutBuffer"
         }
-        )"";
+        )"_json;
 
         ASSERT_THROW(MakeFromJSON<BufferDesc>(jsonInput), std::runtime_error); // "Unknown shader_access value"
     }
@@ -1259,8 +1238,8 @@ TEST(JsonParser, BufferResource) {
 
 TEST(JsonParser, ShaderResource) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "build_options": "-DQUANTIZE",
         "entry": "main",
@@ -1278,7 +1257,7 @@ TEST(JsonParser, ShaderResource) {
         "type": "SPIR-V",
         "uid": "matmul_shader"
     }
-    )"";
+    )"_json;
 
     auto desc = MakeFromJSON<ShaderDesc>(jsonInput);
 
@@ -1297,13 +1276,13 @@ TEST(JsonParser, ShaderResource) {
 
 TEST(JsonParser, RawDataResource) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "src": "./graph_data/rawdata.npy",
         "uid": "RawData"
     }
-    )"";
+    )"_json;
 
     auto desc = MakeFromJSON<RawDataDesc>(jsonInput);
 
@@ -1312,15 +1291,15 @@ TEST(JsonParser, RawDataResource) {
 }
 
 TEST(JsonParser, GraphConstantResource) {
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "uid": "weights0",
         "dims": [16,2,2,2,2,16],
         "format": "VK_FORMAT_R8_SINT",
         "src": "graph_constant.npy"
     }
-    )"";
+    )"_json;
 
     auto desc = MakeFromJSON<GraphConstantDesc>(jsonInput);
 
@@ -1343,8 +1322,8 @@ TEST(JsonParser, GraphConstantResource) {
 
 TEST(JsonParser, TensorResource) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "src": "./graph_data/intensor1.npy",
         "dims": [1, 4, 8, 16],
@@ -1353,7 +1332,7 @@ TEST(JsonParser, TensorResource) {
         "uid": "InTensor1",
         "tiling": "OPTIMAL"
     }
-    )"";
+    )"_json;
 
     auto desc = MakeFromJSON<TensorDesc>(jsonInput);
 
@@ -1373,8 +1352,8 @@ TEST(JsonParser, TensorResource) {
 
 TEST(JsonParser, TensorResourceMissingDims) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "src": "./graph_data/intensor1.npy",
         "format": "VK_FORMAT_R8_SINT",
@@ -1382,15 +1361,15 @@ TEST(JsonParser, TensorResourceMissingDims) {
         "uid": "InTensor1",
         "tiling": "OPTIMAL"
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<TensorDesc>(jsonInput), nlohmann::json_abi_v3_11_3::detail::out_of_range);
 }
 
 TEST(JsonParser, TensorResourceDimsInvalidType) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "src": "./graph_data/intensor1.npy",
         "dims": "1",
@@ -1399,30 +1378,30 @@ TEST(JsonParser, TensorResourceDimsInvalidType) {
         "uid": "InTensor1",
         "tiling": "OPTIMAL"
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<TensorDesc>(jsonInput), nlohmann::json::type_error);
 }
 
 TEST(JsonParser, ImageResourceMissingDims) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "format": "VK_FORMAT_R8G8B8A8_SRGB",
         "shader_access": "readwrite",
         "uid": "InputColorBuffer0",
         "mips": false
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<ImageDesc>(jsonInput), nlohmann::json_abi_v3_11_3::detail::out_of_range);
 }
 
 TEST(JsonParser, ImageResourceDimsInvalidType) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "dims": "256",
         "format": "VK_FORMAT_R8G8B8A8_SRGB",
@@ -1430,7 +1409,7 @@ TEST(JsonParser, ImageResourceDimsInvalidType) {
         "uid": "InputColorBuffer0",
         "mips": false
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<ImageDesc>(jsonInput), nlohmann::json::type_error);
 }
@@ -1448,14 +1427,13 @@ TEST(JsonParser, MarkBoundaryMissingResources) {
     }
     )"";
 
-    std::istringstream iss(jsonScenario);
-    ASSERT_THROW(ScenarioSpec(&iss, {}), nlohmann::json_abi_v3_11_3::detail::out_of_range);
+    ASSERT_THROW(ScenarioSpec{jsonScenario}, nlohmann::json_abi_v3_11_3::detail::out_of_range);
 }
 
 TEST(JsonParser, DispatchComputeMissingRangeND) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "bindings": [
             {
@@ -1466,15 +1444,15 @@ TEST(JsonParser, DispatchComputeMissingRangeND) {
         ],
         "shader_ref": "add_shader"
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchComputeDesc>(jsonInput), nlohmann::json_abi_v3_11_3::detail::out_of_range);
 }
 
 TEST(JsonParser, DispatchComputeRangeNDInvalidType) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "bindings": [
             {
@@ -1486,32 +1464,32 @@ TEST(JsonParser, DispatchComputeRangeNDInvalidType) {
         "rangeND": "10",
         "shader_ref": "add_shader"
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchComputeDesc>(jsonInput), nlohmann::json::type_error);
 }
 
 TEST(JsonParser, DispatchComputeMissingBindings) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "rangeND": [1, 1, 1],
         "shader_ref": "add_shader"
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchComputeDesc>(jsonInput), nlohmann::json_abi_v3_11_3::detail::out_of_range);
 }
 
 TEST(JsonParser, DispatchDataGraphMissingBindings) {
 
-    const std::string jsonInput =
-        R""(
+    const auto jsonInput =
+        R"(
     {
         "graph_ref": "graph1"
     }
-    )"";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<DispatchDataGraphDesc>(jsonInput), nlohmann::json_abi_v3_11_3::detail::out_of_range);
 }
@@ -1992,7 +1970,7 @@ TEST(JsonParser, GlobalMemBarrier) {
 }
 
 TEST(JsonParser, GraphConstantResourceInvalidDimsTooShort) {
-    const std::string jsonInput =
+    const auto jsonInput =
         R"(
     {
         "uid": "graph_constant_0_ref",
@@ -2000,13 +1978,13 @@ TEST(JsonParser, GraphConstantResourceInvalidDimsTooShort) {
         "format": "VK_FORMAT_R8_SINT",
         "src": "constant-0.npy"
     }
-    )";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<GraphConstantDesc>(jsonInput), std::runtime_error);
 }
 
 TEST(JsonParser, GraphConstantResourceInvalidDimsTooLong) {
-    const std::string jsonInput =
+    const auto jsonInput =
         R"(
     {
         "uid": "graph_constant_0_ref",
@@ -2014,7 +1992,7 @@ TEST(JsonParser, GraphConstantResourceInvalidDimsTooLong) {
         "format": "VK_FORMAT_R8_SINT",
         "src": "constant-0.npy"
     }
-    )";
+    )"_json;
 
     ASSERT_THROW(MakeFromJSON<GraphConstantDesc>(jsonInput), std::runtime_error);
 }


### PR DESCRIPTION
Use enum macros to simplify enum parsing.
Use json::parse to directly parse from string or stream. Simplify test code by using json literals.
Avoid unnecessary string streams.
Refactor constructor of ScenarioSpec to use path.

Change-Id: I477ed355f4e0c6c76bf8248b3ebbcb5b6de9d3f0