### PR TITLE
Add RenderDoc root override for builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ available on your `PATH`. The Android™ SDK installation pointed to by
 `ANDROID_HOME` should include `build-tools;34.0.0` and
 `platforms;android-34`, or other compatible versions.
 
+To build with RenderDoc support, add `--enable-rdoc`. If RenderDoc is
+installed outside the default search locations, also pass
+`--renderdoc-path <renderdoc-install-root>`.
+
 To enable and run tests, use the `--test` flag. To lint the tests, use the
 `--lint` flag. To enable tests and documentation building python dependencies
 must be installed:

--- a/cmake/FindRenderDoc.cmake
+++ b/cmake/FindRenderDoc.cmake
@@ -1,14 +1,21 @@
 #
-# SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(RenderDoc_INCLUDE_DIRS "" CACHE PATH "Path to RenderDoc includes directories")
-set(RenderDoc_LIBRARIES "" CACHE PATH "Path to RenderDoc libraries directories")
-set(RenderDoc_BINARY "" CACHE PATH "Path to RenderDoc binary")
+include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
+
+set(RenderDoc_ROOT "" CACHE PATH "Path to the RenderDoc installation root")
+set(RenderDoc_INCLUDE_DIRS "NOTFOUND" CACHE PATH "Path to RenderDoc includes directories")
+set(RenderDoc_LIBRARIES "NOTFOUND" CACHE PATH "Path to RenderDoc libraries directories")
+set(RenderDoc_BINARY "NOTFOUND" CACHE PATH "Path to RenderDoc binary")
 
 if(WIN32)
-    set(RenderDoc_SEARCH_PATHS
+    set(RenderDoc_SEARCH_PATHS)
+    if(RenderDoc_ROOT)
+        list(APPEND RenderDoc_SEARCH_PATHS "${RenderDoc_ROOT}")
+    endif()
+    list(APPEND RenderDoc_SEARCH_PATHS
         "$ENV{ProgramFiles}/RenderDoc_For_Arm_GPUs_Windows_64"
         "$ENV{ProgramFiles}/RenderDoc"
     )
@@ -21,13 +28,33 @@ if(WIN32)
         endif()
     endforeach()
 elseif(LINUX)
-    if(EXISTS "/usr/include/renderdoc_app.h")
+    if(RenderDoc_ROOT)
+        find_path(RenderDoc_INCLUDE_DIRS
+            NAMES renderdoc_app.h
+            PATHS "${RenderDoc_ROOT}"
+            PATH_SUFFIXES include ""
+            NO_DEFAULT_PATH
+        )
+        find_file(RenderDoc_LIBRARIES
+            NAMES librenderdoc.so
+            PATHS "${RenderDoc_ROOT}"
+            PATH_SUFFIXES lib lib64 ""
+            NO_DEFAULT_PATH
+        )
+        find_program(RenderDoc_BINARY
+            NAMES qrenderdoc
+            PATHS "${RenderDoc_ROOT}"
+            PATH_SUFFIXES bin ""
+            NO_DEFAULT_PATH
+        )
+    endif()
+    if(NOT RenderDoc_INCLUDE_DIRS AND EXISTS "/usr/include/renderdoc_app.h")
         set(RenderDoc_INCLUDE_DIRS "/usr/include" CACHE PATH "Path to RenderDoc include directories" FORCE)
     endif()
-    if(EXISTS "/usr/lib/librenderdoc.so")
+    if(NOT RenderDoc_LIBRARIES AND EXISTS "/usr/lib/librenderdoc.so")
         set(RenderDoc_LIBRARIES "/usr/lib/librenderdoc.so" CACHE PATH "Path to RenderDoc libraries directories" FORCE)
     endif()
-    if(EXISTS "/usr/bin/qrenderdoc")
+    if(NOT RenderDoc_BINARY AND EXISTS "/usr/bin/qrenderdoc")
         set(RenderDoc_BINARY "/usr/bin/qrenderdoc" CACHE PATH "Path to RenderDoc binary" FORCE)
     endif()
 else()
@@ -36,5 +63,5 @@ endif()
 
 find_package_handle_standard_args(RenderDoc
     REQUIRED_VARS RenderDoc_INCLUDE_DIRS RenderDoc_LIBRARIES RenderDoc_BINARY
-    FAIL_MESSAGE "RenderDoc package not found. Please install it and set RenderDoc variables manually."
+    FAIL_MESSAGE "RenderDoc package not found. Set RenderDoc_ROOT or the RenderDoc_* cache variables manually."
 )

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -71,6 +71,9 @@ class Builder:
         self.install = args.install
         self.emulation_layer = args.emulation_layer
         self.enable_rdoc = args.enable_rdoc
+        self.renderdoc_path = (
+            absolute(args.renderdoc_path) if args.renderdoc_path else ""
+        )
         self.clang_tidy_fix = args.clang_tidy_fix
         self.experimental_image_format_support = (
             args.enable_experimental_image_format_support
@@ -268,6 +271,8 @@ class Builder:
 
         if self.enable_rdoc:
             cmake_setup_cmd.append("-DSCENARIO_RUNNER_ENABLE_RDOC=ON")
+            if self.renderdoc_path:
+                cmake_setup_cmd.append(f"-DRenderDoc_ROOT={self.renderdoc_path}")
 
         if self.experimental_image_format_support:
             cmake_setup_cmd.append(
@@ -709,6 +714,11 @@ def parse_arguments():
         help=("Enable Rdoc support"),
         action="store_true",
         default=False,
+    )
+    parser.add_argument(
+        "--renderdoc-path",
+        help=("Path to the RenderDoc installation root used with --enable-rdoc"),
+        default="",
     )
     parser.add_argument(
         "--clang-tidy-fix",


### PR DESCRIPTION
Document and wire a RenderDoc installation root override for RenderDoc- enabled builds. This lets the build find RenderDoc when it is installed outside the default search locations.

The Python build wrapper forwards --renderdoc-path to CMake when --enable-rdoc is set, and the CMake finder uses RenderDoc_ROOT before falling back to the existing platform defaults.



Change-Id: I98f87edea844a1b4086af54b99f1116ed04f1783