### PR TITLE
Apply VGF sampler config to intermediate sampled images

### DIFF
--- a/src/tests/vgf_view_tests.cpp
+++ b/src/tests/vgf_view_tests.cpp
@@ -12,6 +12,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
 
 using namespace mlsdk::scenariorunner;
 namespace vgflib = mlsdk::vgflib;
@@ -54,6 +55,37 @@ std::filesystem::path writeVgfWithIntermediateBuffer(vk::Format format, const st
     return vgfPath;
 }
 
+std::filesystem::path writeVgfWithSampledIntermediateImage(uint32_t addressModeU, uint32_t addressModeV) {
+    auto encoder = vgflib::CreateEncoder(123);
+
+    const std::vector<int64_t> shape{16, 16, 1, 1};
+    const auto module = encoder->AddModule(vgflib::ModuleType::COMPUTE, "sampled_image", "main");
+    const auto image =
+        encoder->AddIntermediateResource(vgflib::ToDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER),
+                                         vgflib::ToFormatType(VK_FORMAT_R8G8B8A8_UNORM), shape, {});
+    encoder->AddSamplerConfig(image, VK_FILTER_LINEAR, VK_FILTER_NEAREST, addressModeU, addressModeV,
+                              VK_BORDER_COLOR_INT_OPAQUE_WHITE);
+    const auto binding = encoder->AddBindingSlot(0, image);
+    const auto descriptorSet = encoder->AddDescriptorSetInfo(std::vector<vgflib::BindingSlotRef>{binding});
+
+    encoder->AddModelSequenceInputsOutputs({}, {}, {}, {});
+    encoder->AddSegmentInfo(module, "sampled_image_segment", std::vector<vgflib::DescriptorSetInfoRef>{descriptorSet},
+                            {}, std::vector<vgflib::BindingSlotRef>{binding}, {}, {1, 1, 1});
+    encoder->Finish();
+
+    const auto suffix = std::to_string(addressModeU) + "_" + std::to_string(addressModeV);
+    const auto vgfPath =
+        std::filesystem::temp_directory_path() / ("scenario_runner_vgf_view_sampled_image_" + suffix + ".vgf");
+    std::ofstream output(vgfPath, std::ios::binary);
+    if (!output) {
+        throw std::runtime_error("Failed to open temporary VGF file for writing");
+    }
+    if (!encoder->WriteTo(output)) {
+        throw std::runtime_error("Failed to write temporary VGF file");
+    }
+    return vgfPath;
+}
+
 } // namespace
 
 TEST(VgfView, IntermediateBufferSizeUsesVgfFormatElementSize) {
@@ -70,6 +102,54 @@ TEST(VgfView, IntermediateBufferSizeUsesVgfFormatElementSize) {
         EXPECT_EQ(creator.buffers.front().second.size, elementCount * sizeof(uint16_t));
         EXPECT_TRUE(creator.tensors.empty());
         EXPECT_TRUE(creator.images.empty());
+    } catch (...) {
+        std::filesystem::remove(vgfPath);
+        throw;
+    }
+    std::filesystem::remove(vgfPath);
+}
+
+TEST(VgfView, IntermediateSampledImageUsesVgfSamplerConfig) {
+    const auto vgfPath = writeVgfWithSampledIntermediateImage(VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+                                                              VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER);
+
+    try {
+        auto view = VgfView::createVgfView(vgfPath.string());
+        CapturingResourceCreator creator;
+
+        view.createIntermediateResources(creator);
+
+        ASSERT_EQ(creator.images.size(), 1);
+        const auto &samplerSettings = creator.images.front().second.samplerSettings;
+        EXPECT_EQ(samplerSettings.minFilter, FilterMode::Linear);
+        EXPECT_EQ(samplerSettings.magFilter, FilterMode::Nearest);
+        EXPECT_EQ(samplerSettings.borderAddressMode, AddressMode::ClampBorder);
+        EXPECT_EQ(samplerSettings.borderColor, BorderColor::IntOpaqueWhite);
+        EXPECT_EQ(samplerSettings.mipFilter, FilterMode::Nearest);
+        EXPECT_TRUE(creator.buffers.empty());
+        EXPECT_TRUE(creator.tensors.empty());
+    } catch (...) {
+        std::filesystem::remove(vgfPath);
+        throw;
+    }
+    std::filesystem::remove(vgfPath);
+}
+
+TEST(VgfView, IntermediateSampledImageRejectsDistinctVgfAddressModes) {
+    const auto vgfPath =
+        writeVgfWithSampledIntermediateImage(VK_SAMPLER_ADDRESS_MODE_REPEAT, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE);
+
+    try {
+        auto view = VgfView::createVgfView(vgfPath.string());
+        CapturingResourceCreator creator;
+
+        try {
+            view.createIntermediateResources(creator);
+            FAIL() << "Expected createIntermediateResources to reject distinct sampler U/V address modes";
+        } catch (const std::runtime_error &error) {
+            const std::string message = error.what();
+            EXPECT_NE(message.find("Distinct VGF sampler U/V address modes are not yet supported"), std::string::npos);
+        }
     } catch (...) {
         std::filesystem::remove(vgfPath);
         throw;

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -98,6 +98,103 @@ ResourceIdType getResourceIdType(vgflib::DescriptorType descriptorType) {
 
 Guid createVgfAliasGroupGuid(uint32_t aliasGroupId) { return Guid(std::to_string(aliasGroupId)); }
 
+std::runtime_error unsupportedVgfSamplerValue(const std::string &field, const std::string &value) {
+    return std::runtime_error("Unsupported VGF sampler " + field + ": " + value);
+}
+
+FilterMode vgfSamplerFilterToFilterMode(uint32_t filter) {
+    const auto vgfFilter = vgflib::ToFilterType(static_cast<VkFilter>(filter));
+    if (!vgflib::ValidateDecodedFilterType(vgfFilter)) {
+        throw unsupportedVgfSamplerValue("filter", vgflib::FilterTypeToName(vgfFilter));
+    }
+
+    const auto vkFilter = static_cast<vk::Filter>(vgflib::ToVkFilter(vgfFilter));
+    switch (vkFilter) {
+    case vk::Filter::eNearest:
+        return FilterMode::Nearest;
+    case vk::Filter::eLinear:
+        return FilterMode::Linear;
+    default:
+        throw unsupportedVgfSamplerValue("filter", vk::to_string(vkFilter));
+    }
+}
+
+AddressMode vgfSamplerAddressModeToAddressMode(uint32_t addressMode) {
+    const auto vgfAddressMode = vgflib::ToSamplerAddressModeType(static_cast<VkSamplerAddressMode>(addressMode));
+    if (!vgflib::ValidateDecodedSamplerAddressModeType(vgfAddressMode)) {
+        throw unsupportedVgfSamplerValue("address mode", vgflib::SamplerAddressModeTypeToName(vgfAddressMode));
+    }
+
+    const auto vkAddressMode = static_cast<vk::SamplerAddressMode>(vgflib::ToVkSamplerAddressMode(vgfAddressMode));
+    switch (vkAddressMode) {
+    case vk::SamplerAddressMode::eClampToBorder:
+        return AddressMode::ClampBorder;
+    case vk::SamplerAddressMode::eClampToEdge:
+        return AddressMode::ClampEdge;
+    case vk::SamplerAddressMode::eRepeat:
+        return AddressMode::Repeat;
+    case vk::SamplerAddressMode::eMirroredRepeat:
+        return AddressMode::MirroredRepeat;
+    default:
+        throw unsupportedVgfSamplerValue("address mode", vk::to_string(vkAddressMode));
+    }
+}
+
+BorderColor vgfBorderColorToBorderColor(uint32_t borderColor) {
+    const auto vgfBorderColor = vgflib::ToBorderColorType(static_cast<VkBorderColor>(borderColor));
+    if (!vgflib::ValidateDecodedBorderColorType(vgfBorderColor)) {
+        throw unsupportedVgfSamplerValue("border color", vgflib::BorderColorTypeToName(vgfBorderColor));
+    }
+
+    const auto vkBorderColor = static_cast<vk::BorderColor>(vgflib::ToVkBorderColor(vgfBorderColor));
+    switch (vkBorderColor) {
+    case vk::BorderColor::eFloatTransparentBlack:
+        return BorderColor::FloatTransparentBlack;
+    case vk::BorderColor::eFloatOpaqueBlack:
+        return BorderColor::FloatOpaqueBlack;
+    case vk::BorderColor::eFloatOpaqueWhite:
+        return BorderColor::FloatOpaqueWhite;
+    case vk::BorderColor::eIntTransparentBlack:
+        return BorderColor::IntTransparentBlack;
+    case vk::BorderColor::eIntOpaqueBlack:
+        return BorderColor::IntOpaqueBlack;
+    case vk::BorderColor::eIntOpaqueWhite:
+        return BorderColor::IntOpaqueWhite;
+    case vk::BorderColor::eFloatCustomEXT:
+        return BorderColor::FloatCustomEXT;
+    case vk::BorderColor::eIntCustomEXT:
+        return BorderColor::IntCustomEXT;
+    default:
+        throw unsupportedVgfSamplerValue("border color", vk::to_string(vkBorderColor));
+    }
+}
+
+void applyVgfSamplerConfigIfPresent(const vgflib::ModelResourceTableDecoder &decoder, uint32_t resourceIndex,
+                                    ImageInfo &info) {
+    const auto *const samplerConfigHandle = decoder.getSamplerConfigHandle(resourceIndex);
+    if (samplerConfigHandle == nullptr) {
+        return;
+    }
+
+    const auto addressModeU = decoder.getSamplerConfigAddressModeU(samplerConfigHandle);
+    const auto addressModeV = decoder.getSamplerConfigAddressModeV(samplerConfigHandle);
+    if (addressModeU != addressModeV) {
+        const auto vgfAddressModeU = vgflib::ToSamplerAddressModeType(static_cast<VkSamplerAddressMode>(addressModeU));
+        const auto vgfAddressModeV = vgflib::ToSamplerAddressModeType(static_cast<VkSamplerAddressMode>(addressModeV));
+        throw std::runtime_error("Distinct VGF sampler U/V address modes are not yet supported: address_mode_u=" +
+                                 vgflib::SamplerAddressModeTypeToName(vgfAddressModeU) +
+                                 ", address_mode_v=" + vgflib::SamplerAddressModeTypeToName(vgfAddressModeV));
+    }
+
+    info.samplerSettings.minFilter =
+        vgfSamplerFilterToFilterMode(decoder.getSamplerConfigMinFilter(samplerConfigHandle));
+    info.samplerSettings.magFilter =
+        vgfSamplerFilterToFilterMode(decoder.getSamplerConfigMagFilter(samplerConfigHandle));
+    info.samplerSettings.borderColor =
+        vgfBorderColorToBorderColor(decoder.getSamplerConfigBorderColor(samplerConfigHandle));
+    info.samplerSettings.borderAddressMode = vgfSamplerAddressModeToAddressMode(addressModeU);
+}
+
 } // namespace
 
 VgfView::VgfView(std::unique_ptr<MemoryMap> mapped, std::unique_ptr<vgflib::ModuleTableDecoder> moduleTableDecoder,
@@ -446,6 +543,9 @@ void VgfView::createIntermediateResources(IResourceCreator &creator) const {
                 info.mips = 1;
                 info.isSampled = (descriptorType == DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
                 info.isStorage = (descriptorType == DESCRIPTOR_TYPE_STORAGE_IMAGE);
+                if (descriptorType == DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
+                    applyVgfSamplerConfigIfPresent(*resourceTableDecoder, resourceIndex, info);
+                }
 
                 creator.createImage(guid, std::move(info));
             } break;


### PR DESCRIPTION
Map VGF sampler filter, address mode, and border color values into scenario-runner sampler settings for VGF-owned intermediate combined image samplers. Keep existing defaults when no sampler config is present.

Change-Id: I8c8e40c73fe76b515a1a9b779df52617b0a6567c