### PR TITLE
Save pipeline cache before dispatching commands

### DIFF
--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -939,6 +939,10 @@ void Scenario::setupCommands() {
             throw std::runtime_error("Unknown CommandType in commands");
         }
     }
+    if (_pipelineCache) {
+        PerfCounterGuard guard(_perfCounters, "Save Pipeline Cache (setup)", "Save Pipeline Cache", false);
+        _pipelineCache->save();
+    }
     // Setup profiling
     if (!_opts.profilingPath.empty() && nQueries != 0) {
         mlsdk::logging::info("Setup profiling");

--- a/src/tests/test_pipeline_cache.py
+++ b/src/tests/test_pipeline_cache.py
@@ -35,7 +35,15 @@ def test_enable_pipeline_cache(sdk_tools, resources_helper, numpy_helper, capfd)
     captured = capfd.readouterr()
     assert "[Scenario-Runner] INFO: Pipeline Cache cleared" not in captured.out
     assert "[Scenario-Runner] INFO: Pipeline Cache loaded" not in captured.out
-    assert "[Scenario-Runner] INFO: Pipeline Cache stored" in captured.out
+
+    first_store_idx = captured.out.find("[Scenario-Runner] INFO: Pipeline Cache stored")
+    first_dispatch_idx = captured.out.find("[Scenario-Runner] INFO: Dispatch compute")
+    assert (
+        first_store_idx != -1
+        and first_dispatch_idx != -1
+        and first_store_idx < first_dispatch_idx
+    )
+    assert captured.out.count("[Scenario-Runner] INFO: Pipeline Cache stored") == 2
 
     result_first = numpy_helper.load("outBufferAdd2.npy", np.float32)
     assert np.array_equal(result_first, input1 + input2 + input2)
@@ -58,7 +66,7 @@ def test_enable_pipeline_cache(sdk_tools, resources_helper, numpy_helper, capfd)
     captured = capfd.readouterr()
     assert "[Scenario-Runner] INFO: Pipeline Cache cleared" not in captured.out
     assert "[Scenario-Runner] INFO: Pipeline Cache loaded" in captured.out
-    assert "[Scenario-Runner] INFO: Pipeline Cache stored" in captured.out
+    assert captured.out.count("[Scenario-Runner] INFO: Pipeline Cache stored") == 2
 
     result_second = numpy_helper.load("outBufferAdd2.npy", np.float32)
     assert np.array_equal(result_second, result_first)
@@ -83,7 +91,7 @@ def test_enable_pipeline_cache(sdk_tools, resources_helper, numpy_helper, capfd)
     captured = capfd.readouterr()
     assert "[Scenario-Runner] INFO: Pipeline Cache cleared" in captured.out
     assert "[Scenario-Runner] INFO: Pipeline Cache loaded" not in captured.out
-    assert "[Scenario-Runner] INFO: Pipeline Cache stored" in captured.out
+    assert captured.out.count("[Scenario-Runner] INFO: Pipeline Cache stored") == 2
 
     result_third = numpy_helper.load("outBufferAdd2.npy", np.float32)
     assert np.array_equal(result_third, result_first)
@@ -93,6 +101,37 @@ def test_enable_pipeline_cache(sdk_tools, resources_helper, numpy_helper, capfd)
 
     cache_data_third = files[0].read_bytes()
     assert len(cache_data_third) > 0
+
+
+def test_pipeline_cache_dry_run_precompiles(
+    sdk_tools, resources_helper, numpy_helper, capfd
+):
+    numpy_helper.generate([10], dtype=np.float32, filename="inBufferA.npy")
+    numpy_helper.generate([10], dtype=np.float32, filename="inBufferB.npy")
+
+    sdk_tools.compile_shader("test_shader/add_shader.comp", {"TestType": "float"})
+
+    cache_path = resources_helper.get_testenv_path("pipeline_cache_dry_run")
+    cache_path.mkdir()
+
+    sdk_tools.run_scenario(
+        "test_pipeline_cache/enable_pipeline_cache.json",
+        options=[
+            "--pipeline-caching",
+            "--cache-path",
+            cache_path,
+            "--dry-run",
+        ],
+    )
+
+    captured = capfd.readouterr()
+    assert captured.out.count("[Scenario-Runner] INFO: Pipeline Cache stored") == 2
+    assert "[Scenario-Runner] INFO: Dispatch compute" not in captured.out
+    assert not (resources_helper.get_testenv_path() / "outBufferAdd2.npy").exists()
+
+    files = list(cache_path.iterdir())
+    assert len(files) == 1 and files[0].suffix == ".cache"
+    assert files[0].stat().st_size > 0
 
 
 def test_incorrect_pipeline_cache(sdk_tools, resources_helper, numpy_helper, capfd):


### PR DESCRIPTION
Enable the scenario runner such that it can save a pipeline cache immediately after pipeline creation.
