### PR TITLE
Improve image tools

### DIFF
--- a/src/dds_reader.cpp
+++ b/src/dds_reader.cpp
@@ -322,10 +322,15 @@ uint32_t calculatePitch(uint32_t width, uint32_t elementSize) {
     return (width * elementSize * 8 + 7) / 8;
 }
 
-DDSHeaderInfo generateDDSHeader(const Image &image) {
+DDSHeaderInfo generateDDSHeader(const ImageSaveOptions &options) {
+    if (options.shape.size() != 4) {
+        throw std::runtime_error("Unexpected image shape for DDS export");
+    }
+
+    const auto vkFormat = options.dataType;
     DDSHeaderInfo header =
-        generateDefaultDDSHeader(static_cast<uint32_t>(image.shape()[2]), static_cast<uint32_t>(image.shape()[1]),
-                                 elementSizeFromVkFormat(image.dataType()), vkFormatToDDSFormat(image.dataType()));
+        generateDefaultDDSHeader(static_cast<uint32_t>(options.shape[2]), static_cast<uint32_t>(options.shape[1]),
+                                 elementSizeFromVkFormat(vkFormat), vkFormatToDDSFormat(vkFormat));
     validateDDSHeader(header);
     return header;
 }
@@ -368,7 +373,7 @@ ImageLoadResult loadDataFromDDS(const std::string &filename, const ImageLoadOpti
         throw std::runtime_error("Failed to get DDS file size: " + filename);
     }
 
-    ImageLoadResult result(ddsFormatToVkFormat(header));
+    ImageLoadResult result(ddsFormatToVkFormat(header), header.header.width, header.header.height);
     result.data.resize(static_cast<size_t>(fileSize));
     file.seekg(dataPos);
     file.read(reinterpret_cast<char *>(result.data.data()), fileSize);
@@ -397,17 +402,16 @@ void saveHeaderToDDS(const DDSHeaderInfo &header, std::ofstream &fstream) {
     }
 }
 
-void saveDataToDDS(const std::string &filename, const Image &image, const std::vector<char> &data,
-                   const ImageSaveOptions &) {
+void saveDataToDDS(const std::string &filename, const ImageSaveOptions &options) {
     std::ofstream fstream(filename, std::ofstream::binary);
     if (!fstream.is_open()) {
         throw std::runtime_error("Error creating DDS file: " + filename);
     }
     fstream.exceptions(std::ios::badbit | std::ios::failbit);
 
-    DDSHeaderInfo header = generateDDSHeader(image);
+    DDSHeaderInfo header = generateDDSHeader(options);
     saveHeaderToDDS(header, fstream);
-    fstream.write(data.data(), std::streamsize(data.size()));
+    fstream.write(options.data.data(), std::streamsize(options.data.size()));
     fstream.close();
 }
 

--- a/src/dds_reader.hpp
+++ b/src/dds_reader.hpp
@@ -4,9 +4,7 @@
  */
 
 #include <string>
-#include <vector>
 
-#include "image.hpp"
 #include "image_formats.hpp"
 #include "vulkan/vulkan_core.h"
 
@@ -216,11 +214,8 @@ void saveHeaderToDDS(const DDSHeaderInfo &header, std::ofstream &fstream);
 /// \brief Create DDS file "filename" from image data
 ///
 /// \param filename file to create
-/// \param image image data to save to file
-/// \param data vector of raw data to save
 /// \param options save options
-void saveDataToDDS(const std::string &filename, const Image &image, const std::vector<char> &data,
-                   const ImageSaveOptions &options);
+void saveDataToDDS(const std::string &filename, const ImageSaveOptions &options);
 
 /// \brief Create a standard DDS (DX10) file header
 ///

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "image.hpp"
-#include "dds_reader.hpp"
 #include "image_formats.hpp"
 #include "logging.hpp"
 #include "utils.hpp"
@@ -85,8 +84,7 @@ constexpr vk::ImageTiling convertTiling(const Tiling tiling) {
     }
 }
 
-void loadDataFromNPY(const std::string &filename, vk::Format dataType, std::vector<uint8_t> &data,
-                     vk::Format &initialFormat, uint32_t expectedHeight, uint32_t expectedWidth) {
+ImageLoadResult loadDataFromNPY(const std::string &filename, vk::Format dataType, const ImageLoadOptions &options) {
     MemoryMap mapped(filename);
     auto dataPtr = vgfutils::numpy::parse(mapped);
 
@@ -98,23 +96,24 @@ void loadDataFromNPY(const std::string &filename, vk::Format dataType, std::vect
         throw std::runtime_error("Image batch dimension must be 1 for npy sources");
     }
 
-    if ((dataPtr.shape[1] != static_cast<int64_t>(expectedHeight)) ||
-        (dataPtr.shape[2] != static_cast<int64_t>(expectedWidth)) ||
+    if ((dataPtr.shape[1] != static_cast<int64_t>(options.expectedHeight)) ||
+        (dataPtr.shape[2] != static_cast<int64_t>(options.expectedWidth)) ||
         (dataPtr.shape[3] != static_cast<int64_t>(numComponentsFromVkFormat(dataType)))) {
         throw std::runtime_error("Image description dimensions do not match npy data shape");
     }
 
-    const auto expectedSize =
-        static_cast<uint64_t>(dataPtr.shape[0]) * expectedHeight * expectedWidth * elementSizeFromVkFormat(dataType);
+    const auto expectedSize = static_cast<uint64_t>(dataPtr.shape[0]) * options.expectedHeight * options.expectedWidth *
+                              elementSizeFromVkFormat(dataType);
 
     if (dataPtr.size() != expectedSize) {
         throw std::runtime_error("Image description size does not match data size: expected " +
                                  std::to_string(expectedSize) + " vs " + std::to_string(dataPtr.size()));
     }
 
-    data.resize(dataPtr.size());
-    std::memcpy(data.data(), dataPtr.ptr, dataPtr.size());
-    initialFormat = dataType;
+    ImageLoadResult result(dataType, options.expectedWidth, options.expectedHeight);
+    result.data.resize(dataPtr.size());
+    std::memcpy(result.data.data(), dataPtr.ptr, dataPtr.size());
+    return result;
 }
 
 uint64_t calculateMipDataSize(uint32_t width, uint32_t height, uint32_t depth, uint32_t elementSize) {
@@ -440,7 +439,9 @@ void Image::fillFromDescription(const Context &ctx, const ImageDesc &desc) {
             fileFormat = result.initialFormat;
             mipmapsFromFile = result.mipLevels;
         } else if (extension == ".npy") {
-            loadDataFromNPY(desc.src.value(), _dataType, data, fileFormat, desc.dims[2], desc.dims[1]);
+            auto result = loadDataFromNPY(desc.src.value(), _dataType, ImageLoadOptions{desc.dims[2], desc.dims[1]});
+            data = std::move(result.data);
+            fileFormat = result.initialFormat;
         } else {
             throw std::runtime_error("Unsupported image source file type for " + desc.src.value());
         }
@@ -726,12 +727,12 @@ std::vector<char> Image::getImageData(const Context &ctx) {
 }
 
 void Image::store(const Context &ctx, const std::string &filename) {
-    auto data = getImageData(ctx);
     const auto *handler = getImageFormatHandler(filename);
     if (!handler) {
         throw std::runtime_error("Unsupported image destination format: " + filename);
     }
-    handler->saveData(filename, *this, data, ImageSaveOptions{});
+    const auto data = getImageData(ctx);
+    handler->saveData(filename, ImageSaveOptions{shape(), dataType(), data});
 }
 
 bool Image::isSampled() const { return _imageInfo.isSampled; }

--- a/src/image_formats.hpp
+++ b/src/image_formats.hpp
@@ -12,8 +12,6 @@
 #include <vector>
 #include <vulkan/vulkan.hpp>
 
-#include "image.hpp"
-
 namespace mlsdk::scenariorunner {
 
 struct ImageLoadOptions {
@@ -32,13 +30,25 @@ struct ImageLoadOptions {
     uint64_t maxDecodedBytes{8192 * 8192 * 4};
 };
 
-struct ImageSaveOptions {};
+struct ImageSaveOptions {
+    /// Image shape expected as NHWC.
+    std::vector<int64_t> shape;
+    /// vk::Format of source image data.
+    vk::Format dataType{vk::Format::eUndefined};
+    /// Pixel data to save.
+    const std::vector<char> &data;
+};
 
 struct ImageLoadResult {
-    explicit ImageLoadResult(vk::Format vkFormat) : initialFormat(vkFormat) {}
+    explicit ImageLoadResult(vk::Format vkFormat, uint32_t imageWidth, uint32_t imageHeight)
+        : initialFormat(vkFormat), width(imageWidth), height(imageHeight) {}
 
     /// vk::Format of image file
     vk::Format initialFormat{vk::Format::eUndefined};
+    /// Image width in pixels
+    uint32_t width{0};
+    /// Image height in pixels
+    uint32_t height{0};
     /// Pixel data from file
     std::vector<uint8_t> data;
     /// Number of mip levels (only populated if relevant for data format)
@@ -49,9 +59,7 @@ struct ImageFormatHandler {
     std::set<std::string> extensions; // lower-case extensions including the dot
     std::function<vk::Format(const std::string &filename)> getFormat;
     std::function<ImageLoadResult(const std::string &filename, const ImageLoadOptions &options)> loadData;
-    std::function<void(const std::string &filename, const Image &image, const std::vector<char> &data,
-                       const ImageSaveOptions &options)>
-        saveData;
+    std::function<void(const std::string &filename, const ImageSaveOptions &options)> saveData;
 };
 
 /// \brief Find format handler by filename (extension is extracted and lower-cased).

--- a/src/png_reader.cpp
+++ b/src/png_reader.cpp
@@ -8,6 +8,9 @@
 
 #include "png_reader.hpp"
 
+#include "stb_image.h"
+#include "stb_image_write.h"
+
 #include <limits>
 #include <memory>
 #include <stdexcept>
@@ -78,19 +81,18 @@ ImageLoadResult loadDataFromPNG(const std::string &filename, const ImageLoadOpti
     }
 
     const size_t expectedSize = checkedSize(width, height);
-    ImageLoadResult result(vk::Format::eR8G8B8A8Unorm);
+    ImageLoadResult result(vk::Format::eR8G8B8A8Unorm, static_cast<uint32_t>(width), static_cast<uint32_t>(height));
     result.data.assign(decoded.get(), decoded.get() + expectedSize);
     return result;
 }
 
-void saveDataToPNG(const std::string &filename, const Image &image, const std::vector<char> &data,
-                   const ImageSaveOptions &) {
-    const auto &shape = image.shape();
+void saveDataToPNG(const std::string &filename, const ImageSaveOptions &options) {
+    const auto &shape = options.shape;
     if (shape.size() != 4) {
         throw std::runtime_error("Unexpected image shape for PNG export");
     }
 
-    vk::Format format = image.dataType();
+    vk::Format format = options.dataType;
     if (format != vk::Format::eR8G8B8A8Unorm) {
         throw std::runtime_error("PNG export supports only VK_FORMAT_R8G8B8A8_UNORM");
     }
@@ -98,13 +100,13 @@ void saveDataToPNG(const std::string &filename, const Image &image, const std::v
     const int64_t width64 = shape[1];
     const int64_t height64 = shape[2];
     const size_t expectedSize = checkedSize(width64, height64);
-    if (data.size() != expectedSize) {
+    if (options.data.size() != expectedSize) {
         throw std::runtime_error("Unexpected PNG data size for export");
     }
 
     const int width = static_cast<int>(width64);
     const int height = static_cast<int>(height64);
-    const auto *raw = reinterpret_cast<const unsigned char *>(data.data());
+    const auto *raw = reinterpret_cast<const unsigned char *>(options.data.data());
     if (stbi_write_png(filename.c_str(), width, height, 4, raw, width * 4) == 0) {
         throw std::runtime_error("Failed to write PNG: " + filename);
     }

--- a/src/png_reader.hpp
+++ b/src/png_reader.hpp
@@ -6,12 +6,8 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
-#include "image.hpp"
 #include "image_formats.hpp"
-#include "stb_image.h"
-#include "stb_image_write.h"
 #include "vulkan/vulkan_core.h"
 
 namespace mlsdk::scenariorunner {
@@ -31,10 +27,7 @@ vk::Format getVkFormatFromPNG(const std::string &filename);
 /// \brief Create PNG file from image data (expects RGBA8 data)
 ///
 /// \param filename file to create
-/// \param image image data to save to file
-/// \param data vector of raw data to save
 /// \param options save options
-void saveDataToPNG(const std::string &filename, const Image &image, const std::vector<char> &data,
-                   const ImageSaveOptions &options);
+void saveDataToPNG(const std::string &filename, const ImageSaveOptions &options);
 
 } // namespace mlsdk::scenariorunner

--- a/src/tests/dds_reader_tests.cpp
+++ b/src/tests/dds_reader_tests.cpp
@@ -54,6 +54,8 @@ TEST(DdsReader, loadDataFromDDS) {
     const auto result = loadDataFromDDS(filePath.string(), {});
 
     EXPECT_EQ(result.initialFormat, vk::Format::eR8G8B8A8Unorm);
+    EXPECT_EQ(result.width, width);
+    EXPECT_EQ(result.height, height);
     EXPECT_EQ(result.mipLevels, mipLevels);
 
     std::error_code ignored;
@@ -74,6 +76,29 @@ TEST(DdsReader, ThrowsOnDimensionMismatch) {
     options.expectedWidth = width;
 
     EXPECT_THROW((void)loadDataFromDDS(filePath.string(), options), std::runtime_error);
+
+    std::error_code ignored;
+    std::filesystem::remove(filePath, ignored);
+}
+
+TEST(DdsReader, SaveDataToDDS) {
+    const auto filePath = makeTempDDSPath("scenario_runner_dds_writer_test.dds");
+    const uint32_t width = 4;
+    const uint32_t height = 4;
+    const uint32_t mipLevels = 1;
+    const uint32_t elementSize = 4;
+
+    const auto data = std::vector<char>(static_cast<size_t>(width) * static_cast<size_t>(height) * elementSize, 0);
+    ImageSaveOptions options{{1, height, width, 4}, vk::Format::eR8G8B8A8Unorm, data};
+
+    saveDataToDDS(filePath.string(), options);
+
+    const auto result = loadDataFromDDS(filePath.string(), {});
+
+    EXPECT_EQ(result.initialFormat, vk::Format::eR8G8B8A8Unorm);
+    EXPECT_EQ(result.width, width);
+    EXPECT_EQ(result.height, height);
+    EXPECT_EQ(result.mipLevels, mipLevels);
 
     std::error_code ignored;
     std::filesystem::remove(filePath, ignored);

--- a/src/tests/png_reader_tests.cpp
+++ b/src/tests/png_reader_tests.cpp
@@ -5,6 +5,8 @@
 
 #include "png_reader.hpp"
 
+#include "stb_image_write.h"
+
 #include <cstdint>
 #include <filesystem>
 #include <vector>
@@ -38,6 +40,8 @@ TEST(PngReader, LoadDataFromPNG) {
     const auto result = loadDataFromPNG(filePath.string(), {});
 
     EXPECT_EQ(result.initialFormat, vk::Format::eR8G8B8A8Unorm);
+    EXPECT_EQ(result.width, width);
+    EXPECT_EQ(result.height, height);
     EXPECT_EQ(result.data.size(), static_cast<size_t>(width) * static_cast<size_t>(height) * 4);
 
     std::error_code ignored;
@@ -56,6 +60,27 @@ TEST(PngReader, ThrowsOnDimensionMismatch) {
     options.expectedWidth = width;
 
     EXPECT_THROW((void)loadDataFromPNG(filePath.string(), options), std::runtime_error);
+
+    std::error_code ignored;
+    std::filesystem::remove(filePath, ignored);
+}
+
+TEST(PngReader, SaveDataToPNG) {
+    const auto filePath = makeTempPNGPath("scenario_runner_png_writer_test.png");
+    const uint32_t width = 4;
+    const uint32_t height = 4;
+
+    const auto data = std::vector<char>(static_cast<size_t>(width) * static_cast<size_t>(height) * 4, 0x7f);
+    ImageSaveOptions options{{1, height, width, 4}, vk::Format::eR8G8B8A8Unorm, data};
+
+    saveDataToPNG(filePath.string(), options);
+
+    const auto result = loadDataFromPNG(filePath.string(), {});
+
+    EXPECT_EQ(result.initialFormat, vk::Format::eR8G8B8A8Unorm);
+    EXPECT_EQ(result.width, width);
+    EXPECT_EQ(result.height, height);
+    EXPECT_EQ(result.data.size(), static_cast<size_t>(width) * static_cast<size_t>(height) * 4);
 
     std::error_code ignored;
     std::filesystem::remove(filePath, ignored);

--- a/src/tools/dds_utils/main.cpp
+++ b/src/tools/dds_utils/main.cpp
@@ -18,7 +18,7 @@
 
 using namespace mlsdk::scenariorunner;
 
-using DDSContent = std::pair<DDSHeaderInfo, std::vector<uint8_t>>;
+using DDSContent = std::pair<DDSHeaderInfo, ImageLoadResult>;
 
 std::vector<uint16_t> createRandomFloat16Data(uint32_t size) {
     std::vector<uint16_t> vec(size);
@@ -420,32 +420,23 @@ DDSContent load(const std::string &ddsPath) {
     std::ifstream ddsFile(ddsPath, std::ifstream::binary);
     DDSHeaderInfo ddsHeader = readDDSHeader(ddsFile);
 
-    auto dataPos = ddsFile.tellg();
-    ddsFile.seekg(0, std::ios::end);
-    auto size = ddsFile.tellg() - dataPos;
-    ddsFile.close();
-    if (size < 0) {
-        throw std::runtime_error("Failed to get DDS file size " + ddsPath);
-    }
     auto result = loadDataFromDDS(ddsPath, {});
-
-    return {ddsHeader, std::move(result.data)};
+    return {ddsHeader, std::move(result)};
 }
 
 void convertDDSToNpy(const std::string &input, const std::string &output, uint32_t elementSize) {
-    DDSContent ddsContent = load(input);
-    auto &info = ddsContent.first;
-    auto &ddsData = ddsContent.second;
-    auto imageElementSize = info.header.pitchOrLinearSize / info.header.width;
+    using namespace mlsdk::vgfutils;
+
+    const auto &[ddsHeader, ddsResult] = load(input);
+    auto imageElementSize = ddsHeader.header.pitchOrLinearSize / ddsResult.width;
 
     if (elementSize > imageElementSize) {
         throw std::runtime_error("The image cannot be coverted to a NumPy file with bigger element size");
     }
 
-    mlsdk::vgfutils::numpy::DataPtr data(reinterpret_cast<char *>(ddsData.data()),
-                                         {1, info.header.height, info.header.width, imageElementSize / elementSize},
-                                         mlsdk::vgfutils::numpy::DType('i', elementSize));
-    mlsdk::vgfutils::numpy::write(output, data);
+    const std::vector<int64_t> shape = {1, ddsResult.height, ddsResult.width, imageElementSize / elementSize};
+    numpy::DataPtr data(reinterpret_cast<const char *>(ddsResult.data.data()), shape, numpy::DType('i', elementSize));
+    numpy::write(output, data);
 }
 
 bool compareDDSHeader(const DDSHeaderInfo &input, const DDSHeaderInfo &output) {
@@ -459,18 +450,20 @@ bool isFloat16NaN(uint16_t val) {
 }
 
 bool compare(const std::string &input, const std::string &output, const std::string &elementDtype) {
-    auto [inputHeader, inputData] = load(input);
-    auto [outputHeader, outputData] = load(output);
+    const auto &[inputHeader, inputResult] = load(input);
+    const auto &[outputHeader, outputResult] = load(output);
 
     bool sameHeader = compareDDSHeader(inputHeader, outputHeader);
+    if (!sameHeader) {
+        std::cerr << "DDS headers do not match." << std::endl;
+    }
 
-    bool sameData = false;
+    bool sameData = true;
     if (elementDtype == "fp16") {
-        auto *inputFp16 = reinterpret_cast<uint16_t *>(inputData.data());
-        auto *outputFp16 = reinterpret_cast<uint16_t *>(outputData.data());
+        const auto *inputFp16 = reinterpret_cast<const uint16_t *>(inputResult.data.data());
+        const auto *outputFp16 = reinterpret_cast<const uint16_t *>(outputResult.data.data());
 
-        auto size = inputData.size() / sizeof(uint16_t);
-        sameData = true;
+        auto size = inputResult.data.size() / sizeof(uint16_t);
         for (size_t i = 0; i < size; i++) {
             if (isFloat16NaN(inputFp16[i]) && isFloat16NaN(outputFp16[i])) {
                 continue;
@@ -482,7 +475,10 @@ bool compare(const std::string &input, const std::string &output, const std::str
             }
         }
     } else {
-        sameData = inputData == outputData;
+        sameData = inputResult.data == outputResult.data;
+        if (!sameData) {
+            std::cerr << "DDS data does not match." << std::endl;
+        }
     }
 
     return sameHeader && sameData;
@@ -531,6 +527,9 @@ int main(int argc, const char **argv) {
             auto elementDtype = parser.get<std::string>("--element-dtype");
 
             bool same = compare(input, output, elementDtype);
+            if (same) {
+                std::cout << "DDS files match." << std::endl;
+            }
             return same ? 0 : 1;
         } else {
             throw std::runtime_error("Unsupported action: " + action);

--- a/src/tools/png_utils/main.cpp
+++ b/src/tools/png_utils/main.cpp
@@ -5,7 +5,6 @@
 
 #include <argparse/argparse.hpp>
 #include <cstdint>
-#include <fstream>
 #include <iostream>
 #include <limits>
 #include <stdexcept>
@@ -20,59 +19,43 @@ using namespace mlsdk::scenariorunner;
 namespace {
 
 void generatePNGFile(uint32_t height, uint32_t width, const std::string &output) {
-    if (height == 0 || width == 0 || width > static_cast<uint64_t>(std::numeric_limits<int>::max() / 4) ||
-        height > static_cast<uint64_t>(std::numeric_limits<int>::max()) ||
-        height > (static_cast<uint64_t>(std::numeric_limits<size_t>::max()) / 4) / width) {
-        throw std::runtime_error("Image dimensions exceed supported limits");
-    }
-
-    std::vector<uint8_t> data(static_cast<size_t>(static_cast<uint64_t>(width) * height * 4), 0);
-
-    if (stbi_write_png(output.c_str(), static_cast<int>(width), static_cast<int>(height), 4, data.data(),
-                       static_cast<int>(width) * 4) == 0) {
-        throw std::runtime_error("Failed to write PNG: " + output);
-    }
+    // Trust underlying function for validating dimensions and size.
+    const auto dataSize = static_cast<size_t>(static_cast<uint64_t>(width) * height * 4);
+    const std::vector<char> data(dataSize, 0);
+    const std::vector<int64_t> shape = {1, height, width, 4};
+    ImageSaveOptions options{shape, vk::Format::eR8G8B8A8Unorm, data};
+    saveDataToPNG(output, options);
 }
 
-struct PNG {
-    int width;
-    int height;
-    std::vector<uint8_t> data;
-};
-
-PNG load(const std::string &input) {
+ImageLoadResult load(const std::string &input) {
     auto result = loadDataFromPNG(input, {});
     if (result.initialFormat != vk::Format::eR8G8B8A8Unorm) {
         throw std::runtime_error("Unsupported decoded PNG format");
     }
 
-    int width = 0;
-    int height = 0;
-    int channels = 0;
-    if (!stbi_info(input.c_str(), &width, &height, &channels)) {
-        throw std::runtime_error("Failed to inspect PNG: " + input);
-    }
-    return {width, height, std::move(result.data)};
+    return result;
 }
 
 void convertPNGToNpy(const std::string &input, const std::string &output) {
-    PNG png = load(input);
-    mlsdk::vgfutils::numpy::DataPtr npData(reinterpret_cast<char *>(png.data.data()), {1, png.height, png.width, 4},
-                                           mlsdk::vgfutils::numpy::DType('u', 1));
-    mlsdk::vgfutils::numpy::write(output, npData);
+    using namespace mlsdk::vgfutils;
+    const auto result = load(input);
+    const std::vector<int64_t> shape = {1, result.height, result.width, 4};
+    numpy::DataPtr npData(reinterpret_cast<const char *>(result.data.data()), shape, numpy::DType('u', 1));
+    numpy::write(output, npData);
 }
 
 bool compare(const std::string &input, const std::string &output) {
-    try {
-        PNG lhs = load(input);
-        PNG rhs = load(output);
-        if (lhs.width != rhs.width || lhs.height != rhs.height) {
-            return false;
-        }
-        return lhs.data == rhs.data;
-    } catch (...) {
+    const auto lhs = load(input);
+    const auto rhs = load(output);
+    if (lhs.width != rhs.width || lhs.height != rhs.height) {
+        std::cerr << "PNG dimensions do not match." << std::endl;
         return false;
     }
+    const auto sameData = lhs.data == rhs.data;
+    if (!sameData) {
+        std::cerr << "PNG data does not match." << std::endl;
+    }
+    return sameData;
 }
 
 } // namespace
@@ -110,6 +93,9 @@ int main(int argc, const char **argv) {
             auto output = parser.get<std::string>("--output");
 
             bool same = compare(input, output);
+            if (same) {
+                std::cout << "PNG files match." << std::endl;
+            }
             return same ? 0 : 1;
         } else {
             throw std::runtime_error("Unsupported action: " + action);


### PR DESCRIPTION
Improve tools result reporting
Log compare results for easier usage.
Extend ImageLoadResult with width and height to simplify code. Extend ImageSaveOptions with arguments to decouple from image type. Adopt local numpy file reader function to align with image reading.

Change-Id: Ic7bed3cacf500a5c1f30a52ae5123f05b8a2c608