### PR TITLE
Improve error handling for vgf file parsing

### DIFF
--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -11,17 +11,17 @@ namespace mlsdk::scenariorunner {
 namespace {
 vk::AccessFlags2 convertAccessFlags(MemoryAccess access) {
     switch (access) {
-    case (MemoryAccess::MemoryWrite):
+    case MemoryAccess::MemoryWrite:
         return vk::AccessFlagBits2::eMemoryWrite;
-    case (MemoryAccess::MemoryRead):
+    case MemoryAccess::MemoryRead:
         return vk::AccessFlagBits2::eMemoryRead;
-    case (MemoryAccess::GraphWrite):
+    case MemoryAccess::GraphWrite:
         return vk::AccessFlagBits2::eDataGraphWriteARM;
-    case (MemoryAccess::GraphRead):
+    case MemoryAccess::GraphRead:
         return vk::AccessFlagBits2::eDataGraphReadARM;
-    case (MemoryAccess::ComputeShaderWrite):
+    case MemoryAccess::ComputeShaderWrite:
         return vk::AccessFlagBits2::eShaderWrite;
-    case (MemoryAccess::ComputeShaderRead):
+    case MemoryAccess::ComputeShaderRead:
         return vk::AccessFlagBits2::eShaderRead;
     default: {
         throw std::runtime_error("Invalid barrier access flag");
@@ -31,13 +31,13 @@ vk::AccessFlags2 convertAccessFlags(MemoryAccess access) {
 
 vk::PipelineStageFlags2 convertStageFlag(PipelineStage stage) {
     switch (stage) {
-    case (PipelineStage::Graph):
+    case PipelineStage::Graph:
         return vk::PipelineStageFlagBits2::eDataGraphARM;
-    case (PipelineStage::Compute):
+    case PipelineStage::Compute:
         return vk::PipelineStageFlagBits2::eComputeShader;
-    case (PipelineStage::Graphics):
+    case PipelineStage::Graphics:
         return vk::PipelineStageFlagBits2::eFragmentShader | vk::PipelineStageFlagBits2::eColorAttachmentOutput;
-    case (PipelineStage::All):
+    case PipelineStage::All:
         return vk::PipelineStageFlagBits2::eAllCommands;
     default: {
         throw std::runtime_error("Invalid barrier stage flag");
@@ -55,11 +55,11 @@ vk::Flags<vk::PipelineStageFlagBits2> convertStageFlags(const std::vector<Pipeli
 
 vk::ImageLayout convertImageLayout(ImageLayout layout) {
     switch (layout) {
-    case (ImageLayout::TensorAliasing):
+    case ImageLayout::TensorAliasing:
         return vk::ImageLayout::eTensorAliasingARM;
-    case (ImageLayout::General):
+    case ImageLayout::General:
         return vk::ImageLayout::eGeneral;
-    case (ImageLayout::Undefined):
+    case ImageLayout::Undefined:
         return vk::ImageLayout::eUndefined;
     default: {
         throw std::runtime_error("Invalid image barrier layout");

--- a/src/json_reader.cpp
+++ b/src/json_reader.cpp
@@ -210,47 +210,47 @@ void readJsonImpl(ScenarioSpec &scenarioSpec, const json &j) {
     for (const auto &resourceJson : resourcesJson) {
         const auto resourceType = json(resourceJson.begin().key()).get<ResourceType>();
         switch (resourceType) {
-        case (ResourceType::Shader): {
+        case ResourceType::Shader: {
             auto shader = resourceJson.at("shader"sv).get<ShaderDesc>();
             scenarioSpec.addResource(std::make_unique<ShaderDesc>(std::move(shader)));
         } break;
-        case (ResourceType::Buffer): {
+        case ResourceType::Buffer: {
             auto buffer = resourceJson.at("buffer"sv).get<BufferDesc>();
             scenarioSpec.addResource(std::make_unique<BufferDesc>(std::move(buffer)));
         } break;
-        case (ResourceType::RawData): {
+        case ResourceType::RawData: {
             auto rawData = resourceJson.at("raw_data"sv).get<RawDataDesc>();
             scenarioSpec.addResource(std::make_unique<RawDataDesc>(std::move(rawData)));
         } break;
-        case (ResourceType::DataGraph): {
+        case ResourceType::DataGraph: {
             auto dataGraph = resourceJson.at("graph"sv).get<DataGraphDesc>();
             scenarioSpec.addResource(std::make_unique<DataGraphDesc>(std::move(dataGraph)));
         } break;
-        case (ResourceType::Tensor): {
+        case ResourceType::Tensor: {
             auto tensor = resourceJson.at("tensor"sv).get<TensorDesc>();
             scenarioSpec.addResource(std::make_unique<TensorDesc>(std::move(tensor)));
         } break;
-        case (ResourceType::Image): {
+        case ResourceType::Image: {
             auto image = resourceJson.at("image"sv).get<ImageDesc>();
             scenarioSpec.addResource(std::make_unique<ImageDesc>(std::move(image)));
         } break;
-        case (ResourceType::ImageBarrier): {
+        case ResourceType::ImageBarrier: {
             auto imageBarrier = resourceJson.at("image_barrier"sv).get<ImageBarrierDesc>();
             scenarioSpec.addResource(std::make_unique<ImageBarrierDesc>(std::move(imageBarrier)));
         } break;
-        case (ResourceType::TensorBarrier): {
+        case ResourceType::TensorBarrier: {
             auto tensorBarrier = resourceJson.at("tensor_barrier"sv).get<TensorBarrierDesc>();
             scenarioSpec.addResource(std::make_unique<TensorBarrierDesc>(std::move(tensorBarrier)));
         } break;
-        case (ResourceType::MemoryBarrier): {
+        case ResourceType::MemoryBarrier: {
             auto memoryBarrier = resourceJson.at("memory_barrier"sv).get<MemoryBarrierDesc>();
             scenarioSpec.addResource(std::make_unique<MemoryBarrierDesc>(std::move(memoryBarrier)));
         } break;
-        case (ResourceType::BufferBarrier): {
+        case ResourceType::BufferBarrier: {
             auto bufferBarrier = resourceJson.at("buffer_barrier"sv).get<BufferBarrierDesc>();
             scenarioSpec.addResource(std::make_unique<BufferBarrierDesc>(std::move(bufferBarrier)));
         } break;
-        case (ResourceType::GraphConstant): {
+        case ResourceType::GraphConstant: {
             auto graphConstant = resourceJson.at("graph_constant"sv).get<GraphConstantDesc>();
             scenarioSpec.addResource(std::make_unique<GraphConstantDesc>(std::move(graphConstant)));
         } break;
@@ -263,31 +263,31 @@ void readJsonImpl(ScenarioSpec &scenarioSpec, const json &j) {
     for (const auto &commandJson : commandsJson) {
         const auto commandType = json(commandJson.begin().key()).get<CommandType>();
         switch (commandType) {
-        case (CommandType::DispatchCompute): {
+        case CommandType::DispatchCompute: {
             auto dispatchCompute = commandJson.at("dispatch_compute"sv).get<DispatchComputeDesc>();
             scenarioSpec.addCommand(std::make_unique<DispatchComputeDesc>(std::move(dispatchCompute)));
         } break;
-        case (CommandType::DispatchDataGraph): {
+        case CommandType::DispatchDataGraph: {
             auto dispatchDataGraph = commandJson.at("dispatch_graph"sv).get<DispatchDataGraphDesc>();
             scenarioSpec.addCommand(std::make_unique<DispatchDataGraphDesc>(std::move(dispatchDataGraph)));
         } break;
-        case (CommandType::DispatchSpirvGraph): {
+        case CommandType::DispatchSpirvGraph: {
             auto dispatchSpirvGraph = commandJson.at("dispatch_spirv_graph"sv).get<DispatchSpirvGraphDesc>();
             scenarioSpec.addCommand(std::make_unique<DispatchSpirvGraphDesc>(std::move(dispatchSpirvGraph)));
         } break;
-        case (CommandType::DispatchFragment): {
+        case CommandType::DispatchFragment: {
             auto dispatchFragment = commandJson.at("dispatch_fragment"sv).get<DispatchFragmentDesc>();
             scenarioSpec.addCommand(std::make_unique<DispatchFragmentDesc>(std::move(dispatchFragment)));
         } break;
-        case (CommandType::DispatchBarrier): {
+        case CommandType::DispatchBarrier: {
             auto dispatchBarrier = commandJson.at("dispatch_barrier"sv).get<DispatchBarrierDesc>();
             scenarioSpec.addCommand(std::make_unique<DispatchBarrierDesc>(std::move(dispatchBarrier)));
         } break;
-        case (CommandType::MarkBoundary): {
+        case CommandType::MarkBoundary: {
             auto markBoundary = commandJson.at("mark_boundary"sv).get<MarkBoundaryDesc>();
             scenarioSpec.addCommand(std::make_unique<MarkBoundaryDesc>(std::move(markBoundary)));
         } break;
-        case (CommandType::DispatchOpticalFlow): {
+        case CommandType::DispatchOpticalFlow: {
             auto dispatchOpticalFlow = commandJson.at("dispatch_optical_flow"sv).get<DispatchOpticalFlowDesc>();
             scenarioSpec.addCommand(std::make_unique<DispatchOpticalFlowDesc>(std::move(dispatchOpticalFlow)));
         } break;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -148,29 +148,29 @@ std::vector<GraphConstantInfo> collectGraphConstants(const std::vector<Guid> &co
 
 std::string resourceType(const std::unique_ptr<ResourceDesc> &resource) {
     switch (resource->resourceType) {
-    case (ResourceType::Unknown):
+    case ResourceType::Unknown:
         return "Unknown";
-    case (ResourceType::Buffer):
+    case ResourceType::Buffer:
         return "Buffer";
-    case (ResourceType::DataGraph):
+    case ResourceType::DataGraph:
         return "DataGraph";
-    case (ResourceType::Shader):
+    case ResourceType::Shader:
         return "Shader";
-    case (ResourceType::RawData):
+    case ResourceType::RawData:
         return "RawData";
-    case (ResourceType::Tensor):
+    case ResourceType::Tensor:
         return "Tensor";
-    case (ResourceType::Image):
+    case ResourceType::Image:
         return "Image";
-    case (ResourceType::ImageBarrier):
+    case ResourceType::ImageBarrier:
         return "ImageBarrier";
-    case (ResourceType::MemoryBarrier):
+    case ResourceType::MemoryBarrier:
         return "MemoryBarrier";
-    case (ResourceType::TensorBarrier):
+    case ResourceType::TensorBarrier:
         return "TensorBarrier";
-    case (ResourceType::BufferBarrier):
+    case ResourceType::BufferBarrier:
         return "BufferBarrier";
-    case (ResourceType::GraphConstant):
+    case ResourceType::GraphConstant:
         return "GraphConstant";
     }
     throw std::runtime_error("Unknown resource type in ScenarioSpec");
@@ -665,19 +665,19 @@ void Scenario::setupResources() {
     // Handle memory groups
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
-        case (ResourceType::Buffer): {
+        case ResourceType::Buffer: {
             const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
             if (buffer->memoryGroup.has_value()) {
                 _groupManager.addResourceToGroup(buffer->memoryGroup->memoryUid, buffer->guid, ResourceIdType::Buffer);
             }
         } break;
-        case (ResourceType::Image): {
+        case ResourceType::Image: {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
             if (image->memoryGroup.has_value()) {
                 _groupManager.addResourceToGroup(image->memoryGroup->memoryUid, image->guid, ResourceIdType::Image);
             }
         } break;
-        case (ResourceType::Tensor): {
+        case ResourceType::Tensor: {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
             if (tensor->memoryGroup.has_value()) {
                 _groupManager.addResourceToGroup(tensor->memoryGroup->memoryUid, tensor->guid, ResourceIdType::Tensor);
@@ -694,26 +694,26 @@ void Scenario::setupResources() {
     ResourceInfoFactory resourceInfoFactory{_groupManager};
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
-        case (ResourceType::Buffer): {
+        case ResourceType::Buffer: {
             const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
             const auto info = resourceInfoFactory.createInfo(*buffer);
             _dataManager.createBuffer(resource->guid, info);
         } break;
-        case (ResourceType::RawData): {
+        case ResourceType::RawData: {
             const auto &rawData = reinterpret_cast<const std::unique_ptr<RawDataDesc> &>(resource);
             _dataManager.createRawData(resource->guid, rawData->guidStr, rawData->src.value());
         } break;
-        case (ResourceType::Image): {
+        case ResourceType::Image: {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
             const auto info = resourceInfoFactory.createInfo(*image);
             _dataManager.createImage(resource->guid, info);
         } break;
-        case (ResourceType::DataGraph): {
+        case ResourceType::DataGraph: {
             const auto &dataGraph = reinterpret_cast<const std::unique_ptr<DataGraphDesc> &>(resource);
             PerfCounterGuard guard(_perfCounters, "Parse VGF: " + dataGraph->guidStr, "Scenario Setup");
             _dataManager.createVgfView(resource->guid, dataGraph->src.value());
         } break;
-        case (ResourceType::Tensor): {
+        case ResourceType::Tensor: {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
             const auto info = resourceInfoFactory.createInfo(*tensor, _opts.captureFrame);
             _dataManager.createTensor(resource->guid, info);
@@ -728,11 +728,11 @@ void Scenario::setupResources() {
     // Setup aliasing resources, foundation before accessing tensors
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
-        case (ResourceType::Buffer): {
+        case ResourceType::Buffer: {
             auto &bufferRef = _dataManager.getBufferMut(resource->guid);
             bufferRef.setup(_ctx, _groupManager.getMemoryManager(resource->guid));
         } break;
-        case (ResourceType::Image): {
+        case ResourceType::Image: {
             auto &imageRef = _dataManager.getImageMut(resource->guid);
             imageRef.setup(_ctx, _groupManager.getMemoryManager(resource->guid));
         } break;
@@ -753,22 +753,22 @@ void Scenario::setupResources() {
     BarrierDataFactory barrierDataFactory{_dataManager};
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
-        case (ResourceType::ImageBarrier): {
+        case ResourceType::ImageBarrier: {
             const auto &imageBarrier = reinterpret_cast<const std::unique_ptr<ImageBarrierDesc> &>(resource);
             const auto data = barrierDataFactory.createInfo(*imageBarrier);
             _dataManager.createImageBarrier(resource->guid, data);
         } break;
-        case (ResourceType::MemoryBarrier): {
+        case ResourceType::MemoryBarrier: {
             const auto &memoryBarrier = reinterpret_cast<const std::unique_ptr<MemoryBarrierDesc> &>(resource);
             const auto data = barrierDataFactory.createInfo(*memoryBarrier);
             _dataManager.createMemoryBarrier(resource->guid, data);
         } break;
-        case (ResourceType::TensorBarrier): {
+        case ResourceType::TensorBarrier: {
             const auto &tensorBarrier = reinterpret_cast<const std::unique_ptr<TensorBarrierDesc> &>(resource);
             const auto data = barrierDataFactory.createInfo(*tensorBarrier);
             _dataManager.createTensorBarrier(resource->guid, data);
         } break;
-        case (ResourceType::BufferBarrier): {
+        case ResourceType::BufferBarrier: {
             const auto &bufferBarrier = reinterpret_cast<const std::unique_ptr<BufferBarrierDesc> &>(resource);
             const auto data = barrierDataFactory.createInfo(*bufferBarrier);
             _dataManager.createBufferBarrier(resource->guid, data);
@@ -783,7 +783,7 @@ void Scenario::setupResources() {
     // Allocate and fill resource memory
     for (auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
-        case (ResourceType::Tensor): {
+        case ResourceType::Tensor: {
             const auto &tensor = reinterpret_cast<std::unique_ptr<TensorDesc> &>(resource);
             auto &tensorRec = _dataManager.getTensorMut(tensor->guid);
             tensorRec.allocateMemory(_ctx);
@@ -792,7 +792,7 @@ void Scenario::setupResources() {
                 tensorRec.fillFromDescription(_ctx, *tensor);
             }
         } break;
-        case (ResourceType::Image): {
+        case ResourceType::Image: {
             const auto &image = reinterpret_cast<std::unique_ptr<ImageDesc> &>(resource);
             auto &imageRec = _dataManager.getImageMut(image->guid);
             imageRec.allocateMemory(_ctx);
@@ -803,7 +803,7 @@ void Scenario::setupResources() {
                 imageRec.transitionLayout(_ctx, vk::ImageLayout::eGeneral);
             }
         } break;
-        case (ResourceType::Buffer): {
+        case ResourceType::Buffer: {
             const auto &buffer = reinterpret_cast<std::unique_ptr<BufferDesc> &>(resource);
             auto &bufferRec = _dataManager.getBufferMut(buffer->guid);
             bufferRec.allocateMemory(_ctx);
@@ -834,38 +834,38 @@ void Scenario::setupCommands() {
     uint32_t nQueries = 0;
     for (const auto &command : _scenarioSpec.commands) {
         switch (command->commandType) {
-        case (CommandType::DispatchCompute): {
+        case CommandType::DispatchCompute: {
             const auto &dispatchCompute = reinterpret_cast<DispatchComputeDesc &>(*command);
             const auto data = factory.createData(dispatchCompute);
             createComputePipeline(data, nQueries);
         } break;
-        case (CommandType::DispatchBarrier): {
+        case CommandType::DispatchBarrier: {
             const auto &dispatchBarrier = reinterpret_cast<DispatchBarrierDesc &>(*command);
             const auto data = factory.createData(dispatchBarrier);
             _compute.registerPipelineBarrier(data, _dataManager);
         } break;
-        case (CommandType::DispatchDataGraph): {
+        case CommandType::DispatchDataGraph: {
             const auto &dispatchDataGraph = reinterpret_cast<DispatchDataGraphDesc &>(*command);
             const auto data = factory.createData(dispatchDataGraph);
             createDataGraphPipeline(data, nQueries);
         } break;
-        case (CommandType::DispatchSpirvGraph): {
+        case CommandType::DispatchSpirvGraph: {
             const auto &dispatchSpirvGraph = reinterpret_cast<DispatchSpirvGraphDesc &>(*command);
             const auto data = factory.createData(dispatchSpirvGraph);
             createSpirvGraphPipeline(data, nQueries);
         } break;
-        case (CommandType::DispatchFragment): {
+        case CommandType::DispatchFragment: {
             const auto &dispatchFragment = reinterpret_cast<DispatchFragmentDesc &>(*command);
             const auto data = factory.createData(dispatchFragment);
             createFragmentPipeline(data, nQueries);
         } break;
-        case (CommandType::DispatchOpticalFlow): {
+        case CommandType::DispatchOpticalFlow: {
             const auto &dispatchOpticalFlow = reinterpret_cast<DispatchOpticalFlowDesc &>(*command);
             const auto data = factory.createData(dispatchOpticalFlow);
             verifyOpticalFlowData(_dataManager, data);
             createOpticalFlowPipeline(data, nQueries);
         } break;
-        case (CommandType::MarkBoundary): {
+        case CommandType::MarkBoundary: {
             const auto &markBoundary = reinterpret_cast<MarkBoundaryDesc &>(*command);
             const auto data = factory.createData(markBoundary);
             if (_ctx._optionals.mark_boundary) {

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -11,7 +11,7 @@
 
 namespace mlsdk::scenariorunner {
 namespace {
-std::string categoryToSuffix(vgflib::ResourceCategory category) {
+std::string_view categoryToSuffix(vgflib::ResourceCategory category) {
     switch (category) {
     case vgflib::ResourceCategory::INPUT:
         return "_input";
@@ -27,7 +27,7 @@ std::string categoryToSuffix(vgflib::ResourceCategory category) {
 }
 
 std::string createResourceGuidStr(uint32_t index, vgflib::ResourceCategory category) {
-    return "Resource_" + std::to_string(index) + categoryToSuffix(category);
+    return std::string("Resource_").append(std::to_string(index)).append(categoryToSuffix(category));
 }
 
 uint32_t bufferSize(const vgflib::DataView<int64_t> &shape) {
@@ -264,7 +264,8 @@ void VgfView::validateResource(const IResourceViewer &resourceViewer, uint32_t v
         throw std::runtime_error("Descriptor type not found from VGF file");
     }
 
-    switch (expectedType.value()) {
+    const auto descriptorType = expectedType.value();
+    switch (descriptorType) {
     case DESCRIPTOR_TYPE_UNIFORM_BUFFER: {
         const auto &buffer = resourceViewer.getBuffer();
 
@@ -285,15 +286,13 @@ void VgfView::validateResource(const IResourceViewer &resourceViewer, uint32_t v
 
         // Check if tensor shapes match
         if (actualTensorShape != expectedTensorShape) {
-            throw std::runtime_error("Mismatch of tensor shape declarations "
-                                     "between JSON and VGF file");
+            throw std::runtime_error("Mismatch of tensor shape declarations between JSON and VGF file");
         }
 
         // Check if tensor data formats match
         auto format = resourceTableDecoder->getVkFormat(vgfMrtIndex);
         if (static_cast<int32_t>(tensor.dataType()) != format) {
-            throw std::runtime_error("Mismatch of tensor data type declarations "
-                                     "between JSON and VGF file");
+            throw std::runtime_error("Mismatch of tensor data type declarations between JSON and VGF file");
         }
     } break;
     case DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
@@ -304,20 +303,18 @@ void VgfView::validateResource(const IResourceViewer &resourceViewer, uint32_t v
         auto dims = resourceTableDecoder->getTensorShape(vgfMrtIndex);
         const std::vector<int64_t> expectedImageShape(dims.begin(), dims.end());
         if (actualImageShape != expectedImageShape) {
-            throw std::runtime_error("Mismatch of image shape declarations "
-                                     "between JSON and VGF file");
+            throw std::runtime_error("Mismatch of image shape declarations between JSON and VGF file");
         }
 
         auto format = resourceTableDecoder->getVkFormat(vgfMrtIndex);
         if (static_cast<int32_t>(image.dataType()) != format) {
-            throw std::runtime_error("Mismatch of image data type declarations "
-                                     "between JSON and VGF file");
+            throw std::runtime_error("Mismatch of image data type declarations between JSON and VGF file");
         }
     } break;
     default:
-        throw std::runtime_error(
-            "No resource validation should be performed for resources different from tensors, buffers, and images");
-        break;
+        throw std::runtime_error("No resource validation should be performed for resources different from tensors, "
+                                 "buffers, and images. Found descriptor type: " +
+                                 std::to_string(descriptorType));
     }
 }
 
@@ -328,45 +325,46 @@ void VgfView::createIntermediateResources(IResourceCreator &creator) const {
         auto resourceCategory = resourceTableDecoder->getCategory(resourceIndex);
         if (resourceCategory == vgflib::ResourceCategory::INTERMEDIATE) {
             auto guidStr = createResourceGuidStr(resourceIndex, resourceCategory);
-            auto type = resourceTableDecoder->getDescriptorType(resourceIndex);
-            switch (type.value_or(DESCRIPTOR_TYPE_UNKNOWN)) {
-            case (DESCRIPTOR_TYPE_UNIFORM_BUFFER): {
-                auto shape = resourceTableDecoder->getTensorShape(resourceIndex);
+            const Guid guid(guidStr);
+            const auto shape = resourceTableDecoder->getTensorShape(resourceIndex);
+            const auto type = resourceTableDecoder->getDescriptorType(resourceIndex);
+            const auto descriptorType = type.value_or(DESCRIPTOR_TYPE_UNKNOWN);
+            switch (descriptorType) {
+            case DESCRIPTOR_TYPE_UNIFORM_BUFFER: {
                 auto expectedBufferSize = bufferSize(shape);
 
                 // Create Scenario Runner buffer resource
-                BufferInfo info{guidStr, expectedBufferSize};
-                creator.createBuffer(guidStr, info);
+                BufferInfo info{std::move(guidStr), expectedBufferSize};
+                creator.createBuffer(guid, info);
             } break;
-            case (DESCRIPTOR_TYPE_TENSOR_ARM): {
-                auto shape = resourceTableDecoder->getTensorShape(resourceIndex);
+            case DESCRIPTOR_TYPE_TENSOR_ARM: {
                 auto format = resourceTableDecoder->getVkFormat(resourceIndex);
 
-                auto info = TensorInfo{guidStr, std::vector<int64_t>(shape.begin(), shape.end()), vk::Format(format),
-                                       -1, false};
+                auto info = TensorInfo{std::move(guidStr), std::vector<int64_t>(shape.begin(), shape.end()),
+                                       vk::Format(format), -1, false};
 
                 // Create Scenario Runner tensor
-                creator.createTensor(guidStr, info);
+                creator.createTensor(guid, info);
             } break;
-            case (DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER):
-            case (DESCRIPTOR_TYPE_STORAGE_IMAGE): {
-                auto shape = resourceTableDecoder->getTensorShape(resourceIndex);
+            case DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            case DESCRIPTOR_TYPE_STORAGE_IMAGE: {
                 auto format = resourceTableDecoder->getVkFormat(resourceIndex);
 
                 ImageInfo info{};
-                info.debugName = guidStr;
+                info.debugName = std::move(guidStr);
                 info.shape = std::vector<int64_t>(shape.begin(), shape.end());
                 info.format = vk::Format(format);
                 info.targetFormat = info.format;
                 info.isInput = false;
                 info.mips = 1;
-                info.isSampled = (type == DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-                info.isStorage = (type == DESCRIPTOR_TYPE_STORAGE_IMAGE);
+                info.isSampled = (descriptorType == DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+                info.isStorage = (descriptorType == DESCRIPTOR_TYPE_STORAGE_IMAGE);
 
-                creator.createImage(guidStr, info);
+                creator.createImage(guid, info);
             } break;
             default:
-                throw std::runtime_error("Unknown resource type read from VGF file");
+                throw std::runtime_error("Unknown resource type: " + std::to_string(descriptorType) +
+                                         " read from VGF file for uid: " + guidStr);
             }
         }
     }


### PR DESCRIPTION
- Code polish by removing redundant parantheses and improving error messages when parsing vgf files.
- Improve string concatenation by using std::string_view and append.

Change-Id: Id4cc406a1244c4548ce0727bdb2f8a9f12f8152a