### PR TITLE
Support per-axis sampler address modes internally

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -233,13 +233,15 @@ void Image::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> mem
     trySetVkRaiiObjectDebugName(ctx, _image, _imageInfo.debugName);
 
     // Create image sampler
-    const auto borderAddressMode = convertSamplerAddressMode(_imageInfo.samplerSettings.borderAddressMode);
+    const auto addressModeU = convertSamplerAddressMode(_imageInfo.samplerSettings.addressModeU);
+    const auto addressModeV = convertSamplerAddressMode(_imageInfo.samplerSettings.addressModeV);
+    const auto addressModeW = convertSamplerAddressMode(_imageInfo.samplerSettings.addressModeW);
     const auto mipFilter = convertFilter(_imageInfo.samplerSettings.minFilter);
     const auto magFilter = convertFilter(_imageInfo.samplerSettings.magFilter);
     const auto mipMapMode = convertSamplerMipmapMode(_imageInfo.samplerSettings.mipFilter);
     const auto borderColor = convertBorderColor(_imageInfo.samplerSettings.borderColor);
-    vk::SamplerCreateInfo samplerCreateInfo(vk::SamplerCreateFlags(), mipFilter, magFilter, mipMapMode,
-                                            borderAddressMode, borderAddressMode, borderAddressMode,
+    vk::SamplerCreateInfo samplerCreateInfo(vk::SamplerCreateFlags(), mipFilter, magFilter, mipMapMode, addressModeU,
+                                            addressModeV, addressModeW,
                                             /*mipLodBias=*/0.0f, /*anisotropyEnable=*/false, /*maxAnisotropy=*/1.0f,
                                             /*compareEnable=*/false, vk::CompareOp::eNever, /*minLod=*/0.0f,
                                             /*maxLod=*/static_cast<float>(_imageInfo.mips - 1), borderColor);

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -207,7 +207,9 @@ struct ResourceInfoFactory {
             info.samplerSettings.mipFilter = image.mipFilter.value();
         }
         if (image.borderAddressMode) {
-            info.samplerSettings.borderAddressMode = image.borderAddressMode.value();
+            info.samplerSettings.addressModeU = image.borderAddressMode.value();
+            info.samplerSettings.addressModeV = image.borderAddressMode.value();
+            info.samplerSettings.addressModeW = image.borderAddressMode.value();
         }
         if (image.borderColor) {
             info.samplerSettings.borderColor = image.borderColor.value();

--- a/src/tests/vgf_view_tests.cpp
+++ b/src/tests/vgf_view_tests.cpp
@@ -123,7 +123,9 @@ TEST(VgfView, IntermediateSampledImageUsesVgfSamplerConfig) {
         const auto &samplerSettings = creator.images.front().second.samplerSettings;
         EXPECT_EQ(samplerSettings.minFilter, FilterMode::Linear);
         EXPECT_EQ(samplerSettings.magFilter, FilterMode::Nearest);
-        EXPECT_EQ(samplerSettings.borderAddressMode, AddressMode::ClampBorder);
+        EXPECT_EQ(samplerSettings.addressModeU, AddressMode::ClampBorder);
+        EXPECT_EQ(samplerSettings.addressModeV, AddressMode::ClampBorder);
+        EXPECT_EQ(samplerSettings.addressModeW, AddressMode::ClampEdge);
         EXPECT_EQ(samplerSettings.borderColor, BorderColor::IntOpaqueWhite);
         EXPECT_EQ(samplerSettings.mipFilter, FilterMode::Nearest);
         EXPECT_TRUE(creator.buffers.empty());
@@ -135,7 +137,7 @@ TEST(VgfView, IntermediateSampledImageUsesVgfSamplerConfig) {
     std::filesystem::remove(vgfPath);
 }
 
-TEST(VgfView, IntermediateSampledImageRejectsDistinctVgfAddressModes) {
+TEST(VgfView, IntermediateSampledImageAcceptsDistinctVgfAddressModes) {
     const auto vgfPath =
         writeVgfWithSampledIntermediateImage(VK_SAMPLER_ADDRESS_MODE_REPEAT, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE);
 
@@ -143,13 +145,13 @@ TEST(VgfView, IntermediateSampledImageRejectsDistinctVgfAddressModes) {
         auto view = VgfView::createVgfView(vgfPath.string());
         CapturingResourceCreator creator;
 
-        try {
-            view.createIntermediateResources(creator);
-            FAIL() << "Expected createIntermediateResources to reject distinct sampler U/V address modes";
-        } catch (const std::runtime_error &error) {
-            const std::string message = error.what();
-            EXPECT_NE(message.find("Distinct VGF sampler U/V address modes are not yet supported"), std::string::npos);
-        }
+        view.createIntermediateResources(creator);
+
+        ASSERT_EQ(creator.images.size(), 1);
+        const auto &samplerSettings = creator.images.front().second.samplerSettings;
+        EXPECT_EQ(samplerSettings.addressModeU, AddressMode::Repeat);
+        EXPECT_EQ(samplerSettings.addressModeV, AddressMode::ClampEdge);
+        EXPECT_EQ(samplerSettings.addressModeW, AddressMode::ClampEdge);
     } catch (...) {
         std::filesystem::remove(vgfPath);
         throw;

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -85,7 +85,9 @@ struct SamplerSettings {
     FilterMode minFilter = FilterMode::Nearest;
     FilterMode magFilter = FilterMode::Nearest;
     FilterMode mipFilter = FilterMode::Nearest;
-    AddressMode borderAddressMode = AddressMode::ClampEdge;
+    AddressMode addressModeU = AddressMode::ClampEdge;
+    AddressMode addressModeV = AddressMode::ClampEdge;
+    AddressMode addressModeW = AddressMode::ClampEdge;
     BorderColor borderColor = BorderColor::FloatTransparentBlack;
     CustomColorValue customBorderColor;
 };

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -178,13 +178,6 @@ void applyVgfSamplerConfigIfPresent(const vgflib::ModelResourceTableDecoder &dec
 
     const auto addressModeU = decoder.getSamplerConfigAddressModeU(samplerConfigHandle);
     const auto addressModeV = decoder.getSamplerConfigAddressModeV(samplerConfigHandle);
-    if (addressModeU != addressModeV) {
-        const auto vgfAddressModeU = vgflib::ToSamplerAddressModeType(static_cast<VkSamplerAddressMode>(addressModeU));
-        const auto vgfAddressModeV = vgflib::ToSamplerAddressModeType(static_cast<VkSamplerAddressMode>(addressModeV));
-        throw std::runtime_error("Distinct VGF sampler U/V address modes are not yet supported: address_mode_u=" +
-                                 vgflib::SamplerAddressModeTypeToName(vgfAddressModeU) +
-                                 ", address_mode_v=" + vgflib::SamplerAddressModeTypeToName(vgfAddressModeV));
-    }
 
     info.samplerSettings.minFilter =
         vgfSamplerFilterToFilterMode(decoder.getSamplerConfigMinFilter(samplerConfigHandle));
@@ -192,7 +185,8 @@ void applyVgfSamplerConfigIfPresent(const vgflib::ModelResourceTableDecoder &dec
         vgfSamplerFilterToFilterMode(decoder.getSamplerConfigMagFilter(samplerConfigHandle));
     info.samplerSettings.borderColor =
         vgfBorderColorToBorderColor(decoder.getSamplerConfigBorderColor(samplerConfigHandle));
-    info.samplerSettings.borderAddressMode = vgfSamplerAddressModeToAddressMode(addressModeU);
+    info.samplerSettings.addressModeU = vgfSamplerAddressModeToAddressMode(addressModeU);
+    info.samplerSettings.addressModeV = vgfSamplerAddressModeToAddressMode(addressModeV);
 }
 
 } // namespace


### PR DESCRIPTION
Extend internal sampler settings to track U, V, and W address modes separately while preserving the existing border_address_mode JSON behavior.

Map legacy JSON border_address_mode to all three axes, pass the separate modes into Vulkan sampler creation, and allow VGF sampler configs to use distinct U and V address modes.

Change-Id: I5bf048e7b2ecbca770dd050ef13b684d6875138c