### PR TITLE
refactor: avoid passing large resource info by value

### DIFF
--- a/src/resource_manager.cpp
+++ b/src/resource_manager.cpp
@@ -9,9 +9,10 @@
 
 namespace mlsdk::scenariorunner {
 namespace {
-template <typename Id, typename Info> Id addResource(std::vector<Info> &resources, Info info) {
+template <typename Id, typename StoredInfo, typename InputInfo>
+Id addResource(std::vector<StoredInfo> &resources, InputInfo &&info) {
     const Id id{resources.size()};
-    resources.push_back(std::move(info));
+    resources.emplace_back(std::forward<InputInfo>(info));
     return id;
 }
 
@@ -20,13 +21,21 @@ template <typename Info, typename Id> const Info &getResource(const std::vector<
 }
 } // namespace
 
-BufferId ResourceManager::addBuffer(BufferInfo info) { return addResource<BufferId>(_buffers, std::move(info)); }
+BufferId ResourceManager::addBuffer(const BufferInfo &info) { return addResource<BufferId>(_buffers, info); }
 
-ImageId ResourceManager::addImage(ImageInfo info) { return addResource<ImageId>(_images, std::move(info)); }
+BufferId ResourceManager::addBuffer(BufferInfo &&info) { return addResource<BufferId>(_buffers, std::move(info)); }
 
-TensorId ResourceManager::addTensor(TensorInfo info) { return addResource<TensorId>(_tensors, std::move(info)); }
+ImageId ResourceManager::addImage(const ImageInfo &info) { return addResource<ImageId>(_images, info); }
 
-ShaderId ResourceManager::addShader(ShaderInfo info) { return addResource<ShaderId>(_shaders, std::move(info)); }
+ImageId ResourceManager::addImage(ImageInfo &&info) { return addResource<ImageId>(_images, std::move(info)); }
+
+TensorId ResourceManager::addTensor(const TensorInfo &info) { return addResource<TensorId>(_tensors, info); }
+
+TensorId ResourceManager::addTensor(TensorInfo &&info) { return addResource<TensorId>(_tensors, std::move(info)); }
+
+ShaderId ResourceManager::addShader(const ShaderInfo &info) { return addResource<ShaderId>(_shaders, info); }
+
+ShaderId ResourceManager::addShader(ShaderInfo &&info) { return addResource<ShaderId>(_shaders, std::move(info)); }
 
 const BufferInfo &ResourceManager::get(BufferId id) const { return getResource(_buffers, id); }
 

--- a/src/resource_manager.hpp
+++ b/src/resource_manager.hpp
@@ -14,10 +14,14 @@ namespace mlsdk::scenariorunner {
 
 class ResourceManager {
   public:
-    BufferId addBuffer(BufferInfo info);
-    ImageId addImage(ImageInfo info);
-    TensorId addTensor(TensorInfo info);
-    ShaderId addShader(ShaderInfo info);
+    BufferId addBuffer(const BufferInfo &info);
+    BufferId addBuffer(BufferInfo &&info);
+    ImageId addImage(const ImageInfo &info);
+    ImageId addImage(ImageInfo &&info);
+    TensorId addTensor(const TensorInfo &info);
+    TensorId addTensor(TensorInfo &&info);
+    ShaderId addShader(const ShaderInfo &info);
+    ShaderId addShader(ShaderInfo &&info);
 
     const BufferInfo &get(BufferId id) const;
     const ImageInfo &get(ImageId id) const;

--- a/src/tests/resource_manager_tests.cpp
+++ b/src/tests/resource_manager_tests.cpp
@@ -43,8 +43,9 @@ TEST(ResourceManager, PreservesResourceInfo) {
     shader.entry = "main";
     shader.pushConstantsSize = 16;
 
-    const auto shaderId = resources.addShader(std::move(shader));
+    const auto shaderId = resources.addShader(shader);
 
+    EXPECT_EQ(shader.debugName, "shader");
     EXPECT_EQ(resources.get(shaderId).debugName, "shader");
     EXPECT_EQ(resources.get(shaderId).entry, "main");
     EXPECT_EQ(resources.get(shaderId).pushConstantsSize, 16U);


### PR DESCRIPTION
Add reference and rvalue overloads for resource insertion. Forward values directly into ResourceManager storage.

Change-Id: Ib85ccd5fc44c135f979596f58c00e59f85a43ba6