### PR TITLE
Add missing bug-fix lists to release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,12 @@
   support for Windows® parity.
 - Added PNG load/save support and broader image/texture format coverage.
 
+### Bug Fixes
+
+- Fixed memory leaks in the `--repeat` option.
+- Fixed frame-boundary extension detection and default log-level behavior.
+- Fixed Linux out-of-bounds failures.
+
 ## Version 0.8.0 – *Format Coverage & Tooling Upgrades*
 
 ### Execution & Scenario Control
@@ -48,6 +54,12 @@
 
 - Added Darwin targets for AArch64 to the pip packaging matrix.
 - Refreshed SBOM data and adopted usage of `REUSE.toml`.
+
+### Bug Fixes
+
+- Fixed missing package version initialization, bad package names, and
+  SDK-root `--install` failures in packaging flows.
+- Fixed MSVC AddressSanitizer support in the build and test flow.
 
 ### Supported Platforms
 


### PR DESCRIPTION
Document the missing bug-fix highlights for the 0.8.0 and 0.9.0 releases.

Change-Id: I7462536e85b78383e11e0fa613ce150315de2567