### PR TITLE
refactor: store file resources by typed ID

### DIFF
--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -22,8 +22,8 @@ void DataManager::createImage(Guid guid, const ImageInfo &info) { _images.emplac
 
 void DataManager::createImage(Guid guid, ImageInfo &&info) { _images.emplace(guid, Image(std::move(info))); }
 
-void DataManager::createVgfView(Guid guid, std::string src) {
-    _vgfViews.insert({guid, VgfView::createVgfView(std::move(src))});
+void DataManager::createVgfView(Guid guid, const DataGraphInfo &info) {
+    _vgfViews.insert({guid, VgfView::createVgfView(info.src)});
 }
 
 void DataManager::createImageBarrier(Guid guid, const ImageBarrierData &data) {
@@ -42,8 +42,8 @@ void DataManager::createBufferBarrier(Guid guid, const BufferBarrierData &data) 
     _bufferBarriers.insert({guid, VulkanBufferBarrier(data)});
 }
 
-void DataManager::createRawData(Guid guid, const std::string &debugName, const std::string &src) {
-    _rawData.insert({guid, RawData(debugName, src)});
+void DataManager::createRawData(Guid guid, const RawDataInfo &info) {
+    _rawData.insert({guid, RawData(info.debugName, info.src)});
 }
 
 bool DataManager::hasBuffer(Guid guid) const { return _buffers.find(guid) != _buffers.end(); }

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -23,8 +23,8 @@ class DataManager {
     void createTensor(Guid guid, TensorInfo &&info);
     void createImage(Guid guid, const ImageInfo &info);
     void createImage(Guid guid, ImageInfo &&info);
-    void createRawData(Guid guid, const std::string &debugName, const std::string &src);
-    void createVgfView(Guid guid, std::string src);
+    void createRawData(Guid guid, const RawDataInfo &info);
+    void createVgfView(Guid guid, const DataGraphInfo &info);
     void createImageBarrier(Guid guid, const ImageBarrierData &data);
     void createTensorBarrier(Guid guid, const TensorBarrierData &data);
     void createMemoryBarrier(Guid guid, const MemoryBarrierData &data);

--- a/src/resource_id.hpp
+++ b/src/resource_id.hpp
@@ -28,10 +28,14 @@ struct BufferIdTag;
 struct ImageIdTag;
 struct TensorIdTag;
 struct ShaderIdTag;
+struct RawDataIdTag;
+struct DataGraphIdTag;
 
 using BufferId = ResourceId<BufferIdTag>;
 using ImageId = ResourceId<ImageIdTag>;
 using TensorId = ResourceId<TensorIdTag>;
 using ShaderId = ResourceId<ShaderIdTag>;
+using RawDataId = ResourceId<RawDataIdTag>;
+using DataGraphId = ResourceId<DataGraphIdTag>;
 
 } // namespace mlsdk::scenariorunner

--- a/src/resource_manager.cpp
+++ b/src/resource_manager.cpp
@@ -37,6 +37,18 @@ ShaderId ResourceManager::addShader(const ShaderInfo &info) { return addResource
 
 ShaderId ResourceManager::addShader(ShaderInfo &&info) { return addResource<ShaderId>(_shaders, std::move(info)); }
 
+RawDataId ResourceManager::addRawData(const RawDataInfo &info) { return addResource<RawDataId>(_rawData, info); }
+
+RawDataId ResourceManager::addRawData(RawDataInfo &&info) { return addResource<RawDataId>(_rawData, std::move(info)); }
+
+DataGraphId ResourceManager::addDataGraph(const DataGraphInfo &info) {
+    return addResource<DataGraphId>(_dataGraphs, info);
+}
+
+DataGraphId ResourceManager::addDataGraph(DataGraphInfo &&info) {
+    return addResource<DataGraphId>(_dataGraphs, std::move(info));
+}
+
 const BufferInfo &ResourceManager::get(BufferId id) const { return getResource(_buffers, id); }
 
 const ImageInfo &ResourceManager::get(ImageId id) const { return getResource(_images, id); }
@@ -44,5 +56,9 @@ const ImageInfo &ResourceManager::get(ImageId id) const { return getResource(_im
 const TensorInfo &ResourceManager::get(TensorId id) const { return getResource(_tensors, id); }
 
 const ShaderInfo &ResourceManager::get(ShaderId id) const { return getResource(_shaders, id); }
+
+const RawDataInfo &ResourceManager::get(RawDataId id) const { return getResource(_rawData, id); }
+
+const DataGraphInfo &ResourceManager::get(DataGraphId id) const { return getResource(_dataGraphs, id); }
 
 } // namespace mlsdk::scenariorunner

--- a/src/resource_manager.hpp
+++ b/src/resource_manager.hpp
@@ -22,17 +22,25 @@ class ResourceManager {
     TensorId addTensor(TensorInfo &&info);
     ShaderId addShader(const ShaderInfo &info);
     ShaderId addShader(ShaderInfo &&info);
+    RawDataId addRawData(const RawDataInfo &info);
+    RawDataId addRawData(RawDataInfo &&info);
+    DataGraphId addDataGraph(const DataGraphInfo &info);
+    DataGraphId addDataGraph(DataGraphInfo &&info);
 
     const BufferInfo &get(BufferId id) const;
     const ImageInfo &get(ImageId id) const;
     const TensorInfo &get(TensorId id) const;
     const ShaderInfo &get(ShaderId id) const;
+    const RawDataInfo &get(RawDataId id) const;
+    const DataGraphInfo &get(DataGraphId id) const;
 
   private:
     std::vector<BufferInfo> _buffers;
     std::vector<ImageInfo> _images;
     std::vector<TensorInfo> _tensors;
     std::vector<ShaderInfo> _shaders;
+    std::vector<RawDataInfo> _rawData;
+    std::vector<DataGraphInfo> _dataGraphs;
 };
 
 } // namespace mlsdk::scenariorunner

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -237,6 +237,12 @@ struct ResourceInfoFactory {
         return info;
     }
 
+    RawDataInfo createInfo(const RawDataDesc &rawData) const { return {rawData.guidStr, rawData.src.value()}; }
+
+    DataGraphInfo createInfo(const DataGraphDesc &dataGraph) const {
+        return {dataGraph.guidStr, dataGraph.src.value()};
+    }
+
     ImageInfo createInfo(const ImageDesc &image) const {
         ImageInfo info{};
         info.debugName = image.guidStr;
@@ -808,7 +814,8 @@ void Scenario::setupResources() {
         } break;
         case ResourceType::RawData: {
             const auto &rawData = reinterpret_cast<const std::unique_ptr<RawDataDesc> &>(resource);
-            _dataManager.createRawData(resource->guid, rawData->guidStr, rawData->src.value());
+            const auto id = _resources.addRawData(resourceInfoFactory.createInfo(*rawData));
+            _dataManager.createRawData(resource->guid, _resources.get(id));
         } break;
         case ResourceType::Image: {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
@@ -818,7 +825,8 @@ void Scenario::setupResources() {
         case ResourceType::DataGraph: {
             const auto &dataGraph = reinterpret_cast<const std::unique_ptr<DataGraphDesc> &>(resource);
             PerfCounterGuard guard(_perfCounters, "Parse VGF: " + dataGraph->guidStr, "Scenario Setup");
-            _dataManager.createVgfView(resource->guid, dataGraph->src.value());
+            const auto id = _resources.addDataGraph(resourceInfoFactory.createInfo(*dataGraph));
+            _dataManager.createVgfView(resource->guid, _resources.get(id));
         } break;
         case ResourceType::Tensor: {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);

--- a/src/tests/resource_manager_tests.cpp
+++ b/src/tests/resource_manager_tests.cpp
@@ -25,14 +25,20 @@ TEST(ResourceManager, AssignsIdsIndependentlyPerType) {
     image.debugName = "image";
     BufferInfo bufferB{};
     bufferB.debugName = "buffer_b";
+    RawDataInfo rawData{"raw_data", "data.npy"};
+    DataGraphInfo dataGraph{"data_graph", "graph.vgf"};
 
     const auto bufferAId = resources.addBuffer(std::move(bufferA));
     const auto imageId = resources.addImage(std::move(image));
     const auto bufferBId = resources.addBuffer(std::move(bufferB));
+    const auto rawDataId = resources.addRawData(std::move(rawData));
+    const auto dataGraphId = resources.addDataGraph(std::move(dataGraph));
 
     EXPECT_EQ(bufferAId.value(), 0U);
     EXPECT_EQ(imageId.value(), 0U);
     EXPECT_EQ(bufferBId.value(), 1U);
+    EXPECT_EQ(rawDataId.value(), 0U);
+    EXPECT_EQ(dataGraphId.value(), 0U);
 }
 
 TEST(ResourceManager, PreservesResourceInfo) {
@@ -49,6 +55,14 @@ TEST(ResourceManager, PreservesResourceInfo) {
     EXPECT_EQ(resources.get(shaderId).debugName, "shader");
     EXPECT_EQ(resources.get(shaderId).entry, "main");
     EXPECT_EQ(resources.get(shaderId).pushConstantsSize, 16U);
+
+    const auto rawDataId = resources.addRawData({"raw_data", "data.npy"});
+    const auto dataGraphId = resources.addDataGraph({"data_graph", "graph.vgf"});
+
+    EXPECT_EQ(resources.get(rawDataId).debugName, "raw_data");
+    EXPECT_EQ(resources.get(rawDataId).src, "data.npy");
+    EXPECT_EQ(resources.get(dataGraphId).debugName, "data_graph");
+    EXPECT_EQ(resources.get(dataGraphId).src, "graph.vgf");
 }
 
 TEST(ResourceManager, RejectsOutOfRangeIds) {
@@ -56,4 +70,6 @@ TEST(ResourceManager, RejectsOutOfRangeIds) {
 
     EXPECT_THROW(static_cast<void>(resources.get(BufferId{0})), std::out_of_range);
     EXPECT_THROW(static_cast<void>(resources.get(TensorId{0})), std::out_of_range);
+    EXPECT_THROW(static_cast<void>(resources.get(RawDataId{0})), std::out_of_range);
+    EXPECT_THROW(static_cast<void>(resources.get(DataGraphId{0})), std::out_of_range);
 }

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -65,6 +65,18 @@ struct BufferInfo {
     uint64_t memoryOffset{};
 };
 
+/// \brief Information needed to load raw data from a file
+struct RawDataInfo {
+    std::string debugName;
+    std::string src;
+};
+
+/// \brief Information needed to load a data graph from a file
+struct DataGraphInfo {
+    std::string debugName;
+    std::string src;
+};
+
 /// \brief Structure that describes N-dimensional data
 ///
 /// \note We don't account for any specialized meta-data like


### PR DESCRIPTION
Add typed storage for raw data and VGF-backed graph resources and use it during runtime creation.


Change-Id: I78664da73344958f07e69ebf127c1a6d85fd097d