### PR TITLE
refactor: derive graph constant binding IDs

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -371,7 +371,8 @@ Pipeline::Pipeline(const CommonArguments &args, const ShaderInfo &shaderInfo, co
         constantTensorDescriptions.emplace_back(vk::TensorTilingARM::eLinear, constant.format,
                                                 static_cast<uint32_t>(constant.dims.size()), constant.dims.data(),
                                                 nullptr, vk::TensorUsageFlagBitsARM::eDataGraph);
-        constantInfos.emplace_back(constant.index, constant.data.data(), &constantTensorDescriptions.back());
+        constantInfos.emplace_back(static_cast<uint32_t>(constantInfos.size()), constant.data.data(),
+                                   &constantTensorDescriptions.back());
     }
     graphComputePipelineCommon(args.ctx, shaderInfo, resourceInfos, constantInfos, args.pipelineCache,
                                enableNeuralStatistics, neuralStatisticsMode);

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -123,8 +123,7 @@ std::vector<GraphConstantInfo> collectGraphConstants(const std::vector<Guid> &co
             throw std::runtime_error("Graph constant missing src: " + gc->guidStr);
         }
 
-        GraphConstantInfo spec(gc->guidStr, getVkFormatFromString(gc->format), gc->dims,
-                               static_cast<uint32_t>(constants.size()));
+        GraphConstantInfo spec(gc->guidStr, getVkFormatFromString(gc->format), gc->dims);
 
         MemoryMap mapped(gc->src.value());
         const auto constantData = vgfutils::numpy::parse(mapped);

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -135,14 +135,13 @@ union Constant {
 
 struct GraphConstantInfo {
     GraphConstantInfo() = default;
-    GraphConstantInfo(const std::string &debugName, vk::Format format, std::vector<int64_t> dims, uint32_t index)
-        : format(format), dims(std::move(dims)), debugName(debugName), index(index) {}
+    GraphConstantInfo(const std::string &debugName, vk::Format format, std::vector<int64_t> dims)
+        : format(format), dims(std::move(dims)), debugName(debugName) {}
 
     vk::Format format{vk::Format::eUndefined};
     std::vector<int64_t> dims;
     std::vector<uint8_t> data;
     std::string debugName;
-    uint32_t index{};
 };
 
 /// \brief Typed binding


### PR DESCRIPTION
Assign sequential Vulkan graph constant binding IDs while building pipeline constants instead of storing command-specific indexes in GraphConstantInfo.


Change-Id: Iee067ebeae529165cde2c638799ca351f1fe76be