### PR TITLE
Avoid large VGF resource info copies

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -6,12 +6,14 @@
 #include "buffer.hpp"
 #include "utils.hpp"
 #include "vulkan_debug_utils.hpp"
+
 #include <iostream>
+#include <utility>
 
 namespace mlsdk::scenariorunner {
 
-Buffer::Buffer(const BufferInfo &bufferInfo)
-    : _size(bufferInfo.size), _debugName(bufferInfo.debugName), _memoryOffset(bufferInfo.memoryOffset) {}
+Buffer::Buffer(BufferInfo bufferInfo)
+    : _size(bufferInfo.size), _debugName(std::move(bufferInfo.debugName)), _memoryOffset(bufferInfo.memoryOffset) {}
 
 void Buffer::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> memoryManager) {
     _memoryManager = std::move(memoryManager);

--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -17,7 +17,7 @@ class Buffer {
     /// \brief Constructor
     ///
     /// \param bufferInfo buffer Information
-    explicit Buffer(const BufferInfo &bufferInfo);
+    explicit Buffer(BufferInfo bufferInfo);
     Buffer() = default;
 
     /// \brief Setup instance, assumes all aliasing objects have been constructed

--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -6,13 +6,21 @@
 #include "data_manager.hpp"
 #include "utils.hpp"
 
+#include <utility>
+
 namespace mlsdk::scenariorunner {
 
-void DataManager::createBuffer(Guid guid, const BufferInfo &info) { _buffers.insert({guid, Buffer(info)}); }
+void DataManager::createBuffer(Guid guid, const BufferInfo &info) { _buffers.emplace(guid, Buffer(info)); }
 
-void DataManager::createTensor(Guid guid, const TensorInfo &info) { _tensors.insert({guid, Tensor(info)}); }
+void DataManager::createBuffer(Guid guid, BufferInfo &&info) { _buffers.emplace(guid, Buffer(std::move(info))); }
 
-void DataManager::createImage(Guid guid, const ImageInfo &info) { _images.insert({guid, Image(info)}); }
+void DataManager::createTensor(Guid guid, const TensorInfo &info) { _tensors.emplace(guid, Tensor(info)); }
+
+void DataManager::createTensor(Guid guid, TensorInfo &&info) { _tensors.emplace(guid, Tensor(std::move(info))); }
+
+void DataManager::createImage(Guid guid, const ImageInfo &info) { _images.emplace(guid, Image(info)); }
+
+void DataManager::createImage(Guid guid, ImageInfo &&info) { _images.emplace(guid, Image(std::move(info))); }
 
 void DataManager::createVgfView(Guid guid, std::string src) {
     _vgfViews.insert({guid, VgfView::createVgfView(std::move(src))});

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -18,8 +18,11 @@ namespace mlsdk::scenariorunner {
 class DataManager {
   public:
     void createBuffer(Guid guid, const BufferInfo &info);
+    void createBuffer(Guid guid, BufferInfo &&info);
     void createTensor(Guid guid, const TensorInfo &info);
+    void createTensor(Guid guid, TensorInfo &&info);
     void createImage(Guid guid, const ImageInfo &info);
+    void createImage(Guid guid, ImageInfo &&info);
     void createRawData(Guid guid, const std::string &debugName, const std::string &src);
     void createVgfView(Guid guid, std::string src);
     void createImageBarrier(Guid guid, const ImageBarrierData &data);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -10,6 +10,7 @@
 #include "vulkan_debug_utils.hpp"
 
 #include <cmath>
+#include <utility>
 
 namespace mlsdk::scenariorunner {
 namespace {
@@ -143,6 +144,8 @@ uint32_t calculateMipDimension(uint32_t base, uint32_t level) {
 } // namespace
 
 Image::Image(const ImageInfo &imageInfo) : _imageInfo(imageInfo) {}
+
+Image::Image(ImageInfo &&imageInfo) : _imageInfo(std::move(imageInfo)) {}
 
 void Image::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> memoryManager) {
     _memoryManager = std::move(memoryManager);

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -18,6 +18,7 @@ class Image {
     ///
     /// \param imageInfo ImageInfo struct
     explicit Image(const ImageInfo &imageInfo);
+    explicit Image(ImageInfo &&imageInfo);
     Image() = default;
 
     /// \brief Setup instance, assumes all aliasing objects have been constructed

--- a/src/iresource.hpp
+++ b/src/iresource.hpp
@@ -17,9 +17,9 @@ class IResourceCreator {
     virtual ~IResourceCreator() = default;
 
     // Create buffer resource and setup and allocate memory in buffer
-    virtual void createBuffer(Guid guid, BufferInfo info) = 0;
-    virtual void createTensor(Guid guid, TensorInfo info) = 0;
-    virtual void createImage(Guid guid, ImageInfo info) = 0;
+    virtual void createBuffer(Guid guid, BufferInfo &&info) = 0;
+    virtual void createTensor(Guid guid, TensorInfo &&info) = 0;
+    virtual void createImage(Guid guid, ImageInfo &&info) = 0;
 };
 
 /// @brief Interface for accessing resources in an identifier agnostic way. Derived class handle the resource

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -388,20 +388,20 @@ class Creator final : public IResourceCreator {
     Creator(const Context &ctx, DataManager &dataManager, GroupManager &groupManager)
         : _ctx{ctx}, _dataManager{dataManager}, _groupManager{groupManager} {}
 
-    void createBuffer(Guid guid, BufferInfo info) override {
-        _dataManager.createBuffer(guid, info);
+    void createBuffer(Guid guid, BufferInfo &&info) override {
+        _dataManager.createBuffer(guid, std::move(info));
         _createdResources.push_back({guid, ResourceIdType::Buffer});
     }
 
-    void createTensor(Guid guid, TensorInfo info) override {
+    void createTensor(Guid guid, TensorInfo &&info) override {
         info.isAliasedWithImage = _groupManager.hasAliasOfType(guid, ResourceIdType::Image);
-        _dataManager.createTensor(guid, info);
+        _dataManager.createTensor(guid, std::move(info));
         _createdResources.push_back({guid, ResourceIdType::Tensor});
     }
 
-    void createImage(Guid guid, ImageInfo info) override {
+    void createImage(Guid guid, ImageInfo &&info) override {
         info.isAliased = _groupManager.isAliased(guid);
-        _dataManager.createImage(guid, info);
+        _dataManager.createImage(guid, std::move(info));
         _createdResources.push_back({guid, ResourceIdType::Image});
     }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -8,6 +8,8 @@
 #include "utils.hpp"
 #include "vulkan_debug_utils.hpp"
 
+#include <utility>
+
 namespace mlsdk::scenariorunner {
 namespace {
 constexpr vk::TensorTilingARM convertTiling(const Tiling tiling) {
@@ -23,8 +25,8 @@ constexpr vk::TensorTilingARM convertTiling(const Tiling tiling) {
 
 } // namespace
 
-Tensor::Tensor(const TensorInfo &tensorInfo)
-    : _debugName(tensorInfo.debugName), _shape(tensorInfo.shape), _dataType(tensorInfo.format),
+Tensor::Tensor(TensorInfo tensorInfo)
+    : _debugName(std::move(tensorInfo.debugName)), _shape(std::move(tensorInfo.shape)), _dataType(tensorInfo.format),
       _tiling(convertTiling(tensorInfo.tiling)), _memoryOffset(tensorInfo.memoryOffset),
       _isAliasedWithImage(tensorInfo.isAliasedWithImage),
       _descriptorBufferCaptureReplay(tensorInfo.descriptorBufferCaptureReplay) {}

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -17,7 +17,7 @@ class Tensor {
     /// \brief Constructor
     ///
     /// \param tensorInfo             Tensor info
-    explicit Tensor(const TensorInfo &tensorInfo);
+    explicit Tensor(TensorInfo tensorInfo);
     Tensor() = default;
 
     /// \brief Setup instance, assumes all aliasing objects have been constructed

--- a/src/tests/vgf_view_tests.cpp
+++ b/src/tests/vgf_view_tests.cpp
@@ -26,9 +26,9 @@ namespace {
 
 class CapturingResourceCreator final : public IResourceCreator {
   public:
-    void createBuffer(Guid guid, BufferInfo info) override { buffers.push_back({guid, info}); }
-    void createTensor(Guid guid, TensorInfo info) override { tensors.push_back({guid, info}); }
-    void createImage(Guid guid, ImageInfo info) override { images.push_back({guid, info}); }
+    void createBuffer(Guid guid, BufferInfo &&info) override { buffers.push_back({guid, std::move(info)}); }
+    void createTensor(Guid guid, TensorInfo &&info) override { tensors.push_back({guid, std::move(info)}); }
+    void createImage(Guid guid, ImageInfo &&info) override { images.push_back({guid, std::move(info)}); }
 
     std::vector<std::pair<Guid, BufferInfo>> buffers;
     std::vector<std::pair<Guid, TensorInfo>> tensors;


### PR DESCRIPTION
Consume VGF-created resource info structs by rvalue reference in IResourceCreator and forward them through DataManager with rvalue overloads. This removes the large ImageInfo pass-by-value path while preserving const-reference creation for existing lvalue callers.

Keep the final Buffer and Tensor constructors by value so clang-tidy does not flag rvalue-reference parameters that are only partially moved from.