### PR TITLE
cmake: use /Z7 in MSVC toolchains

### DIFF
--- a/cmake/toolchain/windows-msvc.cmake
+++ b/cmake/toolchain/windows-msvc.cmake
@@ -1,7 +1,13 @@
 #
-# SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
+
+# Use /Z7-style embedded debug info for MSVC debug-symbol configurations.
+# This avoids compiler PDB contention when parallel launchers such as sccache
+# are used during Windows builds.
+set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
+    "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:Embedded>")
 
 # Compilation warnings
 set(ML_SDK_SCENARIO_RUNNER_COMPILE_OPTIONS /EHa /WX /W4)


### PR DESCRIPTION
Set CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded in the scenario-runner MSVC toolchain so Debug and RelWithDebInfo builds avoid compiler PDB contention with sccache.