### PR TITLE
Build ScenarioRunnerUnitTests for Android

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -350,7 +350,7 @@ class Builder:
                 ]
                 subprocess.run(cmake_install_cmd, check=True)
 
-            if self.run_tests:
+            if self.run_tests and self.target_platform != "android":
                 test_cmd = [
                     "ctest",
                     "--test-dir",

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -30,16 +30,18 @@ target_include_directories(ScenarioRunnerTests PRIVATE
 )
 target_compile_options(ScenarioRunnerTests PRIVATE ${ML_SDK_SCENARIO_RUNNER_COMPILE_OPTIONS})
 
-gtest_discover_tests(ScenarioRunnerTests PROPERTIES LABELS ScenarioRunnerTests)
+if(NOT ANDROID)
+  gtest_discover_tests(ScenarioRunnerTests PROPERTIES LABELS ScenarioRunnerTests)
 
-enable_testing()
+  enable_testing()
 
-# pytest tests depend on spirv tools and vgfpy
-add_custom_target(scenario-runner-tests ALL DEPENDS spirv-as spirv-val vgfpy)
-if(NOT (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR) AND ML_SDK_GENERATE_CPACK)
-  install(TARGETS spirv-as EXPORT ai_ml_sdk_for_vulkanConfig)
-  install(TARGETS spirv-val EXPORT ai_ml_sdk_for_vulkanConfig)
-else()
-  install(TARGETS spirv-as EXPORT ${SCENARIO_RUNNER_PACKAGE_NAME}Config)
-  install(TARGETS spirv-val EXPORT ${SCENARIO_RUNNER_PACKAGE_NAME}Config)
+  # pytest tests depend on spirv tools and vgfpy
+  add_custom_target(scenario-runner-tests ALL DEPENDS spirv-as spirv-val vgfpy)
+  if(NOT (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR) AND ML_SDK_GENERATE_CPACK)
+    install(TARGETS spirv-as EXPORT ai_ml_sdk_for_vulkanConfig)
+    install(TARGETS spirv-val EXPORT ai_ml_sdk_for_vulkanConfig)
+  else()
+    install(TARGETS spirv-as EXPORT ${SCENARIO_RUNNER_PACKAGE_NAME}Config)
+    install(TARGETS spirv-val EXPORT ${SCENARIO_RUNNER_PACKAGE_NAME}Config)
+  endif()
 endif()


### PR DESCRIPTION
The test binary should be built for Android too so it can be pushed and ran on the device. Additionally, ensure the Android files are not run on the host.

Change-Id: I11ff2fb53f5883e11c2907c9a13dde31b114f554