### PR TITLE
refactor: store resource info by typed ID

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SCENARIO_RUNNER_LIB_SOURCES
     pipeline.cpp
     raw_data.cpp
     resource_desc.cpp
+    resource_manager.cpp
     scenario.cpp
     scenario_desc.cpp
     tensor.cpp

--- a/src/resource_id.hpp
+++ b/src/resource_id.hpp
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace mlsdk::scenariorunner {
+
+template <typename Tag> class ResourceId {
+  public:
+    using ValueType = size_t;
+
+    explicit constexpr ResourceId(ValueType value) : _value{value} {}
+
+    constexpr ValueType value() const { return _value; }
+
+    friend constexpr bool operator==(ResourceId lhs, ResourceId rhs) { return lhs._value == rhs._value; }
+    friend constexpr bool operator!=(ResourceId lhs, ResourceId rhs) { return !(lhs == rhs); }
+
+  private:
+    ValueType _value;
+};
+
+struct BufferIdTag;
+struct ImageIdTag;
+struct TensorIdTag;
+struct ShaderIdTag;
+
+using BufferId = ResourceId<BufferIdTag>;
+using ImageId = ResourceId<ImageIdTag>;
+using TensorId = ResourceId<TensorIdTag>;
+using ShaderId = ResourceId<ShaderIdTag>;
+
+} // namespace mlsdk::scenariorunner

--- a/src/resource_manager.cpp
+++ b/src/resource_manager.cpp
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "resource_manager.hpp"
+
+#include <utility>
+
+namespace mlsdk::scenariorunner {
+namespace {
+template <typename Id, typename Info> Id addResource(std::vector<Info> &resources, Info info) {
+    const Id id{resources.size()};
+    resources.push_back(std::move(info));
+    return id;
+}
+
+template <typename Info, typename Id> const Info &getResource(const std::vector<Info> &resources, Id id) {
+    return resources.at(id.value());
+}
+} // namespace
+
+BufferId ResourceManager::addBuffer(BufferInfo info) { return addResource<BufferId>(_buffers, std::move(info)); }
+
+ImageId ResourceManager::addImage(ImageInfo info) { return addResource<ImageId>(_images, std::move(info)); }
+
+TensorId ResourceManager::addTensor(TensorInfo info) { return addResource<TensorId>(_tensors, std::move(info)); }
+
+ShaderId ResourceManager::addShader(ShaderInfo info) { return addResource<ShaderId>(_shaders, std::move(info)); }
+
+const BufferInfo &ResourceManager::get(BufferId id) const { return getResource(_buffers, id); }
+
+const ImageInfo &ResourceManager::get(ImageId id) const { return getResource(_images, id); }
+
+const TensorInfo &ResourceManager::get(TensorId id) const { return getResource(_tensors, id); }
+
+const ShaderInfo &ResourceManager::get(ShaderId id) const { return getResource(_shaders, id); }
+
+} // namespace mlsdk::scenariorunner

--- a/src/resource_manager.hpp
+++ b/src/resource_manager.hpp
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "resource_id.hpp"
+#include "types.hpp"
+
+#include <vector>
+
+namespace mlsdk::scenariorunner {
+
+class ResourceManager {
+  public:
+    BufferId addBuffer(BufferInfo info);
+    ImageId addImage(ImageInfo info);
+    TensorId addTensor(TensorInfo info);
+    ShaderId addShader(ShaderInfo info);
+
+    const BufferInfo &get(BufferId id) const;
+    const ImageInfo &get(ImageId id) const;
+    const TensorInfo &get(TensorId id) const;
+    const ShaderInfo &get(ShaderId id) const;
+
+  private:
+    std::vector<BufferInfo> _buffers;
+    std::vector<ImageInfo> _images;
+    std::vector<TensorInfo> _tensors;
+    std::vector<ShaderInfo> _shaders;
+};
+
+} // namespace mlsdk::scenariorunner

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -787,8 +787,8 @@ void Scenario::setupResources() {
         switch (resource->resourceType) {
         case ResourceType::Buffer: {
             const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
-            auto info = resourceInfoFactory.createInfo(*buffer);
-            _dataManager.createBuffer(resource->guid, std::move(info));
+            const auto id = _resources.addBuffer(resourceInfoFactory.createInfo(*buffer));
+            _dataManager.createBuffer(resource->guid, _resources.get(id));
         } break;
         case ResourceType::RawData: {
             const auto &rawData = reinterpret_cast<const std::unique_ptr<RawDataDesc> &>(resource);
@@ -796,8 +796,8 @@ void Scenario::setupResources() {
         } break;
         case ResourceType::Image: {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
-            auto info = resourceInfoFactory.createInfo(*image);
-            _dataManager.createImage(resource->guid, std::move(info));
+            const auto id = _resources.addImage(resourceInfoFactory.createInfo(*image));
+            _dataManager.createImage(resource->guid, _resources.get(id));
         } break;
         case ResourceType::DataGraph: {
             const auto &dataGraph = reinterpret_cast<const std::unique_ptr<DataGraphDesc> &>(resource);
@@ -806,8 +806,8 @@ void Scenario::setupResources() {
         } break;
         case ResourceType::Tensor: {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
-            auto info = resourceInfoFactory.createInfo(*tensor, _opts.captureFrame);
-            _dataManager.createTensor(resource->guid, std::move(info));
+            const auto id = _resources.addTensor(resourceInfoFactory.createInfo(*tensor, _opts.captureFrame));
+            _dataManager.createTensor(resource->guid, _resources.get(id));
         } break;
         default:
             // Skip the other types of resources

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -9,6 +9,7 @@
 #include "context.hpp"
 #include "data_manager.hpp"
 #include "group_manager.hpp"
+#include "resource_manager.hpp"
 #include "scenario_desc.hpp"
 #include "types.hpp"
 
@@ -80,6 +81,7 @@ class Scenario {
 
     ScenarioOptions _opts;
     Context _ctx;
+    ResourceManager _resources;
     DataManager _dataManager;
     ScenarioSpec &_scenarioSpec;
     std::shared_ptr<PipelineCache> _pipelineCache;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(ScenarioRunnerTests
   logging_tests.cpp
   perf_counter_tests.cpp
   png_reader_tests.cpp
+  resource_manager_tests.cpp
   vgf_view_tests.cpp
   vulkan_startup_tests.cpp
 )

--- a/src/tests/resource_manager_tests.cpp
+++ b/src/tests/resource_manager_tests.cpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "resource_manager.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+using namespace mlsdk::scenariorunner;
+
+static_assert(!std::is_same_v<BufferId, TensorId>);
+static_assert(!std::is_convertible_v<BufferId, TensorId>);
+
+TEST(ResourceManager, AssignsIdsIndependentlyPerType) {
+    ResourceManager resources;
+
+    BufferInfo bufferA{};
+    bufferA.debugName = "buffer_a";
+    ImageInfo image{};
+    image.debugName = "image";
+    BufferInfo bufferB{};
+    bufferB.debugName = "buffer_b";
+
+    const auto bufferAId = resources.addBuffer(std::move(bufferA));
+    const auto imageId = resources.addImage(std::move(image));
+    const auto bufferBId = resources.addBuffer(std::move(bufferB));
+
+    EXPECT_EQ(bufferAId.value(), 0U);
+    EXPECT_EQ(imageId.value(), 0U);
+    EXPECT_EQ(bufferBId.value(), 1U);
+}
+
+TEST(ResourceManager, PreservesResourceInfo) {
+    ResourceManager resources;
+
+    ShaderInfo shader{};
+    shader.debugName = "shader";
+    shader.entry = "main";
+    shader.pushConstantsSize = 16;
+
+    const auto shaderId = resources.addShader(std::move(shader));
+
+    EXPECT_EQ(resources.get(shaderId).debugName, "shader");
+    EXPECT_EQ(resources.get(shaderId).entry, "main");
+    EXPECT_EQ(resources.get(shaderId).pushConstantsSize, 16U);
+}
+
+TEST(ResourceManager, RejectsOutOfRangeIds) {
+    const ResourceManager resources;
+
+    EXPECT_THROW(static_cast<void>(resources.get(BufferId{0})), std::out_of_range);
+    EXPECT_THROW(static_cast<void>(resources.get(TensorId{0})), std::out_of_range);
+}


### PR DESCRIPTION
Add strong resource IDs and a ResourceManager for buffer, image, tensor, and shader information.

Route existing buffer, image, and tensor setup through the manager without changing JSON or GUID behavior.

Add focused ResourceManager tests.

Change-Id: If1aaed5d6de96597cfaf22209e6d2baca47e7445