### PR TITLE
Fix optical flow config validation to handle lod

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -31,7 +31,7 @@ SPDX-FileCopyrightText = "Copyright 2023-2026 Arm Limited and/or its affiliates 
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "src/tests/**.json"
+path = "src/tests/**/*.json"
 SPDX-FileCopyrightText = "Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>"
 SPDX-License-Identifier = "Apache-2.0"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SCENARIO_RUNNER_LIB_SOURCES
     json_reader.cpp
     json_writer.cpp
     logging.cpp
+    optical_flow_utils.cpp
     pipeline_cache.cpp
     pipeline.cpp
     raw_data.cpp

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -306,6 +306,10 @@ vk::ImageView Image::imageView(uint32_t lod) const {
         throw std::runtime_error(errorMessage.str());
     }
 
+    if (_imageViewMips.empty()) {
+        return *_imageView;
+    }
+
     return *_imageViewMips[lod];
 }
 
@@ -351,16 +355,17 @@ void Image::addTransitionLayoutCommand(vk::raii::CommandBuffer &cmdBuf, vk::Imag
     vk::AccessFlagBits2 dstAccess = vk::AccessFlagBits2::eShaderRead;
 
     vk::MemoryBarrier2 memoryBarrier{srcStage, srcAccess, dstStage, dstAccess};
-    vk::ImageMemoryBarrier2 imageBarrier{srcStage,
-                                         srcAccess,
-                                         dstStage,
-                                         dstAccess,
-                                         _targetLayout,
-                                         expectedLayout,
-                                         VK_QUEUE_FAMILY_IGNORED,
-                                         VK_QUEUE_FAMILY_IGNORED,
-                                         *_image,
-                                         vk::ImageSubresourceRange{vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1}};
+    vk::ImageMemoryBarrier2 imageBarrier{
+        srcStage,
+        srcAccess,
+        dstStage,
+        dstAccess,
+        _targetLayout,
+        expectedLayout,
+        VK_QUEUE_FAMILY_IGNORED,
+        VK_QUEUE_FAMILY_IGNORED,
+        *_image,
+        vk::ImageSubresourceRange{vk::ImageAspectFlagBits::eColor, 0, _imageInfo.mips, 0, 1}};
 
     vk::DependencyInfo depInfo{
         {},            // memoryBarriers (global)

--- a/src/optical_flow_utils.cpp
+++ b/src/optical_flow_utils.cpp
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "optical_flow_utils.hpp"
+#include "commands.hpp"
+#include "data_manager.hpp"
+#include "image.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+namespace mlsdk::scenariorunner {
+namespace {
+struct OpticalFlowSelectedExtent {
+    uint32_t width{0};
+    uint32_t height{0};
+
+    bool operator==(const OpticalFlowSelectedExtent &other) const {
+        return width == other.width && height == other.height;
+    }
+};
+
+OpticalFlowSelectedExtent getOpticalFlowSelectedExtent(const DataManager &dataManager, const TypedBinding &binding,
+                                                       const char *bindingRole) {
+    if (!dataManager.hasImage(binding.resourceRef)) {
+        throw std::runtime_error("Optical flow " + std::string(bindingRole) + " binding must reference an image");
+    }
+
+    const auto &image = dataManager.getImage(binding.resourceRef);
+    const auto &shape = image.shape();
+    if (shape.size() < 3) {
+        throw std::runtime_error("Optical flow " + std::string(bindingRole) + " image must have at least 3 dimensions");
+    }
+
+    const uint32_t lod = binding.lod.value_or(0);
+    const uint32_t mips = std::max(image.getInfo().mips, 1u);
+    if (lod >= mips) {
+        throw std::runtime_error("Optical flow " + std::string(bindingRole) + " mip level exceeds available mips");
+    }
+
+    const uint32_t width = std::max(1u, static_cast<uint32_t>(shape[1]) >> lod);
+    const uint32_t height = std::max(1u, static_cast<uint32_t>(shape[2]) >> lod);
+    return {width, height};
+}
+} // namespace
+
+void verifyOpticalFlowConfig(const DataManager &dataManager, const TypedBinding &searchImageBinding,
+                             const TypedBinding &templateImageBinding, const TypedBinding &outputImageBinding,
+                             const std::optional<TypedBinding> &hintMotionVectorsBinding,
+                             const std::optional<TypedBinding> &outputCostBinding, uint32_t width, uint32_t height,
+                             OpticalFlowGridSize gridSize) {
+    const auto &searchImage = dataManager.getImage(searchImageBinding.resourceRef);
+    const auto &templateImage = dataManager.getImage(templateImageBinding.resourceRef);
+
+    const auto searchExtent = getOpticalFlowSelectedExtent(dataManager, searchImageBinding, "search");
+    const auto templateExtent = getOpticalFlowSelectedExtent(dataManager, templateImageBinding, "template");
+    const auto outputExtent = getOpticalFlowSelectedExtent(dataManager, outputImageBinding, "output");
+
+    if (width != searchExtent.width || height != searchExtent.height) {
+        throw std::runtime_error(
+            "Optical flow search image dimensions do not match specified input width/height at the selected mip level");
+    }
+    if (!(searchExtent == templateExtent)) {
+        throw std::runtime_error(
+            "Optical flow search and template images must have the same dimensions at the selected mip levels");
+    }
+    if (searchImage.dataType() != templateImage.dataType()) {
+        throw std::runtime_error("Optical flow search and template images must have the same data type");
+    }
+
+    if (outputCostBinding.has_value()) {
+        const auto costExtent = getOpticalFlowSelectedExtent(dataManager, outputCostBinding.value(), "output_cost");
+        if (!(costExtent == outputExtent)) {
+            throw std::runtime_error("Optical flow output cost image must have the same dimensions as the output flow "
+                                     "vector image at the selected mip levels");
+        }
+    }
+    if (hintMotionVectorsBinding.has_value()) {
+        const auto hintExtent =
+            getOpticalFlowSelectedExtent(dataManager, hintMotionVectorsBinding.value(), "hint_motion_vectors");
+        if (!(hintExtent == outputExtent)) {
+            throw std::runtime_error("Optical flow hint motion vector image must have the same dimensions as the "
+                                     "output flow vector image at the selected mip levels");
+        }
+    }
+
+    switch (gridSize) {
+    case OpticalFlowGridSize::e1x1:
+        if (!(outputExtent == searchExtent)) {
+            throw std::runtime_error("Optical flow output flow vector image must have the same dimensions as the "
+                                     "input for 1x1 grid size at the selected mip levels");
+        }
+        break;
+    case OpticalFlowGridSize::e2x2:
+        if (outputExtent.width != (searchExtent.width + 1) / 2 ||
+            outputExtent.height != (searchExtent.height + 1) / 2) {
+            throw std::runtime_error("Optical flow output flow vector image dimensions are incompatible with input "
+                                     "dimensions for 2x2 grid size at the selected mip levels");
+        }
+        break;
+    case OpticalFlowGridSize::e4x4:
+        if (outputExtent.width != (searchExtent.width + 3) / 4 ||
+            outputExtent.height != (searchExtent.height + 3) / 4) {
+            throw std::runtime_error("Optical flow output flow vector image dimensions are incompatible with input "
+                                     "dimensions for 4x4 grid size at the selected mip levels");
+        }
+        break;
+    case OpticalFlowGridSize::e8x8:
+        if (outputExtent.width != (searchExtent.width + 7) / 8 ||
+            outputExtent.height != (searchExtent.height + 7) / 8) {
+            throw std::runtime_error("Optical flow output flow vector image dimensions are incompatible with input "
+                                     "dimensions for 8x8 grid size at the selected mip levels");
+        }
+        break;
+    default:
+        throw std::runtime_error("Unsupported optical flow grid size");
+    }
+}
+
+} // namespace mlsdk::scenariorunner

--- a/src/optical_flow_utils.hpp
+++ b/src/optical_flow_utils.hpp
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "types.hpp"
+
+#include <optional>
+
+namespace mlsdk::scenariorunner {
+class DataManager;
+enum class OpticalFlowGridSize : uint32_t;
+
+void verifyOpticalFlowConfig(const DataManager &dataManager, const TypedBinding &searchImageBinding,
+                             const TypedBinding &templateImageBinding, const TypedBinding &outputImageBinding,
+                             const std::optional<TypedBinding> &hintMotionVectorsBinding,
+                             const std::optional<TypedBinding> &outputCostBinding, uint32_t width, uint32_t height,
+                             OpticalFlowGridSize gridSize);
+
+} // namespace mlsdk::scenariorunner

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -13,6 +13,7 @@
 #include "iresource.hpp"
 #include "json_writer.hpp"
 #include "logging.hpp"
+#include "optical_flow_utils.hpp"
 #include "utils.hpp"
 
 #include "vgf-utils/numpy.hpp"
@@ -599,70 +600,11 @@ auto getOpticalFlowGridSize(OpticalFlowGridSize gridSize) {
     }
 }
 
-void verifyOpticalFlowConfig(const DataManager &dataManager, const DispatchOpticalFlowData &dispatchOpticalFlow) {
-    const auto &searchImage = dataManager.getImage(dispatchOpticalFlow.searchImage.resourceRef);
-    const auto &templateImage = dataManager.getImage(dispatchOpticalFlow.templateImage.resourceRef);
-    const auto &outputFlowImage = dataManager.getImage(dispatchOpticalFlow.outputImage.resourceRef);
-
-    if (searchImage.shape().size() < 3 || outputFlowImage.shape().size() < 3) {
-        throw std::runtime_error("Optical flow search and output flow images must have at least 3 dimensions");
-    }
-    const auto &searchImageWidth = searchImage.shape()[1];
-    const auto &searchImageHeight = searchImage.shape()[2];
-    const auto &outputFlowImageWidth = outputFlowImage.shape()[1];
-    const auto &outputFlowImageHeight = outputFlowImage.shape()[2];
-
-    if (dispatchOpticalFlow.width != searchImageWidth || dispatchOpticalFlow.height != searchImageHeight) {
-        throw std::runtime_error("Optical flow search image dimensions do not match specified input width/height");
-    }
-    if (searchImage.shape() != templateImage.shape()) {
-        throw std::runtime_error("Optical flow search and template images must have the same dimensions");
-    }
-    if (searchImage.dataType() != templateImage.dataType()) {
-        throw std::runtime_error("Optical flow search and template images must have the same data type");
-    }
-    if (dispatchOpticalFlow.outputCost.has_value()) {
-        const auto &costImage = dataManager.getImage(dispatchOpticalFlow.outputCost->resourceRef);
-        if (costImage.shape() != outputFlowImage.shape()) {
-            throw std::runtime_error(
-                "Optical flow output cost image must have the same dimensions as the output flow vector image");
-        }
-    }
-    if (dispatchOpticalFlow.hintMotionVectors.has_value()) {
-        const auto &hintMVImage = dataManager.getImage(dispatchOpticalFlow.hintMotionVectors->resourceRef);
-        if (hintMVImage.shape() != outputFlowImage.shape()) {
-            throw std::runtime_error(
-                "Optical flow hint motion vector image must have the same dimensions as the output flow vector image");
-        }
-    }
-
-    // Check ratio of input/output/grid size is correct
-    if (dispatchOpticalFlow.gridSize == OpticalFlowGridSize::e1x1) {
-        if (outputFlowImage.shape() != searchImage.shape()) {
-            throw std::runtime_error(
-                "Optical flow output flow vector image must have the same dimensions as the input for 1x1 grid size");
-        }
-    } else if (dispatchOpticalFlow.gridSize == OpticalFlowGridSize::e2x2) {
-        if (outputFlowImage.shape().size() < 2 || outputFlowImageWidth != (searchImageWidth + 1) / 2 ||
-            outputFlowImageHeight != (searchImageHeight + 1) / 2) {
-            throw std::runtime_error("Optical flow output flow vector image dimensions are incompatible with input "
-                                     "dimensions for 2x2 grid size");
-        }
-    } else if (dispatchOpticalFlow.gridSize == OpticalFlowGridSize::e4x4) {
-        if (outputFlowImage.shape().size() < 2 || outputFlowImageWidth != (searchImageWidth + 3) / 4 ||
-            outputFlowImageHeight != (searchImageHeight + 3) / 4) {
-            throw std::runtime_error("Optical flow output flow vector image dimensions are incompatible with input "
-                                     "dimensions for 4x4 grid size");
-        }
-    } else if (dispatchOpticalFlow.gridSize == OpticalFlowGridSize::e8x8) {
-        if (outputFlowImage.shape().size() < 2 || outputFlowImageWidth != (searchImageWidth + 7) / 8 ||
-            outputFlowImageHeight != (searchImageHeight + 7) / 8) {
-            throw std::runtime_error("Optical flow output flow vector image dimensions are incompatible with input "
-                                     "dimensions for 8x8 grid size");
-        }
-    } else {
-        throw std::runtime_error("Unsupported optical flow grid size");
-    }
+void verifyOpticalFlowData(const DataManager &dataManager, const DispatchOpticalFlowData &dispatchOpticalFlow) {
+    verifyOpticalFlowConfig(dataManager, dispatchOpticalFlow.searchImage, dispatchOpticalFlow.templateImage,
+                            dispatchOpticalFlow.outputImage, dispatchOpticalFlow.hintMotionVectors,
+                            dispatchOpticalFlow.outputCost, dispatchOpticalFlow.width, dispatchOpticalFlow.height,
+                            dispatchOpticalFlow.gridSize);
 }
 
 } // namespace
@@ -920,7 +862,7 @@ void Scenario::setupCommands() {
         case (CommandType::DispatchOpticalFlow): {
             const auto &dispatchOpticalFlow = reinterpret_cast<DispatchOpticalFlowDesc &>(*command);
             const auto data = factory.createData(dispatchOpticalFlow);
-            verifyOpticalFlowConfig(_dataManager, data);
+            verifyOpticalFlowData(_dataManager, data);
             createOpticalFlowPipeline(data, nQueries);
         } break;
         case (CommandType::MarkBoundary): {

--- a/src/tests/json_parser_tests.cpp
+++ b/src/tests/json_parser_tests.cpp
@@ -478,6 +478,39 @@ TEST(JsonParser, DispatchOpticalFlowRejectsIntegerExecutionFlag) {
     ASSERT_THROW(MakeFromJSON<DispatchOpticalFlowDesc>(jsonInput), std::runtime_error);
 }
 
+TEST(JsonParser, DispatchOpticalFlowAcceptsSearchImageLod) {
+    const std::string jsonInput =
+        R""(
+    {
+        "width": 64,
+        "height": 64,
+        "grid_size": "4x4",
+        "bindings": {
+            "search_image": {
+                "id": 0,
+                "set": 0,
+                "resource_ref": "input_search",
+                "lod": 1
+            },
+            "template_image": {
+                "id": 1,
+                "set": 0,
+                "resource_ref": "input_template"
+            },
+            "output_image": {
+                "id": 2,
+                "set": 0,
+                "resource_ref": "output_flow"
+            }
+        }
+    }
+    )"";
+
+    const auto cmd = MakeFromJSON<DispatchOpticalFlowDesc>(jsonInput);
+    ASSERT_TRUE(cmd.searchImage.lod.has_value());
+    ASSERT_EQ(cmd.searchImage.lod.value(), 1);
+}
+
 // Test the JSON parser:
 // 1. Deserialize a JSON test case
 // 2. Validate the number of commands and resources

--- a/src/tests/resources/scenarios/test_fragment/sampled_fragment_lod.json
+++ b/src/tests/resources/scenarios/test_fragment/sampled_fragment_lod.json
@@ -1,0 +1,75 @@
+{
+    "commands": [
+        {
+            "dispatch_fragment": {
+                "vertex_shader_ref": "fullscreen_vs",
+                "fragment_shader_ref": "sampled_copy_fs",
+                "color_attachment_refs": [
+                    {
+                        "resource_ref": "output_color",
+                        "lod": 1
+                    }
+                ],
+                "bindings": [
+                    {
+                        "set": 0,
+                        "id": 0,
+                        "resource_ref": "input_image",
+                        "lod": 1
+                    }
+                ]
+            }
+        }
+    ],
+    "resources": [
+        {
+            "shader": {
+                "uid": "fullscreen_vs",
+                "src": "fullscreen_triangle.spv",
+                "type": "SPIR-V",
+                "stage": "vertex",
+                "entry": "main"
+            }
+        },
+        {
+            "shader": {
+                "uid": "sampled_copy_fs",
+                "src": "sampled_copy.spv",
+                "type": "SPIR-V",
+                "stage": "fragment",
+                "entry": "main"
+            }
+        },
+        {
+            "image": {
+                "uid": "input_image",
+                "src": "input.png",
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    1
+                ],
+                "mips": 2,
+                "format": "VK_FORMAT_R8G8B8A8_UNORM",
+                "shader_access": "readonly"
+            }
+        },
+        {
+            "image": {
+                "uid": "output_color",
+                "dst": "output.png",
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    1
+                ],
+                "mips": 2,
+                "format": "VK_FORMAT_R8G8B8A8_UNORM",
+                "shader_access": "writeonly",
+                "color_attachment": true
+            }
+        }
+    ]
+}

--- a/src/tests/resources/scenarios/test_mipmap_writing/write_to_mipmaps_permuted_lod.json
+++ b/src/tests/resources/scenarios/test_mipmap_writing/write_to_mipmaps_permuted_lod.json
@@ -1,0 +1,144 @@
+{
+    "commands": [
+      {
+        "dispatch_compute": {
+          "bindings": [
+            { "set": 0, "id": 0, "resource_ref": "all_lods", "lod" : 0, "descriptor_type" : "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE" }
+          ],
+          "shader_ref": "save",
+          "rangeND": [256, 256, 1],
+          "push_data_ref": "blue"
+        }
+      },
+      {
+        "dispatch_compute": {
+          "bindings": [
+            { "set": 0, "id": 0, "resource_ref": "all_lods", "lod" : 1, "descriptor_type" : "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE" }
+          ],
+          "shader_ref": "save",
+          "rangeND": [128, 128, 1],
+          "push_data_ref": "red"
+        }
+      },
+      {
+        "dispatch_compute": {
+          "bindings": [
+            { "set": 0, "id": 0, "resource_ref": "all_lods", "lod" : 2, "descriptor_type" : "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE" }
+          ],
+          "shader_ref": "save",
+          "rangeND": [64, 64, 1],
+          "push_data_ref": "green"
+        }
+      },
+      {
+        "dispatch_barrier": {
+          "image_barrier_refs": ["lod_Barrier"],
+          "tensor_barrier_refs": [],
+          "memory_barrier_refs": [],
+          "buffer_barrier_refs": []
+        }
+      },
+      {
+        "dispatch_compute": {
+          "bindings": [
+            { "set": 0, "id": 0, "resource_ref": "all_lods" },
+            { "set": 1, "id": 0, "resource_ref": "lod0" },
+            { "set": 1, "id": 1, "resource_ref": "lod1"},
+            { "set": 1, "id": 2, "resource_ref": "lod2"}
+          ],
+          "shader_ref": "read",
+          "rangeND": [256, 256, 1]
+        }
+      }
+    ],
+    "resources": [
+      {
+        "shader": {
+          "uid": "save",
+          "src": "write_to_mipmaps.spv",
+          "type": "SPIR-V",
+          "push_constants_size": 16
+        }
+      },
+      {
+        "shader": {
+          "uid": "read",
+          "src": "read_from_mipmaps.spv",
+          "type": "SPIR-V"
+        }
+      },
+      {
+        "image": {
+          "uid": "all_lods",
+          "dims": [1, 256, 256, 1],
+          "mips": 3,
+          "format": "VK_FORMAT_R32G32B32A32_SFLOAT",
+          "shader_access": "readwrite"
+        }
+      },
+      {
+        "image": {
+          "uid": "lod0",
+          "dims": [1, 256, 256, 1],
+          "mips": 1,
+          "format": "VK_FORMAT_R32G32B32A32_SFLOAT",
+          "shader_access": "writeonly",
+          "dst" : "lod0.dds"
+        }
+      },
+      {
+        "image": {
+          "uid": "lod1",
+          "dims": [1, 128, 128, 1],
+          "mips": 1,
+          "format": "VK_FORMAT_R32G32B32A32_SFLOAT",
+          "shader_access": "writeonly",
+          "dst" : "lod1.dds"
+        }
+      },
+      {
+        "image": {
+          "uid": "lod2",
+          "dims": [1, 64, 64, 1],
+          "mips": 1,
+          "format": "VK_FORMAT_R32G32B32A32_SFLOAT",
+          "shader_access": "writeonly",
+          "dst" : "lod2.dds"
+        }
+      },
+      {
+        "image_barrier": {
+          "uid": "lod_Barrier",
+          "src_access": "compute_shader_write",
+          "dst_access": "compute_shader_read",
+          "old_layout": "general",
+          "new_layout": "general",
+          "image_resource": "all_lods",
+          "subresource_range": {
+            "base_mip_level": 0,
+            "level_count": 3,
+            "base_array_layer": 0,
+            "layer_count": 1
+          }
+        }
+      },
+      {
+        "raw_data": {
+          "uid": "red",
+          "src": "red.npy"
+        }
+      },
+      {
+        "raw_data": {
+          "uid": "green",
+          "src": "green.npy"
+        }
+      },
+      {
+        "raw_data": {
+          "uid": "blue",
+          "src": "blue.npy"
+        }
+      }
+    ]
+}

--- a/src/tests/resources/scenarios/test_optical_flow/optical_flow_search_lod_invalid.json
+++ b/src/tests/resources/scenarios/test_optical_flow/optical_flow_search_lod_invalid.json
@@ -1,0 +1,117 @@
+{
+    "commands": [
+        {
+            "dispatch_optical_flow": {
+                "width": 64,
+                "height": 64,
+                "grid_size": "4x4",
+                "performance_level": "medium",
+                "execution_flags": [
+                    "input_unchanged"
+                ],
+                "mean_flow_l1_norm_hint": 2,
+                "implicit_barrier": true,
+                "bindings": {
+                    "search_image": {
+                        "id": 0,
+                        "set": 0,
+                        "resource_ref": "input_search",
+                        "lod": 1
+                    },
+                    "template_image": {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "input_template"
+                    },
+                    "output_image": {
+                        "id": 2,
+                        "set": 0,
+                        "resource_ref": "output_flow"
+                    },
+                    "hint_motion_vectors": {
+                        "id": 3,
+                        "set": 0,
+                        "resource_ref": "input_hint_mv"
+                    },
+                    "output_cost": {
+                        "id": 4,
+                        "set": 0,
+                        "resource_ref": "output_cost"
+                    }
+                }
+            }
+        }
+    ],
+    "resources": [
+        {
+            "image": {
+                "uid": "input_search",
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    1
+                ],
+                "format": "VK_FORMAT_R8G8B8A8_UNORM",
+                "shader_access": "readonly",
+                "src": "input_search.DDS"
+            }
+        },
+        {
+            "image": {
+                "uid": "input_template",
+                "dims": [
+                    1,
+                    64,
+                    64,
+                    1
+                ],
+                "format": "VK_FORMAT_R8G8B8A8_UNORM",
+                "shader_access": "readonly",
+                "src": "input_template.DDS"
+            }
+        },
+        {
+            "image": {
+                "uid": "input_hint_mv",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16G16_SFLOAT",
+                "shader_access": "readonly",
+                "src": "input_mv.npy"
+            }
+        },
+        {
+            "image": {
+                "uid": "output_flow",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16G16_SFLOAT",
+                "shader_access": "writeonly",
+                "dst": "output_flow.dds"
+            }
+        },
+        {
+            "image": {
+                "uid": "output_cost",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "shader_access": "writeonly",
+                "dst": "output_cost.dds"
+            }
+        }
+    ]
+}

--- a/src/tests/test_fragment.py
+++ b/src/tests/test_fragment.py
@@ -76,3 +76,24 @@ def test_fragment_dispatch_rejects_mismatched_color_attachment_extent(
 
     with pytest.raises(subprocess.CalledProcessError):
         sdk_tools.run_scenario("test_fragment/sampled_fragment_mismatched_extent.json")
+
+
+def test_fragment_dispatch_with_lod_bindings(
+    sdk_tools: SDKTools,
+    resources_helper: ResourcesHelper,
+) -> None:
+    width = 64
+    height = 64
+
+    input_arr = np.arange(width * height * 4, dtype=np.uint8).reshape(
+        (1, height, width, 4)
+    )
+
+    sdk_tools.generate_png_file(height, width, "input.png", data=input_arr[0].tobytes())
+    _prepare_fragment_shaders(sdk_tools)
+
+    sdk_tools.run_scenario("test_fragment/sampled_fragment_lod.json")
+
+    output_png = resources_helper.get_testenv_path("output.png")
+    assert output_png.is_file()
+    assert output_png.stat().st_size > 0

--- a/src/tests/test_mipmaps_writing.py
+++ b/src/tests/test_mipmaps_writing.py
@@ -136,3 +136,65 @@ def test_write_to_mipmaps(sdk_tools, resources_helper, numpy_helper):
         mip_width //= 2
         mip_height //= 2
         sample_window_size *= 2
+
+
+def test_write_to_mipmaps_permuted_lod_mapping(
+    sdk_tools, resources_helper, numpy_helper
+):
+    width, height, element_size, mip_levels = 256, 256, 4, 3
+
+    data = np.zeros([width * height * 4], np.float32)
+    for x in range(width):
+        for y in range(height):
+            pos = (x * height + y) * 4
+            data[pos] = float(x)
+            data[pos + 1] = float(y)
+            data[pos + 2] = float(x * y)
+            data[pos + 3] = 128
+
+    sdk_tools.generate_dds_file(
+        height,
+        width,
+        "fp32",
+        element_size * 4,
+        "DXGI_FORMAT_R32G32B32A32_FLOAT",
+        "base_layer.dds",
+        data=data.tobytes(),
+    )
+
+    for color, rgba in [
+        ("red", [255.0, 0, 0, 0]),
+        ("green", [0, 255.0, 0, 0]),
+        ("blue", [0, 0, 255.0, 0]),
+    ]:
+        numpy_helper.generate(
+            (4,),
+            np.float32,
+            f"{color}.npy",
+            rgba,
+        )
+
+    sdk_tools.compile_shader("test_mipmap_writing/write_to_mipmaps.comp")
+    sdk_tools.compile_shader("test_mipmap_writing/read_from_mipmaps.comp")
+    sdk_tools.run_scenario("test_mipmap_writing/write_to_mipmaps_permuted_lod.json")
+
+    # LOD 0 <- blue (channel 2), LOD 1 <- red (channel 0), LOD 2 <- green (channel 1)
+    expected_channel_by_lod = [2, 0, 1]
+    mip_width, mip_height = width, height
+    for cur_mip_level in range(mip_levels):
+        dds_filename = f"lod{cur_mip_level}.dds"
+        dds_file = resources_helper.get_testenv_path(dds_filename)
+
+        dds_npy_file = sdk_tools.convert_dds_to_npy(dds_file, f"{dds_filename}.npy", 4)
+        dds_npy = numpy_helper.load(dds_npy_file, np.float32)
+        assert dds_npy.shape == (1, mip_height, mip_width, 4)
+
+        dds_npy = np.reshape(dds_npy, (-1, 4))
+
+        expected_channel = expected_channel_by_lod[cur_mip_level]
+        assert np.all(dds_npy[:, expected_channel] == 255.0)
+        assert np.all(dds_npy[:, :expected_channel] == 0)
+        assert np.all(dds_npy[:, expected_channel + 1 :] == 0)
+
+        mip_width //= 2
+        mip_height //= 2

--- a/src/tests/test_optical_flow.py
+++ b/src/tests/test_optical_flow.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
+import subprocess
 import sys
 
 import numpy as np
@@ -75,3 +76,33 @@ def test_optical_flow_dds(sdk_tools, resources_helper, numpy_helper):
 
     sdk_tools.run_scenario("test_optical_flow/optical_flow_dds.json")
     _assert_outputs(resources_helper)
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin", reason="Optical flow is not supported on Darwin"
+)
+def test_optical_flow_search_image_lod_invalid(sdk_tools, numpy_helper):
+    width, height = 64, 64
+    out_w, out_h = 16, 16
+
+    sdk_tools.generate_dds_file(
+        height,
+        width,
+        "uint8",
+        4,
+        "DXGI_FORMAT_R8G8B8A8_UNORM",
+        "input_search.DDS",
+    )
+    sdk_tools.generate_dds_file(
+        height,
+        width,
+        "uint8",
+        4,
+        "DXGI_FORMAT_R8G8B8A8_UNORM",
+        "input_template.DDS",
+    )
+
+    _generate_hint_motion_vectors(numpy_helper, out_h, out_w)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        sdk_tools.run_scenario("test_optical_flow/optical_flow_search_lod_invalid.json")


### PR DESCRIPTION
- Extract validation into separate file
- Add dedicated json parse test for lod
- Add negative pytests for OF with lod to validate config checking
- Add pytest for lod in fragment and mipmap writing tests
- Fix REUSE file to cover all json test files


Change-Id: Ibd4995a16ec7f89606929a908a800aa03640c188