### PR TITLE
Support VGF resource alias groups in Scenario Runner

### DIFF
--- a/src/iresource.hpp
+++ b/src/iresource.hpp
@@ -17,9 +17,9 @@ class IResourceCreator {
     virtual ~IResourceCreator() = default;
 
     // Create buffer resource and setup and allocate memory in buffer
-    virtual void createBuffer(Guid guid, const BufferInfo &info) = 0;
-    virtual void createTensor(Guid guid, const TensorInfo &info) = 0;
-    virtual void createImage(Guid guid, const ImageInfo &info) = 0;
+    virtual void createBuffer(Guid guid, BufferInfo info) = 0;
+    virtual void createTensor(Guid guid, TensorInfo info) = 0;
+    virtual void createImage(Guid guid, ImageInfo info) = 0;
 };
 
 /// @brief Interface for accessing resources in an identifier agnostic way. Derived class handle the resource

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -383,32 +383,72 @@ std::vector<TypedBinding> convertBindings(const DataManager &dataManager,
 
 class Creator final : public IResourceCreator {
   public:
-    Creator(const Context &ctx, DataManager &dataManager) : _ctx{ctx}, _dataManager{dataManager} {}
+    Creator(const Context &ctx, DataManager &dataManager, GroupManager &groupManager)
+        : _ctx{ctx}, _dataManager{dataManager}, _groupManager{groupManager} {}
 
-    void createBuffer(Guid guid, const BufferInfo &info) override {
+    void createBuffer(Guid guid, BufferInfo info) override {
         _dataManager.createBuffer(guid, info);
-        auto &buffer = _dataManager.getBufferMut(guid);
-        buffer.setup(_ctx);
-        buffer.allocateMemory(_ctx);
+        _createdResources.push_back({guid, ResourceIdType::Buffer});
     }
 
-    void createTensor(Guid guid, const TensorInfo &info) override {
+    void createTensor(Guid guid, TensorInfo info) override {
+        info.isAliasedWithImage = _groupManager.hasAliasOfType(guid, ResourceIdType::Image);
         _dataManager.createTensor(guid, info);
-        auto &tensor = _dataManager.getTensorMut(guid);
-        tensor.setup(_ctx);
-        tensor.allocateMemory(_ctx);
+        _createdResources.push_back({guid, ResourceIdType::Tensor});
     }
 
-    void createImage(Guid guid, const ImageInfo &info) override {
+    void createImage(Guid guid, ImageInfo info) override {
+        info.isAliased = _groupManager.isAliased(guid);
         _dataManager.createImage(guid, info);
-        auto &image = _dataManager.getImageMut(guid);
-        image.setup(_ctx);
-        image.allocateMemory(_ctx);
+        _createdResources.push_back({guid, ResourceIdType::Image});
+    }
+
+    void setupCreatedNonTensorResources() {
+        for (const auto &[guid, type] : _createdResources) {
+            switch (type) {
+            case ResourceIdType::Buffer:
+                _dataManager.getBufferMut(guid).setup(_ctx, _groupManager.getMemoryManager(guid));
+                break;
+            case ResourceIdType::Image:
+                _dataManager.getImageMut(guid).setup(_ctx, _groupManager.getMemoryManager(guid));
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
+    void setupCreatedTensorResources() {
+        for (const auto &[guid, type] : _createdResources) {
+            if (type == ResourceIdType::Tensor) {
+                _dataManager.getTensorMut(guid).setup(_ctx, _groupManager.getMemoryManager(guid));
+            }
+        }
+    }
+
+    void allocateCreatedResources() {
+        for (const auto &[guid, type] : _createdResources) {
+            switch (type) {
+            case ResourceIdType::Buffer:
+                _dataManager.getBufferMut(guid).allocateMemory(_ctx);
+                break;
+            case ResourceIdType::Image:
+                _dataManager.getImageMut(guid).allocateMemory(_ctx);
+                break;
+            case ResourceIdType::Tensor:
+                _dataManager.getTensorMut(guid).allocateMemory(_ctx);
+                break;
+            default:
+                break;
+            }
+        }
     }
 
   private:
     const Context &_ctx;
     DataManager &_dataManager;
+    GroupManager &_groupManager;
+    std::vector<GroupResourceEntry> _createdResources;
 };
 
 struct CommandDataFactory {
@@ -725,6 +765,22 @@ void Scenario::setupResources() {
         mlsdk::logging::debug(resourceType(resource) + ": " + resource->guidStr + " loaded");
     }
 
+    Creator vgfResourceCreator{_ctx, _dataManager, _groupManager};
+    for (const auto &command : _scenarioSpec.commands) {
+        if (command->commandType != CommandType::DispatchDataGraph) {
+            continue;
+        }
+
+        const auto &dispatchDataGraph = static_cast<const DispatchDataGraphDesc &>(*command);
+        const auto &vgfView = _dataManager.getVgfView(dispatchDataGraph.dataGraphRef);
+        const auto externalBindings = convertBindings(_dataManager, dispatchDataGraph.bindings);
+        // Register aliases before creating resources so setup/allocation sees the complete group membership.
+        for (const auto &alias : vgfView.getResourceAliases(externalBindings)) {
+            _groupManager.addResourceToGroup(alias.group, alias.resource, alias.resourceType);
+        }
+        vgfView.createIntermediateResources(vgfResourceCreator);
+    }
+
     // Setup aliasing resources, foundation before accessing tensors
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
@@ -740,6 +796,7 @@ void Scenario::setupResources() {
             break; // No action
         }
     }
+    vgfResourceCreator.setupCreatedNonTensorResources();
 
     // Setup tensors, aliasing tensors are dependent on other resources having been constructed
     for (const auto &resource : _scenarioSpec.resources) {
@@ -748,6 +805,7 @@ void Scenario::setupResources() {
             tensorRef.setup(_ctx, _groupManager.getMemoryManager(resource->guid));
         }
     }
+    vgfResourceCreator.setupCreatedTensorResources();
 
     // Setup barrier resource info, these depend on other resources
     BarrierDataFactory barrierDataFactory{_dataManager};
@@ -818,6 +876,7 @@ void Scenario::setupResources() {
         }
         mlsdk::logging::debug(resourceType(resource) + ": " + resource->guidStr + " loaded");
     }
+    vgfResourceCreator.allocateCreatedResources();
 }
 
 void Scenario::setupCommands() {
@@ -1118,8 +1177,6 @@ void Scenario::createFragmentPipeline(const DispatchFragmentData &dispatchFragme
 
 void Scenario::createDataGraphPipeline(const DispatchDataGraphData &dispatchDataGraph, uint32_t &nQueries) {
     const VgfView &vgfView = _dataManager.getVgfView(dispatchDataGraph.dataGraphRef);
-    Creator creator{_ctx, _dataManager};
-    vgfView.createIntermediateResources(creator);
     for (uint32_t segmentIndex = 0; segmentIndex < vgfView.getNumSegments(); ++segmentIndex) {
         const auto &sequenceBindings = vgfView.resolveBindings(segmentIndex, _dataManager, dispatchDataGraph.bindings);
         auto moduleName = vgfView.getModuleName(segmentIndex);

--- a/src/tests/resources/scenarios/test_vgf_shader/vgf_alias_group_intermediate_buffer_tensor.json
+++ b/src/tests/resources/scenarios/test_vgf_shader/vgf_alias_group_intermediate_buffer_tensor.json
@@ -1,0 +1,62 @@
+{
+    "commands": [
+        {
+            "dispatch_graph": {
+                "bindings": [
+                    {
+                        "id": 1,
+                        "set": 0,
+                        "resource_ref": "output"
+                    }
+                ],
+                "shader_substitutions": [
+                    {
+                        "shader_ref": "writeBuffer",
+                        "target": "write_alias_buffer"
+                    },
+                    {
+                        "shader_ref": "copyTensor",
+                        "target": "copy_alias_tensor"
+                    }
+                ],
+                "graph_ref": "vgfGraph"
+            }
+        }
+    ],
+    "resources": [
+        {
+            "shader": {
+                "src": "write_alias_buffer_u16.spv",
+                "type": "SPIR-V",
+                "uid": "writeBuffer"
+            }
+        },
+        {
+            "shader": {
+                "src": "copy_tensor_shader.spv",
+                "type": "SPIR-V",
+                "uid": "copyTensor"
+            }
+        },
+        {
+            "graph": {
+                "uid": "vgfGraph",
+                "src": "alias_intermediates.vgf"
+            }
+        },
+        {
+            "tensor": {
+                "uid": "output",
+                "shader_access": "readwrite",
+                "dims": [
+                    1,
+                    16,
+                    16,
+                    1
+                ],
+                "format": "VK_FORMAT_R16_UINT",
+                "dst": "output.npy"
+            }
+        }
+    ]
+}

--- a/src/tests/resources/shaders/test_memory_aliasing/write_alias_buffer_u16.comp
+++ b/src/tests/resources/shaders/test_memory_aliasing/write_alias_buffer_u16.comp
@@ -1,0 +1,20 @@
+/*
+* SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+* SPDX-License-Identifier: Apache-2.0
+*/
+#version 450
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0, std430) buffer AliasBuffer
+{
+    uint16_t values[];
+};
+
+void main()
+{
+    uint index = gl_GlobalInvocationID.x + (gl_GlobalInvocationID.y * 16u);
+    values[index] = uint16_t(index + 5u);
+}

--- a/src/tests/test_vgf_shader.py
+++ b/src/tests/test_vgf_shader.py
@@ -16,6 +16,7 @@ import vgfpy as vgf
 DESCRIPTOR_TYPE_STORAGE_BUFFER_EXT = 6
 DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000
 VK_FORMAT_R8_SINT = 14
+VK_FORMAT_R16_UINT = 74
 pretendVulkanHeaderVersion = 123
 
 pytestmark = pytest.mark.vgf_shader
@@ -628,6 +629,86 @@ def test_two_spirv_shader_module_in_vgf_with_shader_substitution(
 
     result = numpy_helper.load("output.npy", np.uint8)
     assert np.array_equal(result, np.add(input, 3))
+
+
+def test_vgf_alias_group_for_internal_intermediates(
+    sdk_tools, resources_helper, numpy_helper
+):
+    sdk_tools.compile_shader(
+        "test_memory_aliasing/write_alias_buffer_u16.comp",
+        output="write_alias_buffer_u16.spv",
+    )
+    sdk_tools.compile_shader(
+        "test_memory_aliasing/copy_tensor_shader.comp",
+        output="copy_tensor_shader.spv",
+    )
+
+    encoder = vgf.CreateEncoder(pretendVulkanHeaderVersion)
+
+    module0 = encoder.AddModule(vgf.ModuleType.Compute, "write_alias_buffer", "main")
+    module1 = encoder.AddModule(vgf.ModuleType.Compute, "copy_alias_tensor", "main")
+
+    aliasBuffer = encoder.AddIntermediateResource(
+        DESCRIPTOR_TYPE_STORAGE_BUFFER_EXT, VK_FORMAT_R8_SINT, [512], [], 7
+    )
+    aliasTensor = encoder.AddIntermediateResource(
+        DESCRIPTOR_TYPE_TENSOR_ARM, VK_FORMAT_R16_UINT, [1, 16, 16, 1], [], 7
+    )
+    outputTensor = encoder.AddOutputResource(
+        DESCRIPTOR_TYPE_TENSOR_ARM, VK_FORMAT_R16_UINT, [1, 16, 16, 1], []
+    )
+
+    aliasBufferBinding = encoder.AddBindingSlot(0, aliasBuffer)
+    aliasTensorBinding = encoder.AddBindingSlot(0, aliasTensor)
+    outputTensorBinding = encoder.AddBindingSlot(1, outputTensor)
+
+    writerDescSetInfo = encoder.AddDescriptorSetInfo([aliasBufferBinding])
+    readerDescSetInfo = encoder.AddDescriptorSetInfo(
+        [aliasTensorBinding, outputTensorBinding]
+    )
+
+    encoder.AddModelSequenceInputsOutputs(
+        [],
+        [],
+        [outputTensorBinding],
+        ["outputTensor"],
+    )
+
+    encoder.AddSegmentInfo(
+        module0,
+        "write_alias_buffer_segment",
+        [writerDescSetInfo],
+        [],
+        [aliasBufferBinding],
+        [],
+        [16, 16, 1],
+    )
+    encoder.AddSegmentInfo(
+        module1,
+        "copy_alias_tensor_segment",
+        [readerDescSetInfo],
+        [aliasTensorBinding],
+        [outputTensorBinding],
+        [],
+        [16, 16, 1],
+    )
+
+    encoder.Finish()
+
+    vgfStream = io.FileIO(
+        resources_helper.get_testenv_path("alias_intermediates.vgf"), mode="wb"
+    )
+    assert encoder.WriteTo(vgfStream)
+    vgfStream.close()
+
+    sdk_tools.run_scenario(
+        "test_vgf_shader/vgf_alias_group_intermediate_buffer_tensor.json"
+    )
+
+    result = numpy_helper.load("output.npy", np.uint16)
+    expected = (np.arange(256, dtype=np.uint16) + np.uint16(5)).reshape(1, 16, 16, 1)
+
+    assert np.array_equal(result, expected)
 
 
 def test_two_spirv_shader_module_in_vgf_without_shader_substitution(

--- a/src/tests/vgf_view_tests.cpp
+++ b/src/tests/vgf_view_tests.cpp
@@ -20,9 +20,9 @@ namespace {
 
 class CapturingResourceCreator final : public IResourceCreator {
   public:
-    void createBuffer(Guid guid, const BufferInfo &info) override { buffers.push_back({guid, info}); }
-    void createTensor(Guid guid, const TensorInfo &info) override { tensors.push_back({guid, info}); }
-    void createImage(Guid guid, const ImageInfo &info) override { images.push_back({guid, info}); }
+    void createBuffer(Guid guid, BufferInfo info) override { buffers.push_back({guid, info}); }
+    void createTensor(Guid guid, TensorInfo info) override { tensors.push_back({guid, info}); }
+    void createImage(Guid guid, ImageInfo info) override { images.push_back({guid, info}); }
 
     std::vector<std::pair<Guid, BufferInfo>> buffers;
     std::vector<std::pair<Guid, TensorInfo>> tensors;

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -8,6 +8,8 @@
 #include "iresource.hpp"
 #include "utils.hpp"
 
+#include "vgf/vulkan_helpers.generated.hpp"
+
 #include <numeric>
 #include <optional>
 
@@ -78,6 +80,23 @@ std::optional<uint32_t> findModelInterfaceMrtIndex(const vgflib::ModelSequenceTa
     const auto mrtIndex = findInBindingSlots(decoder.getModelSequenceInputBindingSlotsHandle());
     return mrtIndex.has_value() ? mrtIndex : findInBindingSlots(decoder.getModelSequenceOutputBindingSlotsHandle());
 }
+
+ResourceIdType getResourceIdType(vgflib::DescriptorType descriptorType) {
+    switch (vk::DescriptorType(vgflib::ToVkDescriptorType(descriptorType))) {
+    case vk::DescriptorType::eUniformBuffer:
+    case vk::DescriptorType::eStorageBuffer:
+        return ResourceIdType::Buffer;
+    case vk::DescriptorType::eCombinedImageSampler:
+    case vk::DescriptorType::eStorageImage:
+        return ResourceIdType::Image;
+    case vk::DescriptorType::eTensorARM:
+        return ResourceIdType::Tensor;
+    default:
+        throw std::runtime_error("Resource type from VGF file not found");
+    }
+}
+
+Guid createVgfAliasGroupGuid(uint32_t aliasGroupId) { return Guid(std::to_string(aliasGroupId)); }
 
 } // namespace
 
@@ -287,6 +306,42 @@ std::vector<TypedBinding> VgfView::resolveBindings(uint32_t segmentIndex, const 
     return bindings;
 }
 
+std::vector<ResourceAlias> VgfView::getResourceAliases(const std::vector<TypedBinding> &externalBindings) const {
+    std::vector<ResourceAlias> aliases;
+
+    for (const auto &externalBinding : externalBindings) {
+        const auto mrtIndex = findModelInterfaceMrtIndex(*sequenceTableDecoder, externalBinding.id);
+        if (!mrtIndex.has_value()) {
+            continue;
+        }
+
+        const auto aliasGroupId = resourceTableDecoder->getAliasGroupId(*mrtIndex);
+        if (!aliasGroupId.has_value()) {
+            continue;
+        }
+
+        const auto type = resourceTableDecoder->getDescriptorType(*mrtIndex);
+        const auto descriptorType = type.value_or(DESCRIPTOR_TYPE_UNKNOWN);
+        aliases.push_back(
+            {createVgfAliasGroupGuid(*aliasGroupId), externalBinding.resourceRef, getResourceIdType(descriptorType)});
+    }
+
+    size_t numResources = resourceTableDecoder->size();
+    for (uint32_t resourceIndex = 0; resourceIndex < numResources; ++resourceIndex) {
+        auto resourceCategory = resourceTableDecoder->getCategory(resourceIndex);
+        if (resourceCategory == vgflib::ResourceCategory::INTERMEDIATE) {
+            auto guidStr = createResourceGuidStr(resourceIndex, resourceCategory);
+            const Guid guid(guidStr);
+            if (const auto aliasGroupId = resourceTableDecoder->getAliasGroupId(resourceIndex)) {
+                const auto type = resourceTableDecoder->getDescriptorType(resourceIndex);
+                const auto descriptorType = type.value_or(DESCRIPTOR_TYPE_UNKNOWN);
+                aliases.push_back({createVgfAliasGroupGuid(*aliasGroupId), guid, getResourceIdType(descriptorType)});
+            }
+        }
+    }
+    return aliases;
+}
+
 void VgfView::validateResource(const IResourceViewer &resourceViewer, uint32_t vgfMrtIndex) const {
     std::optional<vgflib::DescriptorType> expectedType = resourceTableDecoder->getDescriptorType(vgfMrtIndex);
     if (!expectedType.has_value()) {
@@ -367,7 +422,7 @@ void VgfView::createIntermediateResources(IResourceCreator &creator) const {
 
                 // Create Scenario Runner buffer resource
                 BufferInfo info{std::move(guidStr), expectedBufferSize};
-                creator.createBuffer(guid, info);
+                creator.createBuffer(guid, std::move(info));
             } break;
             case DESCRIPTOR_TYPE_TENSOR_ARM: {
                 auto format = resourceTableDecoder->getVkFormat(resourceIndex);
@@ -376,7 +431,7 @@ void VgfView::createIntermediateResources(IResourceCreator &creator) const {
                                        vk::Format(format), -1, false};
 
                 // Create Scenario Runner tensor
-                creator.createTensor(guid, info);
+                creator.createTensor(guid, std::move(info));
             } break;
             case DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
             case DESCRIPTOR_TYPE_STORAGE_IMAGE: {
@@ -392,7 +447,7 @@ void VgfView::createIntermediateResources(IResourceCreator &creator) const {
                 info.isSampled = (descriptorType == DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
                 info.isStorage = (descriptorType == DESCRIPTOR_TYPE_STORAGE_IMAGE);
 
-                creator.createImage(guid, info);
+                creator.createImage(guid, std::move(info));
             } break;
             default:
                 throw std::runtime_error("Unknown resource type: " + std::to_string(descriptorType) +

--- a/src/vgf_view.hpp
+++ b/src/vgf_view.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "iresource.hpp"
+#include "scenario_runner.hpp"
 #include "types.hpp"
 
 #include "vgf-utils/memory_map.hpp"
@@ -12,10 +13,17 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 namespace mlsdk::scenariorunner {
 
 class DataManager;
+
+struct ResourceAlias {
+    Guid group;
+    Guid resource;
+    ResourceIdType resourceType;
+};
 
 class VgfView {
   public:
@@ -42,6 +50,7 @@ class VgfView {
 
     std::vector<TypedBinding> resolveBindings(uint32_t segmentIndex, const DataManager &dataManager,
                                               const std::vector<TypedBinding> &externalBindings) const;
+    std::vector<ResourceAlias> getResourceAliases(const std::vector<TypedBinding> &externalBindings) const;
     void createIntermediateResources(IResourceCreator &creator) const;
 
   private:


### PR DESCRIPTION
Read alias group metadata from VGF model resources and register the corresponding scenario/VGF resources with the existing memory group manager before setup and allocation. Create VGF intermediates during resource setup so they follow the normal alias-aware lifecycle, including reuse of predeclared resources.

Change-Id: Ide10110bb9e970ac2b0e7782d8c00d5e4e1bfbeb