### PR TITLE
Add Emulation Layer profiling dump option

### DIFF
--- a/docs/help/scenario_runner_help.rst
+++ b/docs/help/scenario_runner_help.rst
@@ -1,25 +1,26 @@
-Usage: ./scenario-runner [--help] [--version] --scenario VAR [--output VAR] [--profiling-dump-path VAR] [--pipeline-caching] [--clear-pipeline-cache] [--cache-path VAR] [--neural-debug-database-dump-dir VAR] [--fail-on-pipeline-cache-miss] [--neural-statistics-dump-dir VAR] [--neural-statistics-mode VAR] [--perf-counters-dump-path VAR] [--log-level VAR] [--wait-for-key-stroke-before-run] [--dry-run] [--disable-extension VAR...]... [--enable-gpu-debug-markers] [--session-memory-dump-dir VAR] [--repeat VAR] [--capture-frame] [--pause-on-exit]
+Usage: ./scenario-runner [--help] [--version] --scenario VAR [--output VAR] [--profiling-dump-path VAR] [--pipeline-caching] [--clear-pipeline-cache] [--cache-path VAR] [--neural-debug-database-dump-dir VAR] [--fail-on-pipeline-cache-miss] [--emulation-layer-profiling-dump-dir VAR] [--neural-statistics-dump-dir VAR] [--neural-statistics-mode VAR] [--perf-counters-dump-path VAR] [--log-level VAR] [--wait-for-key-stroke-before-run] [--dry-run] [--disable-extension VAR...]... [--enable-gpu-debug-markers] [--session-memory-dump-dir VAR] [--repeat VAR] [--capture-frame] [--pause-on-exit]
 
 Optional arguments:
-  -h, --help                        shows help message and exits
-  -v, --version                     prints version information and exits
-  --scenario                        file to load the scenario from. File should be in JSON format [required]
-  --output                          output folder
-  --profiling-dump-path             path to save runtime profiling
-  --pipeline-caching                enable the pipeline caching
-  --clear-pipeline-cache            clear pipeline cache
-  --cache-path                      set pipeline cache location [default: "/tmp"]
-  --neural-debug-database-dump-dir  path to dump Neural Accelerator Debug Database [nargs=0..1] [default: ""]
-  --fail-on-pipeline-cache-miss     ensure an error is generated on a pipeline cache miss
-  --neural-statistics-dump-dir      path to dump Neural Accelerator Statistics [nargs=0..1] [default: ""]
-  --neural-statistics-mode          set neural accelerator statistics mode to 0 or 1 [nargs=0..1] [default: "1"]
-  --perf-counters-dump-path         path to save performance counter stats [default: ""]
-  --log-level                       set logging level [default: info]
-  --wait-for-key-stroke-before-run  wait for a key stroke before run
-  --dry-run                         setup pipelines but skip the actual execution
-  --disable-extension               specify extensions to disable out of the following: VK_EXT_custom_border_color, VK_EXT_frame_boundary, VK_ARM_data_graph_neural_accelerator_statistics, VK_KHR_maintenance5, VK_KHR_deferred_host_operations [nargs: 1 or more] [may be repeated]
-  --enable-gpu-debug-markers        enable GPU debug markers
-  --session-memory-dump-dir         path to dump the contents of the sessions ram after inference completes
-  --repeat                          optional repeat count for scenario execution
-  --capture-frame                   enable RenderDoc integration for frame capturing
-  --pause-on-exit                   pause before exiting
+  -h, --help                            shows help message and exits
+  -v, --version                         prints version information and exits
+  --scenario                            file to load the scenario from. File should be in JSON format [required]
+  --output                              output folder
+  --profiling-dump-path                 path to save runtime profiling
+  --pipeline-caching                    enable the pipeline caching
+  --clear-pipeline-cache                clear pipeline cache
+  --cache-path                          set pipeline cache location [default: "/tmp"]
+  --neural-debug-database-dump-dir      path to dump Neural Accelerator Debug Database [nargs=0..1] [default: ""]
+  --fail-on-pipeline-cache-miss         ensure an error is generated on a pipeline cache miss
+  --emulation-layer-profiling-dump-dir  path to dump Emulation Layer graph profiling data [nargs=0..1] [default: ""]
+  --neural-statistics-dump-dir          path to dump Neural Accelerator Statistics [nargs=0..1] [default: ""]
+  --neural-statistics-mode              set neural accelerator statistics mode to 0 or 1 [nargs=0..1] [default: "1"]
+  --perf-counters-dump-path             path to save performance counter stats [default: ""]
+  --log-level                           set logging level [default: info]
+  --wait-for-key-stroke-before-run      wait for a key stroke before run
+  --dry-run                             setup pipelines but skip the actual execution
+  --disable-extension                   specify extensions to disable out of the following: VK_EXT_custom_border_color, VK_EXT_frame_boundary, VK_ARM_data_graph_neural_accelerator_statistics, VK_KHR_maintenance5, VK_KHR_deferred_host_operations [nargs: 1 or more] [may be repeated]
+  --enable-gpu-debug-markers            enable GPU debug markers
+  --session-memory-dump-dir             path to dump the contents of the sessions ram after inference completes
+  --repeat                              optional repeat count for scenario execution
+  --capture-frame                       enable RenderDoc integration for frame capturing
+  --pause-on-exit                       pause before exiting

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -18,6 +18,11 @@ Use ``--neural-debug-database-dump-dir`` to dump the neural accelerator debug da
 
 If neural accelerator dumps are requested and ``VK_ARM_data_graph_neural_accelerator_statistics`` is not supported or enabled, Scenario Runner fails during startup before creating the Vulkan® device.
 
+Graph profiling dumps
+---------------------
+
+Use ``--emulation-layer-profiling-dump-dir`` to request Emulation layer graph profiling payload from data graph pipelines using the custom Emulation layer property token ``0x7ffffffe`` in ``vkGetDataGraphPipelineAvailablePropertiesARM``. This option is Emulation layer specific and best-effort: Scenario Runner warns and continues if the property is unavailable or returns no data. When data is returned, Scenario Runner writes one file per graph pipeline with the name ``Graph_Pipeline_<idx>_EL_Performance.json``. The payload is stored exactly as returned, without JSON validation or pretty-printing.
+
 Resource memory aliasing
 ------------------------
 

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -15,6 +15,10 @@ namespace mlsdk::scenariorunner {
 
 namespace {
 
+// Keep in sync with the value defined in emulation-layer
+constexpr vk::DataGraphPipelinePropertyARM graphProfilingProperty =
+    static_cast<vk::DataGraphPipelinePropertyARM>(0x7ffffffe);
+
 struct PipelineBarrierDebugNameBuilder {
     template <class BarrierType> void addBarrier(const BarrierType &barrier) {
         if (!barrier.debugName().empty()) {
@@ -748,6 +752,50 @@ void Compute::dumpNeuralStatistics(const std::filesystem::path &neuralStatistics
         dumpFile.write(statisticsData.data(), std::streamsize(statisticsData.size()));
         dumpFile.close();
         mlsdk::logging::info("Neural statistics saved to \"" + statisticsFileName + "\"");
+    }
+}
+
+void Compute::dumpGraphProfilingData(const std::filesystem::path &graphProfilingDumpDir) const {
+    uint32_t graphPipelineIdx = 0;
+    for (const auto &pipeline : _pipelines) {
+        if (!pipeline.isDataGraphPipeline()) {
+            continue;
+        }
+
+        const auto graphPipelineIdxStr = std::to_string(graphPipelineIdx++);
+        try {
+            if (!pipeline.hasGraphPipelineProperty(_ctx.device(), graphProfilingProperty)) {
+                logging::warning("Skipping graph profiling dump for graph pipeline " + graphPipelineIdxStr +
+                                 ": property 0x7ffffffe is not available");
+                continue;
+            }
+        } catch (const std::exception &err) {
+            logging::warning("Failed querying available graph properties for pipeline " + graphPipelineIdxStr + ": " +
+                             err.what());
+            continue;
+        }
+
+        std::vector<char> graphProfilingData;
+        try {
+            graphProfilingData = pipeline.getGraphPipelinePropertyData<char>(_ctx.device(), graphProfilingProperty);
+        } catch (const std::exception &err) {
+            logging::warning("Skipping graph profiling dump for graph pipeline " + graphPipelineIdxStr +
+                             ": failed to query property data: " + err.what());
+            continue;
+        }
+
+        if (graphProfilingData.empty()) {
+            logging::warning("Skipping graph profiling dump for graph pipeline " + graphPipelineIdxStr +
+                             ": property data is empty");
+            continue;
+        }
+
+        const std::string fileName = "EmulationLayerPipeline_" + graphPipelineIdxStr + ".json";
+
+        std::ofstream dumpFile(graphProfilingDumpDir / fileName);
+        dumpFile.write(graphProfilingData.data(), std::streamsize(graphProfilingData.size()));
+        dumpFile.close();
+        logging::info("Graph profiling data saved to \"" + fileName + "\"");
     }
 }
 

--- a/src/compute.hpp
+++ b/src/compute.hpp
@@ -159,6 +159,7 @@ class Compute {
     void dumpNeuralDebugDatabase(const std::filesystem::path &neuralDebugDatabaseDumpDir) const;
     void dumpNeuralStatistics(const std::filesystem::path &neuralStatisticsDumpDir,
                               vk::NeuralAcceleratorStatisticsModeARM neuralStatisticsMode) const;
+    void dumpGraphProfilingData(const std::filesystem::path &graphProfilingDumpDir) const;
     void sessionRAMsDump(const std::filesystem::path &sessionRAMsDumpDir) const;
 
   private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,6 +144,9 @@ int runScenarioRunner(int argc, const char **argv) {
             .help("ensure an error is generated on a pipeline cache miss")
             .default_value(false)
             .implicit_value(true);
+        parser.add_argument("--emulation-layer-profiling-dump-dir")
+            .help("path to dump Emulation Layer graph profiling data")
+            .default_value<std::string>("");
         parser.add_argument("--neural-statistics-dump-dir")
             .help("path to dump Neural Accelerator Statistics")
             .default_value<std::string>("");
@@ -232,6 +235,14 @@ int runScenarioRunner(int argc, const char **argv) {
                     selectableExtensions.end()) {
                     throw std::runtime_error("Unrecognized extension, cannot disable: " + extension);
                 }
+            }
+        }
+
+        auto graphProfilingDumpDirStr = parser.get("--emulation-layer-profiling-dump-dir");
+        if (!graphProfilingDumpDirStr.empty()) {
+            scenarioOptions.graphProfilingDumpDir = std::filesystem::path(graphProfilingDumpDirStr);
+            if (!std::filesystem::is_directory(scenarioOptions.graphProfilingDumpDir)) {
+                throw std::runtime_error("Invalid graph profiling dump directory: " + graphProfilingDumpDirStr);
             }
         }
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -10,6 +10,7 @@
 #include "spirv-tools/libspirv.hpp"
 #include "vulkan_debug_utils.hpp"
 
+#include <algorithm>
 #include <array>
 
 namespace mlsdk::scenariorunner {
@@ -673,6 +674,17 @@ void Pipeline::buildDataGraphPipeline(const Context &ctx, const std::string &ent
     trySetVkRaiiObjectDebugName(ctx, _pipeline, _debugName);
 
     initSession(ctx, enableNeuralStatistics, neuralStatisticsMode);
+}
+
+bool Pipeline::hasGraphPipelineProperty(const vk::raii::Device &device,
+                                        vk::DataGraphPipelinePropertyARM property) const {
+    if (!isDataGraphPipeline()) {
+        throw std::runtime_error("getDataGraphPipelineAvailablePropertiesARM called on a non DataGraphPipeline");
+    }
+
+    vk::DataGraphPipelineInfoARM pipelineInfo{*_pipeline, nullptr};
+    const auto availableProperties = device.getDataGraphPipelineAvailablePropertiesARM(pipelineInfo);
+    return std::find(availableProperties.begin(), availableProperties.end(), property) != availableProperties.end();
 }
 
 const std::string &Pipeline::debugName() const { return _debugName; }

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -89,6 +89,8 @@ class Pipeline {
     std::vector<T> getGraphPipelinePropertyData(const vk::raii::Device &device,
                                                 vk::DataGraphPipelinePropertyARM property) const;
 
+    bool hasGraphPipelineProperty(const vk::raii::Device &device, vk::DataGraphPipelinePropertyARM property) const;
+
     const std::string &debugName() const;
 
     const std::optional<NeuralStatisticsMemoryInfo> &neuralStatisticsMemoryInfo() const {

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -1358,6 +1358,11 @@ void Scenario::saveResults(bool dryRun) {
         _compute.dumpNeuralStatistics(_opts.neuralStatisticsDumpDir, _opts.neuralStatisticsMode);
     }
 
+    // Store Graph Profiling Data Dump
+    if (_opts.shouldDumpGraphProfiling()) {
+        _compute.dumpGraphProfilingData(_opts.graphProfilingDumpDir);
+    }
+
     // Hexdump the session ram for debugging
     if (!_opts.sessionRAMsDumpDir.empty()) {
         _compute.sessionRAMsDump(_opts.sessionRAMsDumpDir);

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -26,6 +26,7 @@ struct ScenarioOptions {
     std::filesystem::path pipelineCachePath;
     std::filesystem::path neuralDebugDatabaseDumpDir;
     std::filesystem::path neuralStatisticsDumpDir;
+    std::filesystem::path graphProfilingDumpDir;
     std::filesystem::path sessionRAMsDumpDir;
     std::filesystem::path perfCountersPath;
     std::filesystem::path profilingPath;
@@ -34,6 +35,7 @@ struct ScenarioOptions {
 
     bool shouldDumpNeuralDebugDatabase() const { return !neuralDebugDatabaseDumpDir.empty(); }
     bool shouldDumpNeuralStatistics() const { return !neuralStatisticsDumpDir.empty(); }
+    bool shouldDumpGraphProfiling() const { return !graphProfilingDumpDir.empty(); }
 };
 
 struct DispatchComputeData;

--- a/src/tests/test_cli_options.py
+++ b/src/tests/test_cli_options.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+import subprocess
+
+import pytest
+
+
+def test_graph_profiling_dump_dir_requires_existing_directory(
+    scenario_runner, resources_helper
+):
+    scenario = resources_helper.get_scenario_path("test_shader/add_shader.json")
+    invalid_dump_dir = resources_helper.get_testenv_path("missing_graph_profiling_dir")
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        scenario_runner.run(
+            "--scenario",
+            scenario,
+            "--emulation-layer-profiling-dump-dir",
+            invalid_dump_dir,
+        )
+
+    assert "Invalid graph profiling dump directory:" in (exc_info.value.stderr or "")


### PR DESCRIPTION
- add CLI support for --emulation-layer-profiling-dump-dir and option plumbing
- dump Emulation Layer profiling payload per graph pipeline to EmulationLayerPipeline_<idx>.json
- gate on vkGetDataGraphPipelineAvailablePropertiesARM before querying payload data
- fetch dump data via vkGetDataGraphPipelinePropertiesARM
- keep behavior best-effort with warnings when property is unavailable/empty
- update usage/help docs and add CLI validation test for invalid dump directory

Change-Id: Ie9cf1600e8c4e55909f029193b546069873b194a