### PR TITLE
Normalize scenario-runner version reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,14 @@ mlsdk_generate_version_header(
         ${SCENARIO_RUNNER_VERSION_DEPS}
 )
 
+get_filename_component(SCENARIO_RUNNER_VERSION_HEADER_DIR "${SCENARIO_RUNNER_VERSION_HEADER}" DIRECTORY)
+foreach(SCENARIO_RUNNER_VERSION_TARGET glslc dds_utils png_utils hlslc)
+    if(TARGET ${SCENARIO_RUNNER_VERSION_TARGET})
+        target_include_directories(${SCENARIO_RUNNER_VERSION_TARGET} PRIVATE "${SCENARIO_RUNNER_VERSION_HEADER_DIR}")
+    endif()
+endforeach()
+
 if(ANDROID)
-    get_filename_component(SCENARIO_RUNNER_VERSION_HEADER_DIR "${SCENARIO_RUNNER_VERSION_HEADER}" DIRECTORY)
     target_include_directories(scenario_runner_jni PRIVATE "${SCENARIO_RUNNER_VERSION_HEADER_DIR}")
 endif()
 

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2024, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -18,8 +18,14 @@ function(mlsdk_get_git_revision SRCDIR RETURN_GIT_REVISION)
         return()
     endif()
 
+    # Refresh cached stat metadata before describe so clean checkouts do not
+    # get a false -dirty suffix. Real local changes still report as dirty.
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --dirty --always --tag --broken
+        COMMAND ${GIT_EXECUTABLE} update-index -q --refresh
+        WORKING_DIRECTORY ${SRCDIR})
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --dirty --always --tag --broken --long
         WORKING_DIRECTORY ${SRCDIR}
         RESULT_VARIABLE GIT_RETURN_CODE
         OUTPUT_VARIABLE GIT_OUTPUT
@@ -57,7 +63,7 @@ function(mlsdk_generate_version_header)
         set(depVersionVar "${dep}_VERSION")
         set(depVersion "unknown")
 
-        if(${depVersionVar})
+        if(DEFINED ${depVersionVar})
             set(depVersion "${${depVersionVar}}")
         else()
             message(WARNING "Unable to get version for ${dep}: ${depVersionVar} is not set")

--- a/src/tools/dds_utils/main.cpp
+++ b/src/tools/dds_utils/main.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <argparse/argparse.hpp>
+#include <version.hpp>
 
 #include "dds_reader.hpp"
 #include "vgf-utils/numpy.hpp"
@@ -274,7 +275,7 @@ bool compare(const std::string &input, const std::string &output, const std::str
 
 int main(int argc, const char **argv) {
     try {
-        argparse::ArgumentParser parser(argv[0]);
+        argparse::ArgumentParser parser(argv[0], details::version);
 
         parser.add_argument("--action")
             .choices("generate", "to_npy", "compare")

--- a/src/tools/glslc/main.cpp
+++ b/src/tools/glslc/main.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <argparse/argparse.hpp>
+#include <version.hpp>
 
 #include "glsl_compiler.hpp"
 
@@ -15,7 +16,7 @@ using namespace mlsdk::scenariorunner;
 int main(int argc, const char **argv) {
 
     try {
-        argparse::ArgumentParser parser(argv[0]);
+        argparse::ArgumentParser parser(argv[0], details::version);
 
         parser.add_argument("--input").help("the GLSL file to be compiled to SPIR-V").required();
         parser.add_argument("--output").help("the SPIR-V output file").required();

--- a/src/tools/hlsl/main.cpp
+++ b/src/tools/hlsl/main.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <argparse/argparse.hpp>
+#include <version.hpp>
 
 #include "hlsl_compiler.hpp"
 
@@ -13,7 +14,7 @@ using namespace mlsdk::scenariorunner;
 int main(int argc, const char **argv) {
 
     try {
-        argparse::ArgumentParser parser(argv[0]);
+        argparse::ArgumentParser parser(argv[0], details::version);
 
         parser.add_argument("--input").help("the HLSL file to be compiled to SPIR-V").required();
         parser.add_argument("--output").help("the SPIR-V output file").required();

--- a/src/tools/png_utils/main.cpp
+++ b/src/tools/png_utils/main.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <version.hpp>
 
 #include "png_reader.hpp"
 #include "vgf-utils/numpy.hpp"
@@ -62,7 +63,7 @@ bool compare(const std::string &input, const std::string &output) {
 
 int main(int argc, const char **argv) {
     try {
-        argparse::ArgumentParser parser(argv[0]);
+        argparse::ArgumentParser parser(argv[0], details::version);
 
         parser.add_argument("--action")
             .choices("generate", "to_npy", "compare")


### PR DESCRIPTION
Refresh Git index metadata before `git describe --dirty` to avoid false dirty suffixes, and use long describe output for consistent tag version strings.

Use safer CMake dependency version variable lookup.

Wire the scenario-runner utility tools to the generated version header so `glslc`, `dds_utils`, `png_utils`, and `hlslc` report the same JSON version format as the main `scenario-runner` executable.