### PR TITLE
fix: Correct graph pipeline cache feedback

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,9 +11,9 @@
 
 ### Bug Fixes
 
-- Enforce fail-on-pipeline-cache-miss for all pipeline types. Cache miss detection
-  has also been extended to check pipeline creation feedback, in addition to
-  compile required.
+- Fixed pipeline-cache miss handling for all pipeline types by checking pipeline
+  creation feedback as well as compile-required results. Data graph pipelines
+  now use the required zero per-stage feedback entries.
 
 ## Version 0.10.0 – *Optical Flow, VGF Runtime & APK Packaging*
 

--- a/src/pipeline_cache.cpp
+++ b/src/pipeline_cache.cpp
@@ -73,7 +73,18 @@ PipelineCache::PipelineCache(const Context &ctx, const std::filesystem::path &pi
 }
 
 vk::PipelineCreationFeedbackCreateInfo *PipelineCache::getCacheFeedbackCreateInfo(PipelineType pipelineType) {
-    const uint32_t stageCount = pipelineType == PipelineType::Graphics ? 2 : 1;
+    uint32_t stageCount = 0;
+    switch (pipelineType) {
+    case PipelineType::Compute:
+        stageCount = 1;
+        break;
+    case PipelineType::Graphics:
+        stageCount = 2;
+        break;
+    case PipelineType::GraphCompute:
+    case PipelineType::Unknown:
+        break;
+    }
     _feedback = vk::PipelineCreationFeedback(vk::PipelineCreationFeedbackFlagBits::eValid, 0);
     _stagedFeedback.assign(stageCount, vk::PipelineCreationFeedback(vk::PipelineCreationFeedbackFlagBits::eValid, 0));
     _feedbackCreateInfo = vk::PipelineCreationFeedbackCreateInfo(

--- a/src/tests/test_pipeline_cache.py
+++ b/src/tests/test_pipeline_cache.py
@@ -15,6 +15,7 @@ import pytest
 
 
 pytestmark = pytest.mark.pipeline_cache
+PIPELINE_CACHE_HEADER_SIZE = 32
 
 
 def _seed_real_pipeline_cache_file(
@@ -244,8 +245,9 @@ def test_enable_pipeline_cache(sdk_tools, resources_helper, numpy_helper, capfd)
     assert len(files) == 1 and files[0].suffix == ".cache"
 
     cache_data_first = files[0].read_bytes()
+    assert len(cache_data_first) >= PIPELINE_CACHE_HEADER_SIZE
 
-    # run the second time and see if cache is loaded
+    # Run the second time and verify the cache file is accepted.
     sdk_tools.run_scenario(
         "test_pipeline_cache/enable_pipeline_cache.json",
         options=[
@@ -293,6 +295,53 @@ def test_enable_pipeline_cache(sdk_tools, resources_helper, numpy_helper, capfd)
 
     cache_data_third = files[0].read_bytes()
     assert len(cache_data_third) > 0
+
+
+@pytest.mark.parametrize(
+    "setup",
+    [
+        pytest.param(_setup_compute_pipeline_cache_miss, id="compute"),
+        pytest.param(
+            _setup_graph_pipeline_cache_miss,
+            marks=pytest.mark.skipif(
+                sys.platform == "win32",
+                reason="The Windows data graph driver does not serialize a reusable pipeline cache payload",
+            ),
+            id="graph_compute",
+        ),
+    ],
+)
+def test_pipeline_cache_hit(sdk_tools, resources_helper, numpy_helper, capfd, setup):
+    scenario, replacements = setup(sdk_tools, resources_helper, numpy_helper)
+    cache_path = resources_helper.get_testenv_path(
+        f"{scenario.replace('/', '_')}_hit_cache"
+    )
+    cache_path.mkdir()
+
+    options = ["--pipeline-caching", "--cache-path", cache_path, "--dry-run"]
+    sdk_tools.run_scenario(scenario, replacements, options=options)
+
+    cache_files = list(cache_path.glob("*.cache"))
+    assert len(cache_files) == 1
+    cache_data = cache_files[0].read_bytes()
+    assert len(cache_data) >= PIPELINE_CACHE_HEADER_SIZE
+    header_size = int.from_bytes(cache_data[:4], byteorder=sys.byteorder)
+    assert header_size == PIPELINE_CACHE_HEADER_SIZE
+    if len(cache_data) == header_size:
+        pytest.skip("Vulkan driver did not serialize a pipeline cache payload")
+
+    capfd.readouterr()
+    sdk_tools.run_scenario(
+        scenario,
+        replacements,
+        options=[*options, "--fail-on-pipeline-cache-miss"],
+    )
+
+    captured = capfd.readouterr()
+    assert "INFO: Pipeline Cache loaded and validated." in captured.out
+    assert "ERROR: Pipeline cache miss for pipeline:" not in (
+        captured.out + captured.err
+    )
 
 
 def test_pipeline_cache_dry_run_precompiles(


### PR DESCRIPTION
Data graph pipelines require zero per-stage pipeline creation feedback entries. Preserve the existing compute and graphics counts while handling graph pipelines according to the Vulkan validity rules.

Strengthen cache tests by requiring identical second runs to hit serialized caches. The Windows data graph driver can emit a non-empty cache without a reusable graph entry, so retain compute hit coverage there and skip only the driver-dependent graph hit case.

Change-Id: Ied23a82fb0b3e43bff47ee72a6fe90abebb4bddc