### PR TITLE
Add command names to profiling output

### DIFF
--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -272,7 +272,7 @@ void Compute::_registerPipelineFencedCommon(const DataManager &dataManager, cons
 
 void Compute::registerPipelineFenced(const DataManager &dataManager, const std::vector<TypedBinding> &bindings,
                                      const char *pushConstantData, size_t pushConstantSize, bool implicitBarriers,
-                                     ComputeDispatch computeDispatch,
+                                     const ComputeDispatch &computeDispatch,
                                      std::optional<OpticalFlowDispatchInfo> opticalFlowDispatchInfo) {
     _registerPipelineFencedCommon(dataManager, bindings, pushConstantData, pushConstantSize);
     _addDispatch(computeDispatch, opticalFlowDispatchInfo);
@@ -320,7 +320,7 @@ void Compute::_addDispatch(const ComputeDispatch &computeDispatch,
                            const std::optional<OpticalFlowDispatchInfo> &dispatchInfo) {
     const auto &pipeline = _pipelines.back();
     if (pipeline.isDataGraphPipeline()) {
-        DataGraphDispatch dispatch{pipeline.session(), std::nullopt};
+        DataGraphDispatch dispatch{pipeline.session(), std::nullopt, pipeline.debugName()};
         if (dispatchInfo.has_value()) {
             dispatch.dispatchInfo = dispatchInfo;
         }
@@ -331,7 +331,7 @@ void Compute::_addDispatch(const ComputeDispatch &computeDispatch,
 }
 
 void Compute::_addGraphicsDispatch(const GraphicsDispatchInfo &graphicsDispatch) {
-    _commands.emplace_back(GraphicsDispatch{graphicsDispatch});
+    _commands.emplace_back(GraphicsDispatch{graphicsDispatch, _pipelines.back().debugName()});
 }
 
 void Compute::_addImplicitBarriers() {
@@ -669,20 +669,23 @@ void Compute::writeProfilingFile(const std::filesystem::path &profilingPath, int
     std::vector<uint64_t> timestamps = _queryTimestamps();
     VkPhysicalDeviceLimits physicalDeviceLimits = _ctx.physicalDevice().getProperties().limits;
     float timestampPeriod = physicalDeviceLimits.timestampPeriod;
-    std::vector<std::string> profiledCommands;
+    std::vector<ProfiledCommand> profiledCommands;
     for (const auto &command : _commands) {
         if (std::holds_alternative<ComputeDispatch>(command)) {
-            profiledCommands.push_back("ComputeDispatch");
+            const auto &dispatch = std::get<ComputeDispatch>(command);
+            profiledCommands.push_back({"ComputeDispatch", dispatch.profileName});
         } else if (std::holds_alternative<DataGraphDispatch>(command)) {
-            profiledCommands.push_back("DataGraphDispatch");
+            const auto &dispatch = std::get<DataGraphDispatch>(command);
+            profiledCommands.push_back({"DataGraphDispatch", dispatch.profileName});
         } else if (std::holds_alternative<GraphicsDispatch>(command)) {
-            profiledCommands.push_back("GraphicsDispatch");
+            const auto &dispatch = std::get<GraphicsDispatch>(command);
+            profiledCommands.push_back({"GraphicsDispatch", dispatch.profileName});
         }
     }
-    std::vector<uint64_t> memoryUsages;
+    std::vector<ProfiledMemoryUsage> memoryUsages;
     for (const auto &pipeline : _pipelines) {
         if (pipeline.isDataGraphPipeline()) {
-            memoryUsages.push_back(pipeline.getDataGraphPipelineMemoryRequirement());
+            memoryUsages.push_back({pipeline.debugName(), pipeline.getDataGraphPipelineMemoryRequirement()});
         }
     }
     writeProfilingData(timestamps, timestampPeriod, profiledCommands, memoryUsages, profilingPath, iteration,

--- a/src/compute.hpp
+++ b/src/compute.hpp
@@ -32,15 +32,25 @@ struct MarkBoundaryData {
     std::vector<Guid> tensors;
 };
 
+/// \brief Image attachment used by a graphics dispatch
 struct GraphicsDispatchAttachment {
     vk::ImageView view;
     vk::Image image;
     vk::ImageLayout layout;
 };
 
+/// \brief Attachment and extent information for a graphics dispatch
 struct GraphicsDispatchInfo {
     std::vector<GraphicsDispatchAttachment> colorAttachments;
     vk::Extent2D extent;
+};
+
+/// \brief Group count for x, y and z
+struct ComputeDispatch {
+    uint32_t gwcx{1};
+    uint32_t gwcy{1};
+    uint32_t gwcz{1};
+    std::string profileName;
 };
 
 /// @brief Compute command orchestrator
@@ -121,7 +131,7 @@ class Compute {
     /// \param opticalFlowDispatchInfo (Optional) Optical flow dispatch info (optical flow flags, mean flow hint).
     void registerPipelineFenced(const DataManager &dataManager, const std::vector<TypedBinding> &bindings,
                                 const char *pushConstantData, size_t pushConstantSize, bool implicitBarriers,
-                                ComputeDispatch computeDispatch = {},
+                                const ComputeDispatch &computeDispatch = {},
                                 std::optional<OpticalFlowDispatchInfo> opticalFlowDispatchInfo = std::nullopt);
     void registerPipelineFenced(const DataManager &dataManager, const std::vector<TypedBinding> &bindings,
                                 const char *pushConstantData, size_t pushConstantSize, bool implicitBarriers,
@@ -184,6 +194,7 @@ class Compute {
     struct DataGraphDispatch {
         vk::DataGraphPipelineSessionARM session{nullptr};
         std::optional<OpticalFlowDispatchInfo> dispatchInfo;
+        std::string profileName;
     };
 
     struct MemoryBarrier {
@@ -217,6 +228,7 @@ class Compute {
 
     struct GraphicsDispatch {
         GraphicsDispatchInfo info;
+        std::string profileName;
     };
 
     using Command =

--- a/src/json_writer.cpp
+++ b/src/json_writer.cpp
@@ -17,18 +17,19 @@ json _profilingDataJsonOutput;
 
 struct CommandTimestamps {
     CommandTimestamps() = default;
-    CommandTimestamps(const std::string &commandType, const std::vector<uint64_t> &commandTimestamps,
+    CommandTimestamps(const ProfiledCommand &command, const std::vector<uint64_t> &commandTimestamps,
                       const float timestampPeriod, const int iteration = 1)
-        : type(commandType), timestamps(commandTimestamps), period(timestampPeriod), iteration(iteration) {}
+        : command(command), timestamps(commandTimestamps), period(timestampPeriod), iteration(iteration) {}
 
-    std::string type;
+    ProfiledCommand command;
     std::vector<uint64_t> timestamps;
     float period{};
     int iteration{};
 };
 
 void to_json(json &j, const CommandTimestamps &commandTimestamps) {
-    j = json{{"Command type", commandTimestamps.type},
+    j = json{{"Command type", commandTimestamps.command.type},
+             {"Command name", commandTimestamps.command.name},
              {"Cycle count before command", commandTimestamps.timestamps[0]},
              {"Cycle count after command", commandTimestamps.timestamps[1]},
              {"Cycle count for command", commandTimestamps.timestamps[1] - commandTimestamps.timestamps[0]},
@@ -95,8 +96,9 @@ void writePerfCounters(std::vector<PerformanceCounter> &perfCounters, std::files
 }
 
 void writeProfilingData(const std::vector<uint64_t> &timestamps, const float timestampPeriod,
-                        const std::vector<std::string> &profiledCommands, const std::vector<uint64_t> &memoryUsages,
-                        const std::filesystem::path &path, const int iteration, const int repeatCount) {
+                        const std::vector<ProfiledCommand> &profiledCommands,
+                        const std::vector<ProfiledMemoryUsage> &memoryUsages, const std::filesystem::path &path,
+                        const int iteration, const int repeatCount) {
     if (profiledCommands.size() * 2 != timestamps.size()) {
         throw std::runtime_error("Cannot map all timestamps to their respective commands");
     }
@@ -106,7 +108,8 @@ void writeProfilingData(const std::vector<uint64_t> &timestamps, const float tim
     }
     for (size_t idx = 0; idx < memoryUsages.size(); ++idx) {
         _profilingDataJsonOutput["Memory Usage"] += {{"Command type", "DataGraphDispatch"},
-                                                     {"Session memory [bytes]", memoryUsages[idx]},
+                                                     {"Command name", memoryUsages[idx].commandName},
+                                                     {"Session memory [bytes]", memoryUsages[idx].sessionMemoryBytes},
                                                      {"Iteration", iteration}};
     }
     // Check if this is the last iteration

--- a/src/json_writer.hpp
+++ b/src/json_writer.hpp
@@ -6,15 +6,27 @@
 
 #include "perf_counter.hpp"
 
+#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <vector>
 
 namespace mlsdk::scenariorunner {
 
+struct ProfiledCommand {
+    std::string type;
+    std::string name;
+};
+
+struct ProfiledMemoryUsage {
+    std::string commandName;
+    uint64_t sessionMemoryBytes{};
+};
+
 void writePerfCounters(std::vector<PerformanceCounter> &perfCounters, std::filesystem::path &path);
 
 void writeProfilingData(const std::vector<uint64_t> &timestamps, float timestampPeriod,
-                        const std::vector<std::string> &profiledCommands, const std::vector<uint64_t> &memoryUsages,
-                        const std::filesystem::path &path, int iteration, int repeatCount);
+                        const std::vector<ProfiledCommand> &profiledCommands,
+                        const std::vector<ProfiledMemoryUsage> &memoryUsages, const std::filesystem::path &path,
+                        int iteration, int repeatCount);
 } // namespace mlsdk::scenariorunner

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -463,6 +463,7 @@ struct CommandDataFactory {
         data.computeDispatch.gwcx = dispatchCompute.rangeND[0];
         data.computeDispatch.gwcy = dispatchCompute.rangeND[1];
         data.computeDispatch.gwcz = dispatchCompute.rangeND[2];
+        data.computeDispatch.profileName = dispatchCompute.debugName;
         data.shaderRef = dispatchCompute.shaderRef;
         data.implicitBarrier = dispatchCompute.implicitBarrier;
         data.pushDataRef = dispatchCompute.pushDataRef;
@@ -1290,7 +1291,8 @@ void Scenario::createOpticalFlowPipeline(const DispatchOpticalFlowData &dispatch
 void Scenario::createPipeline(const uint32_t segmentIndex, const std::vector<TypedBinding> &sequenceBindings,
                               const VgfView &vgfView, const DispatchDataGraphData &dispatchDataGraph,
                               uint32_t &nQueries) {
-    const Compute::PipelineCreateArguments args{dispatchDataGraph.debugName, sequenceBindings, _pipelineCache};
+    const auto profileName = dispatchDataGraph.debugName + "/" + vgfView.getSegmentName(segmentIndex);
+    const Compute::PipelineCreateArguments args{profileName, sequenceBindings, _pipelineCache};
     switch (vgfView.getSegmentType(segmentIndex)) {
     case ModuleType::GRAPH: {
         _compute.createPipeline(args, segmentIndex, vgfView, _dataManager, _opts.shouldDumpNeuralStatistics(),
@@ -1349,7 +1351,7 @@ void Scenario::createPipeline(const uint32_t segmentIndex, const std::vector<Typ
         auto dispatchShape = vgfView.getDispatchShape(segmentIndex);
         _compute.registerWriteTimestamp(nQueries++, vk::PipelineStageFlagBits2::eComputeShader);
         _compute.registerPipelineFenced(_dataManager, sequenceBindings, nullptr, 0, dispatchDataGraph.implicitBarrier,
-                                        {dispatchShape[0], dispatchShape[1], dispatchShape[2]});
+                                        {dispatchShape[0], dispatchShape[1], dispatchShape[2], profileName});
         _compute.registerWriteTimestamp(nQueries++, vk::PipelineStageFlagBits2::eComputeShader);
         mlsdk::logging::debug("Shader Pipeline: " + vgfView.getModuleName(segmentIndex) + " created");
     } break;

--- a/src/tests/test_repeated_runs.py
+++ b/src/tests/test_repeated_runs.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import io
+import json
 import os
 
 import numpy as np
@@ -143,7 +144,32 @@ def test_conv2d_vgf_count(sdk_tools, resources_helper, numpy_helper):
     input = numpy_helper.generate(
         [1, 16, 16, 16], dtype=np.int8, filename="conv2dInput.npy"
     )
-    sdk_tools.run_scenario("test_vgf_graph/conv2d.json", options=["--repeat", "2"])
+    dump_path = os.path.join(os.getcwd(), "conv2dProfilingTest.json")
+    sdk_tools.run_scenario(
+        "test_vgf_graph/conv2d.json",
+        options=["--repeat", "2", "--profiling-dump-path", dump_path],
+    )
+
+    with open(dump_path, encoding="utf-8") as dump_file:
+        profiling_data = json.load(dump_file)
+
+    expected_command_name = "graph_ref/conv2d_graph_segment"
+    timestamps = profiling_data["Timestamps"]
+    memory_usages = profiling_data["Memory Usage"]
+    assert len(timestamps) == 2
+    assert len(memory_usages) == 2
+    assert all(
+        timestamp["Command type"] == "DataGraphDispatch"
+        and timestamp["Command name"] == expected_command_name
+        for timestamp in timestamps
+    )
+    assert all(
+        memory_usage["Command name"] == expected_command_name
+        for memory_usage in memory_usages
+    )
+
+    if os.path.exists(dump_path):
+        os.remove(dump_path)
 
 
 def test_enable_pipeline_cache_repeat_run(

--- a/src/tests/test_vgf_shader.py
+++ b/src/tests/test_vgf_shader.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import io
+import json
 import subprocess
 
 import numpy as np
@@ -625,7 +626,24 @@ def test_two_spirv_shader_module_in_vgf_with_shader_substitution(
         [1024], dtype=np.uint8, filename="input.npy", data=[42] * 1024
     )
 
-    sdk_tools.run_scenario("test_vgf_shader/two_shader_module.json")
+    dump_path = resources_helper.get_testenv_path("two_shader_module_profiling.json")
+    sdk_tools.run_scenario(
+        "test_vgf_shader/two_shader_module.json",
+        options=["--profiling-dump-path", dump_path.as_posix()],
+    )
+
+    with open(dump_path, encoding="utf-8") as dump_file:
+        profiling_data = json.load(dump_file)
+
+    timestamps = profiling_data["Timestamps"]
+    assert [timestamp["Command type"] for timestamp in timestamps] == [
+        "ComputeDispatch",
+        "ComputeDispatch",
+    ]
+    assert [timestamp["Command name"] for timestamp in timestamps] == [
+        "vgfGraph/shader_segment0",
+        "vgfGraph/shader_segment1",
+    ]
 
     result = numpy_helper.load("output.npy", np.uint8)
     assert np.array_equal(result, np.add(input, 3))

--- a/src/tests/vulkan_startup_tests.cpp
+++ b/src/tests/vulkan_startup_tests.cpp
@@ -114,7 +114,8 @@ void runShader(const ScenarioOptions &scenarioOptions) {
     shaderInfo.shaderType = ShaderType::SPIR_V;
     compute.createPipeline(args, shaderInfo);
     bool implicitBarriers = true;
-    compute.registerPipelineFenced(dataManager, bindings, nullptr, 0, implicitBarriers, {numElements, 1, 1});
+    compute.registerPipelineFenced(dataManager, bindings, nullptr, 0, implicitBarriers,
+                                   {numElements, 1, 1, "test_pipeline"});
 
     // Run and wait on fence
     compute.submitAndWaitOnFence();

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -169,11 +169,4 @@ struct ShaderInfo {
     std::vector<std::string> includeDirs;
 };
 
-/// \brief Group count for x, y and z
-struct ComputeDispatch {
-    uint32_t gwcx{1};
-    uint32_t gwcy{1};
-    uint32_t gwcz{1};
-};
-
 } // namespace mlsdk::scenariorunner

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -292,6 +292,14 @@ ModuleType VgfView::getSegmentType(uint32_t segmentIndex) const {
     }
 }
 
+std::string VgfView::getSegmentName(uint32_t segmentIndex) const {
+    std::string segmentName(sequenceTableDecoder->getSegmentName(segmentIndex));
+    if (!segmentName.empty()) {
+        return segmentName;
+    }
+    return "segment_" + std::to_string(segmentIndex);
+}
+
 bool VgfView::hasSPVModule(uint32_t segmentIndex) const {
     uint32_t moduleIndex = sequenceTableDecoder->getSegmentModuleIndex(segmentIndex);
     return moduleTableDecoder->hasSPIRVCode(moduleIndex);

--- a/src/vgf_view.hpp
+++ b/src/vgf_view.hpp
@@ -33,6 +33,7 @@ class VgfView {
 
     size_t getNumSegments() const;
     ModuleType getSegmentType(uint32_t segmentIndex) const;
+    std::string getSegmentName(uint32_t segmentIndex) const;
 
     bool hasSPVModule(uint32_t segmentIndex) const;
     bool hasGLSLModule(uint32_t segmentIndex) const;


### PR DESCRIPTION
Include the recorded command name in profiling timestamp entries. For data graph pipelines, also include the command name in memory usage entries.

Change-Id: I2891e2d3e246cb98d20566390b17493cfc8fac33