### PR TITLE
refactor: derive alias state from resource memory

### DIFF
--- a/src/group_manager.cpp
+++ b/src/group_manager.cpp
@@ -28,13 +28,13 @@ size_t GroupManager::getAliasCount(const Guid &resource) const {
     return 0;
 }
 
-bool GroupManager::isAliased(const Guid &resource) const { return getAliasCount(resource) > 0; }
+bool GroupManager::isAliased(const Guid &resource) const { return getAliasCount(resource) > 1; }
 
 bool GroupManager::hasAliasOfType(const Guid &resource, ResourceIdType resourceIdType) const {
     if (const auto group = getGroupForResource(resource); group.has_value()) {
         // Group found, look for requested type
-        for (const auto &groupResource : _groupResources.at(*group)) {
-            if (groupResource.second == resourceIdType) {
+        for (const auto &[aliasResource, aliasType] : _groupResources.at(*group)) {
+            if (aliasResource != resource && aliasType == resourceIdType) {
                 return true;
             }
         }
@@ -44,9 +44,13 @@ bool GroupManager::hasAliasOfType(const Guid &resource, ResourceIdType resourceI
 
 std::shared_ptr<ResourceMemoryManager> GroupManager::getMemoryManager(const Guid &resource) {
     if (const auto group = getGroupForResource(resource); group.has_value()) {
-        // Only inserts if not existing
-        const auto result = _groupMemoryManagers.emplace(*group, std::make_shared<ResourceMemoryManager>());
-        return result.first->second;
+        // Create one memory manager per group on first access.
+        const auto [manager, inserted] =
+            _groupMemoryManagers.emplace(*group, std::make_shared<ResourceMemoryManager>());
+        if (inserted && isAliased(resource)) {
+            manager->second->markShared();
+        }
+        return manager->second;
     }
     // Not a group, create new one
     return std::make_shared<ResourceMemoryManager>();

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -160,7 +160,7 @@ void Image::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> mem
             1) {
         throw std::runtime_error("Number of mips exceeds maximum number allowed for the image size");
     }
-    if (_imageInfo.isAliased && _imageInfo.mips > 1) {
+    if (_memoryManager->isShared() && _imageInfo.mips > 1) {
         throw std::runtime_error("A mipped image cannot be aliased");
     }
 
@@ -204,7 +204,7 @@ void Image::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> mem
             if ((featProps.optimalTilingFeatures & requiredFormatFlags) != requiredFormatFlags) {
                 throw std::runtime_error("Tiling type: OPTIMAL is not supported for this formatType");
             }
-            if (_imageInfo.isAliased) {
+            if (_memoryManager->isShared()) {
                 mlsdk::logging::info("Allowing OPTIMAL tiling with aliasing for image");
             }
         }
@@ -223,7 +223,7 @@ void Image::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> mem
 
     _initialLayout = vk::ImageLayout::eUndefined;
 
-    if (_imageInfo.isAliased && _tiling != vk::ImageTiling::eLinear) {
+    if (_memoryManager->isShared() && _tiling != vk::ImageTiling::eLinear) {
         usageFlags |= vk::ImageUsageFlagBits::eTensorAliasingARM;
     }
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -215,8 +215,6 @@ std::string resourceType(const std::unique_ptr<ResourceDesc> &resource) {
 }
 
 struct ResourceInfoFactory {
-    const GroupManager &_groupManager;
-
     BufferInfo createInfo(const BufferDesc &buffer) const {
         BufferInfo info{};
         info.debugName = buffer.guidStr;
@@ -304,7 +302,6 @@ struct ResourceInfoFactory {
             info.memoryOffset = image.memoryGroup->offset;
         }
 
-        info.isAliased = _groupManager.isAliased(image.guid);
         info.isColorAttachment = image.colorAttachment;
         return info;
     }
@@ -315,7 +312,6 @@ struct ResourceInfoFactory {
         if (tensor.memoryGroup.has_value()) {
             info.memoryOffset = tensor.memoryGroup->offset;
         }
-        info.isAliasedWithImage = _groupManager.hasAliasOfType(tensor.guid, ResourceIdType::Image);
         info.format = getVkFormatFromString(tensor.format);
         info.shape.resize(tensor.dims.size());
         std::copy(tensor.dims.begin(), tensor.dims.end(), info.shape.begin());
@@ -432,13 +428,11 @@ class Creator final : public IResourceCreator {
     }
 
     void createTensor(Guid guid, TensorInfo &&info) override {
-        info.isAliasedWithImage = _groupManager.hasAliasOfType(guid, ResourceIdType::Image);
         _dataManager.createTensor(guid, std::move(info));
         _createdResources.push_back({guid, ResourceIdType::Tensor});
     }
 
     void createImage(Guid guid, ImageInfo &&info) override {
-        info.isAliased = _groupManager.isAliased(guid);
         _dataManager.createImage(guid, std::move(info));
         _createdResources.push_back({guid, ResourceIdType::Image});
     }
@@ -782,7 +776,7 @@ void Scenario::setupResources() {
 
     // Setup resource info
     // (Memory for Tensors and Images is allocated in next pass)
-    ResourceInfoFactory resourceInfoFactory{_groupManager};
+    ResourceInfoFactory resourceInfoFactory;
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
         case ResourceType::Buffer: {

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -28,7 +28,6 @@ constexpr vk::TensorTilingARM convertTiling(const Tiling tiling) {
 Tensor::Tensor(TensorInfo tensorInfo)
     : _debugName(std::move(tensorInfo.debugName)), _shape(std::move(tensorInfo.shape)), _dataType(tensorInfo.format),
       _tiling(convertTiling(tensorInfo.tiling)), _memoryOffset(tensorInfo.memoryOffset),
-      _isAliasedWithImage(tensorInfo.isAliasedWithImage),
       _descriptorBufferCaptureReplay(tensorInfo.descriptorBufferCaptureReplay) {}
 
 void Tensor::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> memoryManager) {
@@ -47,7 +46,7 @@ void Tensor::setup(const Context &ctx, std::shared_ptr<ResourceMemoryManager> me
 
     auto rank = static_cast<uint32_t>(_shape.size());
 
-    if (_isAliasedWithImage && _tiling != vk::TensorTilingARM::eOptimal) {
+    if (_memoryManager->hasImageMetadata() && _tiling != vk::TensorTilingARM::eOptimal) {
         /*
           The extension to the spec does not support rank 4 tensors aliasing 2D images. Rank 4 tensor is associated with
           a 3D image. The image type check was added to avoid faults for 2D images due to this spec requirement:

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -83,7 +83,6 @@ class Tensor {
     vk::TensorTilingARM _tiling{vk::TensorTilingARM::eLinear};
     vk::DeviceSize _size{0};
     uint64_t _memoryOffset{0};
-    bool _isAliasedWithImage{false};
     bool _rankConverted{false};
     bool _descriptorBufferCaptureReplay{false};
 };

--- a/src/tests/group_manager_tests.cpp
+++ b/src/tests/group_manager_tests.cpp
@@ -17,7 +17,7 @@ TEST(GroupManager, GroupHandling) {
     GroupManager gm;
     gm.addResourceToGroup(group0, tensor0, ResourceIdType::Tensor);
     ASSERT_EQ(gm.getAliasCount(tensor0), 1U);
-    ASSERT_TRUE(gm.isAliased(tensor0));
+    ASSERT_FALSE(gm.isAliased(tensor0));
     ASSERT_EQ(gm.getAliasCount(image0), 0U);
     ASSERT_FALSE(gm.isAliased(image0));
     ASSERT_FALSE(gm.hasAliasOfType(tensor0, ResourceIdType::Image));
@@ -35,6 +35,7 @@ TEST(GroupManager, GroupHandling) {
     auto mmTensor = gm.getMemoryManager(tensor0);
     auto mmImage = gm.getMemoryManager(image0);
     ASSERT_EQ(mmTensor, mmImage);
+    ASSERT_TRUE(mmTensor->isShared());
 }
 
 TEST(GroupManager, DuplicateResourceRegistrationToDifferentGroupThrows) {

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -76,7 +76,6 @@ struct TensorInfo {
     vk::Format format;
     int64_t sparsityDimension{-1};
     bool descriptorBufferCaptureReplay{false};
-    bool isAliasedWithImage{false};
     Tiling tiling{Tiling::Linear};
     uint64_t memoryOffset{};
 };
@@ -105,7 +104,6 @@ struct ImageInfo {
     vk::Format targetFormat;
     bool isInput;
     SamplerSettings samplerSettings;
-    bool isAliased{false};
     uint32_t mips;
     bool isSampled{false};
     bool isStorage{false};

--- a/src/vulkan_memory_manager.hpp
+++ b/src/vulkan_memory_manager.hpp
@@ -16,6 +16,12 @@ class ResourceMemoryManager {
   public:
     bool isInitalized() const { return _initalized; }
 
+    bool isShared() const { return _isShared; }
+
+    void markShared() { _isShared = true; }
+
+    bool hasImageMetadata() const { return _hasImageMetadata; }
+
     void allocateDeviceMemory(const Context &ctx, vk::MemoryPropertyFlags flags) {
         if (_memSize == 0) {
             throw std::runtime_error("Allocated memory size must be non-zero");
@@ -63,7 +69,10 @@ class ResourceMemoryManager {
 
     void updateFormat(vk::Format format) { _format = format; }
 
-    void updateImageType(vk::ImageType imType) { _imType = imType; }
+    void updateImageType(vk::ImageType imType) {
+        _imType = imType;
+        _hasImageMetadata = true;
+    }
 
     void updateMemType(uint32_t type) { _memType &= type; }
 
@@ -191,6 +200,8 @@ class ResourceMemoryManager {
     uint32_t _memType{UINT32_MAX};
     vk::raii::DeviceMemory _deviceMemory{nullptr};
     bool _initalized{false};
+    bool _isShared{false};
+    bool _hasImageMetadata{false};
     vk::raii::Buffer _stagingBuffer{nullptr};
     vk::raii::DeviceMemory _stagingBufferDeviceMemory{nullptr};
 };


### PR DESCRIPTION
Remove alias-derived fields from resource info and determine shared-memory and image metadata during resource setup.

Change-Id: Id70efa140bab1a4f9d1366e04ae3032bf7867e35