### PR TITLE
fix: Handle fail on cache miss for all pipeline types

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,14 @@
  - Updated Scenario Runner `--version` output to report the package version and include git revision and dependency revision information.
  - Added KosmicKrisp support on Darwin.
 
+## Unreleased
+
+### Bug Fixes
+
+- Enforce fail-on-pipeline-cache-miss for all pipeline types. Cache miss detection
+  has also been extended to check pipeline creation feedback, in addition to
+  compile required.
+
 ## Version 0.10.0 – *Optical Flow, VGF Runtime & APK Packaging*
 
 ### Optical Flow Task API

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -36,6 +36,15 @@ bool makePipelineRobustnessCreateInfo(const Context &ctx, vk::PipelineRobustness
     return true;
 }
 
+void throwOnPipelineCacheMiss(const vk::raii::Pipeline &pipeline, const std::shared_ptr<PipelineCache> &pipelineCache,
+                              const std::string &pipelineName) {
+    if (pipelineCache && pipelineCache->failOnCacheMiss() &&
+        (!pipelineCache->wasPipelineCacheHit() ||
+         pipeline.getConstructorSuccessCode() == vk::Result::ePipelineCompileRequired)) {
+        throw std::runtime_error("Pipeline cache miss for pipeline: " + pipelineName);
+    }
+}
+
 vk::raii::ShaderModule createShaderModuleFromCode(const Context &ctx, const uint32_t *spvCode, const size_t spvSize) {
     const vk::ShaderModuleCreateInfo shaderCreateInfo({}, spvSize * sizeof(uint32_t), spvCode);
     return vk::raii::ShaderModule(ctx.device(), shaderCreateInfo);
@@ -195,7 +204,7 @@ void Pipeline::computePipelineCommon(const Context &ctx, const ShaderInfo &shade
         if (pipelineCache->failOnCacheMiss()) {
             flags |= vk::PipelineCreateFlagBits::eFailOnPipelineCompileRequired;
         }
-        pNext = pipelineCache->getCacheFeedbackCreateInfo();
+        pNext = pipelineCache->getCacheFeedbackCreateInfo(_type);
         vkPipelineCache = pipelineCache->get();
     }
 
@@ -206,11 +215,7 @@ void Pipeline::computePipelineCommon(const Context &ctx, const ShaderInfo &shade
         insertAfter(&computePipelineCreateInfo, &pipelineRobustnessInfo);
     }
     _pipeline = vk::raii::Pipeline(ctx.device(), vkPipelineCache, computePipelineCreateInfo);
-
-    if (pipelineCache && pipelineCache->failOnCacheMiss() &&
-        _pipeline.getConstructorSuccessCode() == vk::Result::ePipelineCompileRequired) {
-        throw std::runtime_error("Pipeline cache miss for pipeline: " + shaderInfo.debugName);
-    }
+    throwOnPipelineCacheMiss(_pipeline, pipelineCache, shaderInfo.debugName);
 
     trySetVkRaiiObjectDebugName(ctx, _pipeline, _debugName);
 }
@@ -313,12 +318,14 @@ void Pipeline::graphicsPipelineCommon(const Context &ctx, const ShaderInfo &vert
         if (pipelineCache->failOnCacheMiss()) {
             flags |= vk::PipelineCreateFlagBits::eFailOnPipelineCompileRequired;
         }
-        insertAfter(&renderingInfo, pipelineCache->getCacheFeedbackCreateInfo());
+        insertAfter(&renderingInfo, pipelineCache->getCacheFeedbackCreateInfo(_type));
         vkPipelineCache = pipelineCache->get();
     }
     graphicsPipelineCreateInfo.flags = flags;
 
     _pipeline = vk::raii::Pipeline(ctx.device(), vkPipelineCache, graphicsPipelineCreateInfo);
+    throwOnPipelineCacheMiss(_pipeline, pipelineCache, _debugName);
+
     trySetVkRaiiObjectDebugName(ctx, _pipeline, _debugName);
 }
 
@@ -503,7 +510,7 @@ Pipeline::Pipeline(const CommonArguments &args, const DataManager &dataManager, 
         if (args.pipelineCache->failOnCacheMiss()) {
             flags2 |= vk::PipelineCreateFlagBits2KHR::eFailOnPipelineCompileRequired;
         }
-        insertAfter(&opticalFlowCreateInfo, args.pipelineCache->getCacheFeedbackCreateInfo());
+        insertAfter(&opticalFlowCreateInfo, args.pipelineCache->getCacheFeedbackCreateInfo(_type));
         vkPipelineCache = args.pipelineCache->get();
     }
 
@@ -515,6 +522,7 @@ Pipeline::Pipeline(const CommonArguments &args, const DataManager &dataManager, 
     pipelineCreateInfo.setPNext(&singleNodeInfo);
 
     _pipeline = vk::raii::Pipeline(args.ctx.device(), deferredOperation, vkPipelineCache, pipelineCreateInfo);
+    throwOnPipelineCacheMiss(_pipeline, args.pipelineCache, _debugName);
 
     trySetVkRaiiObjectDebugName(args.ctx, _pipeline, _debugName);
 
@@ -685,13 +693,15 @@ void Pipeline::buildDataGraphPipeline(const Context &ctx, const std::string &ent
         if (pipelineCache->failOnCacheMiss()) {
             flags |= vk::PipelineCreateFlagBits2KHR::eFailOnPipelineCompileRequired;
         }
-        insertAfter(&shaderModuleInfo, pipelineCache->getCacheFeedbackCreateInfo());
+        insertAfter(&shaderModuleInfo, pipelineCache->getCacheFeedbackCreateInfo(_type));
         vkPipelineCache = pipelineCache->get();
     }
 
     const vk::DataGraphPipelineCreateInfoARM pipelineCreateInfo(
         flags, *_pipelineLayout, static_cast<uint32_t>(resourceInfos.size()), resourceInfos.data(), &shaderModuleInfo);
     _pipeline = vk::raii::Pipeline(ctx.device(), deferredOperation, vkPipelineCache, pipelineCreateInfo);
+    throwOnPipelineCacheMiss(_pipeline, pipelineCache, _debugName);
+
     trySetVkRaiiObjectDebugName(ctx, _pipeline, _debugName);
 
     initSession(ctx, enableNeuralStatistics, neuralStatisticsMode);

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -98,8 +98,6 @@ class Pipeline {
     }
 
   private:
-    enum class PipelineType { Unknown, Compute, GraphCompute, Graphics };
-
     PipelineType _type{PipelineType::Unknown};
     std::vector<vk::raii::DescriptorSetLayout> _descriptorSetLayouts;
     vk::raii::PipelineLayout _pipelineLayout{nullptr};

--- a/src/pipeline_cache.cpp
+++ b/src/pipeline_cache.cpp
@@ -6,6 +6,7 @@
 #include "pipeline_cache.hpp"
 #include "logging.hpp"
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 
@@ -68,10 +69,26 @@ PipelineCache::PipelineCache(const Context &ctx, const std::filesystem::path &pi
     }
     _pipelineCache = vk::raii::PipelineCache(ctx.device(), cacheCreateInfo);
 
-    _feedback = vk::PipelineCreationFeedback(vk::PipelineCreationFeedbackFlagBits::eValid, 0);
+    getCacheFeedbackCreateInfo(PipelineType::Unknown);
+}
 
-    _stagedFeedback = vk::PipelineCreationFeedback(vk::PipelineCreationFeedbackFlagBits::eValid, 0);
-    _feedbackCreateInfo = vk::PipelineCreationFeedbackCreateInfo(&_feedback, 1, &_stagedFeedback);
+vk::PipelineCreationFeedbackCreateInfo *PipelineCache::getCacheFeedbackCreateInfo(PipelineType pipelineType) {
+    const uint32_t stageCount = pipelineType == PipelineType::Graphics ? 2 : 1;
+    _feedback = vk::PipelineCreationFeedback(vk::PipelineCreationFeedbackFlagBits::eValid, 0);
+    _stagedFeedback.assign(stageCount, vk::PipelineCreationFeedback(vk::PipelineCreationFeedbackFlagBits::eValid, 0));
+    _feedbackCreateInfo = vk::PipelineCreationFeedbackCreateInfo(
+        &_feedback, static_cast<uint32_t>(_stagedFeedback.size()), _stagedFeedback.data());
+    return &_feedbackCreateInfo;
+}
+
+bool PipelineCache::wasPipelineCacheHit() const {
+    const auto cacheHit = vk::PipelineCreationFeedbackFlagBits::eApplicationPipelineCacheHit;
+    if (static_cast<bool>(_feedback.flags & cacheHit)) {
+        return true;
+    }
+    return std::any_of(_stagedFeedback.begin(), _stagedFeedback.end(), [cacheHit](const auto &stageFeedback) {
+        return static_cast<bool>(stageFeedback.flags & cacheHit);
+    });
 }
 
 void PipelineCache::save() {

--- a/src/pipeline_cache.hpp
+++ b/src/pipeline_cache.hpp
@@ -12,6 +12,7 @@
 #include "vulkan/vulkan_raii.hpp"
 
 #include <filesystem>
+#include <vector>
 
 namespace mlsdk::scenariorunner {
 
@@ -22,8 +23,9 @@ class PipelineCache {
     void save();
 
     const vk::raii::PipelineCache *get() const { return &_pipelineCache; }
-    vk::PipelineCreationFeedbackCreateInfo *getCacheFeedbackCreateInfo() { return &_feedbackCreateInfo; }
+    vk::PipelineCreationFeedbackCreateInfo *getCacheFeedbackCreateInfo(PipelineType pipelineType);
     bool failOnCacheMiss() const { return _failOnMiss && _cacheData; }
+    bool wasPipelineCacheHit() const;
 
   private:
     bool isValidPipelineCache(const void *cacheDataPtr, size_t cacheDataSize, uint32_t expectedVendorID,
@@ -33,7 +35,7 @@ class PipelineCache {
     vk::raii::PipelineCache _pipelineCache{nullptr};
     vk::PipelineCreationFeedbackCreateInfo _feedbackCreateInfo;
     vk::PipelineCreationFeedback _feedback;
-    vk::PipelineCreationFeedback _stagedFeedback;
+    std::vector<vk::PipelineCreationFeedback> _stagedFeedback;
     bool _failOnMiss{false};
 };
 

--- a/src/tests/test_pipeline_cache.py
+++ b/src/tests/test_pipeline_cache.py
@@ -3,7 +3,10 @@
 # SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
+import json
 import os
+import subprocess
+import sys
 
 import numpy as np
 import pytest
@@ -12,6 +15,195 @@ import pytest
 
 
 pytestmark = pytest.mark.pipeline_cache
+
+
+def _seed_real_pipeline_cache_file(
+    sdk_tools, resources_helper, numpy_helper, cache_path, target_scenario
+):
+    warmup_scenario = "test_shader/shader_build_opts.json"
+
+    numpy_helper.generate([10], dtype=np.float32, filename="inBuffer.npy")
+    sdk_tools.compile_shader(
+        "test_shader/shader_build_opts.comp",
+        compile_opts="-DCONSTANT_0=10.0 -DDIVIDE_BY_TWO",
+    )
+
+    warmup_scenario_path = resources_helper.prepare_scenario(warmup_scenario)
+    target_scenario_path = resources_helper.get_testenv_path(
+        os.path.basename(target_scenario)
+    )
+    target_scenario_path.write_text(warmup_scenario_path.read_text())
+
+    sdk_tools.scenario_runner.run(
+        "--scenario",
+        target_scenario_path,
+        "--pipeline-caching",
+        "--cache-path",
+        cache_path,
+        "--dry-run",
+    )
+
+    target_cache_name = (
+        f"{os.path.splitext(os.path.basename(target_scenario))[0]}.cache"
+    )
+    target_cache_file = cache_path / target_cache_name
+    assert target_cache_file.is_file()
+    assert target_cache_file.stat().st_size > 0
+
+
+def _setup_compute_pipeline_cache_miss(sdk_tools, resources_helper, numpy_helper):
+    numpy_helper.generate([10], dtype=np.float32, filename="inBufferA.npy")
+    numpy_helper.generate([10], dtype=np.float32, filename="inBufferB.npy")
+
+    sdk_tools.compile_shader("test_shader/add_shader.comp", {"TestType": "float"})
+
+    return "test_pipeline_cache/enable_pipeline_cache.json", None
+
+
+def _setup_graph_pipeline_cache_miss(sdk_tools, resources_helper, numpy_helper):
+    conv2d_spv_path = sdk_tools.assemble_spirv(
+        "test_vgf_graph/conv2d.spvasm",
+        {
+            "INPUT_SET": "0",
+            "INPUT_BINDING": "0",
+            "OUTPUT_SET": "0",
+            "OUTPUT_BINDING": "1",
+        },
+    )
+    sdk_tools.validate_spirv(conv2d_spv_path)
+
+    const_shape = [16, 2, 2, 16]
+    numpy_helper.generate([1, 16, 16, 16], dtype=np.int8, filename="conv2dInput.npy")
+    numpy_helper.save(np.full(const_shape, 1, dtype=np.int8), "graphConstant0.npy")
+
+    return (
+        "test_spv_graph/conv2d_spv.json",
+        {
+            "{SPV}": json.dumps(conv2d_spv_path.as_posix()),
+            "{OUT}": json.dumps(
+                resources_helper.get_testenv_path("conv2dOutput_spv.npy").as_posix()
+            ),
+            "{CONST}": json.dumps(
+                resources_helper.get_testenv_path("graphConstant0.npy").as_posix()
+            ),
+            "{CONST_DIMS}": json.dumps(const_shape),
+        },
+    )
+
+
+def _setup_graphics_pipeline_cache_miss(sdk_tools, resources_helper, numpy_helper):
+    width = 64
+    height = 64
+    input_arr = np.arange(width * height * 4, dtype=np.uint8).reshape(
+        (1, height, width, 4)
+    )
+
+    sdk_tools.generate_png_file(height, width, "input.png", input_arr[0].tobytes())
+    sdk_tools.compile_shader("test_fragment/fullscreen_triangle.vert")
+    sdk_tools.compile_shader("test_fragment/sampled_copy.frag")
+
+    return "test_fragment/sampled_fragment.json", None
+
+
+def _setup_optical_flow_pipeline_cache_miss(sdk_tools, resources_helper, numpy_helper):
+    width = 64
+    height = 64
+    output_width = 16
+    output_height = 16
+    input_data = np.arange(width * height * 4, dtype=np.uint8).reshape(
+        (height, width, 4)
+    )
+
+    sdk_tools.generate_png_file(height, width, "input_search.png", input_data.tobytes())
+    sdk_tools.generate_png_file(
+        height, width, "input_template.png", input_data[::-1].tobytes()
+    )
+    numpy_helper.generate(
+        [1, output_height, output_width, 2],
+        dtype=np.float16,
+        filename="input_mv.npy",
+    )
+
+    return "test_optical_flow/optical_flow_png.json", None
+
+
+@pytest.mark.parametrize(
+    "setup",
+    [
+        pytest.param(_setup_compute_pipeline_cache_miss, id="compute"),
+        pytest.param(_setup_graph_pipeline_cache_miss, id="graph_compute"),
+        pytest.param(_setup_graphics_pipeline_cache_miss, id="graphics"),
+        pytest.param(
+            _setup_optical_flow_pipeline_cache_miss,
+            marks=pytest.mark.skipif(
+                sys.platform == "darwin",
+                reason="Optical flow is not supported on Darwin",
+            ),
+            id="optical_flow",
+        ),
+    ],
+)
+def test_fail_on_pipeline_cache_miss_triggers_for_all_pipeline_types(
+    sdk_tools, resources_helper, numpy_helper, capfd, setup
+):
+    scenario, replacements = setup(sdk_tools, resources_helper, numpy_helper)
+
+    cache_path = resources_helper.get_testenv_path(
+        f"{scenario.replace('/', '_')}_miss_cache"
+    )
+    cache_path.mkdir()
+    # Using an empty cachefile does not trigger a cache miss, so we need to seed the cache with a valid cache file
+    _seed_real_pipeline_cache_file(
+        sdk_tools, resources_helper, numpy_helper, cache_path, scenario
+    )
+    capfd.readouterr()
+
+    with pytest.raises(subprocess.CalledProcessError):
+        sdk_tools.run_scenario(
+            scenario,
+            replacements,
+            options=[
+                "--pipeline-caching",
+                "--fail-on-pipeline-cache-miss",
+                "--cache-path",
+                cache_path,
+                "--dry-run",
+            ],
+        )
+
+    captured = capfd.readouterr()
+    assert "INFO: Pipeline Cache loaded and validated." in captured.out
+    assert "ERROR: Pipeline cache miss for pipeline:" in (captured.out + captured.err)
+
+
+def test_pass_on_empty_pipeline_cache(sdk_tools, resources_helper, numpy_helper, capfd):
+    scenario, replacements = _setup_compute_pipeline_cache_miss(
+        sdk_tools, resources_helper, numpy_helper
+    )
+
+    cache_path = resources_helper.get_testenv_path(
+        f"{scenario.replace('/', '_')}_miss_cache"
+    )
+    cache_path.mkdir()
+    capfd.readouterr()
+
+    sdk_tools.run_scenario(
+        scenario,
+        replacements,
+        options=[
+            "--pipeline-caching",
+            "--fail-on-pipeline-cache-miss",
+            "--cache-path",
+            cache_path,
+            "--dry-run",
+        ],
+    )
+
+    captured = capfd.readouterr()
+    assert "INFO: Pipeline Cache loaded and validated." not in captured.out
+    assert "ERROR: Pipeline cache miss for pipeline:" not in (
+        captured.out + captured.err
+    )
 
 
 def test_enable_pipeline_cache(sdk_tools, resources_helper, numpy_helper, capfd):

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -42,6 +42,7 @@ enum class MemoryAccess {
     Unknown
 };
 enum class PipelineStage { Graph, Compute, Graphics, All, Unknown };
+enum class PipelineType { Unknown, Compute, GraphCompute, Graphics };
 enum class ImageLayout { General, TensorAliasing, Undefined, Unknown };
 struct SubresourceRange {
     uint32_t baseMipLevel{0};


### PR DESCRIPTION
Only compute pipeline enforced the --fail-on-pipeline-cache-miss option, the other pipeline types did not perform the same check. This caused the constructor to complete with VK_PIPELINE_COMPILE_REQUIRED, making the pipeline not valid for session creation, which could lead to driver-side segfault instead of a useful scenario-runner error.

Add a shared helper for this check and call it after every pipeline creation site before using the pipeline further. This keeps compute behavior unchanged and makes graphics, optical-flow data graph, and regular data graph pipelines report cache misses consistently.

Extend the helper to check the Pipeline Creation Feedback for cache hit. Modify _stagedFeedback to  account for graphic pipeline's two shader stages.

Change-Id: I93662894499d0f719e4c5a49f869be404f54104f