### PR TITLE
feat: Write profiling data during dry runs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,10 @@
 - Added startup logging for Vulkan API and driver versions and common device
   shader capabilities.
 
+### Profiling
+
+- Using --dry-run with --profiling-dump-path now outputs information about pipeline compilation
+
 ### Bug Fixes
 
 - Fixed pipeline-cache miss handling for all pipeline types by checking pipeline

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "compute.hpp"
-#include "json_writer.hpp"
 #include "logging.hpp"
 #include "utils.hpp"
 
@@ -665,31 +664,33 @@ std::vector<uint64_t> Compute::_queryTimestamps() const {
     throw std::runtime_error("Failed to retrieve timestamps, since the query pool is empty");
 }
 
-void Compute::writeProfilingFile(const std::filesystem::path &profilingPath, int iteration, int repeatCount) const {
-    std::vector<uint64_t> timestamps = _queryTimestamps();
-    VkPhysicalDeviceLimits physicalDeviceLimits = _ctx.physicalDevice().getProperties().limits;
-    float timestampPeriod = physicalDeviceLimits.timestampPeriod;
-    std::vector<ProfiledCommand> profiledCommands;
+RuntimeProfilingData Compute::getRuntimeProfilingData() const {
+    RuntimeProfilingData profilingData;
+    profilingData.timestamps = _queryTimestamps();
+    profilingData.timestampPeriod = _ctx.physicalDevice().getProperties().limits.timestampPeriod;
     for (const auto &command : _commands) {
         if (std::holds_alternative<ComputeDispatch>(command)) {
             const auto &dispatch = std::get<ComputeDispatch>(command);
-            profiledCommands.push_back({"ComputeDispatch", dispatch.profileName});
+            profilingData.commands.push_back({"ComputeDispatch", dispatch.profileName});
         } else if (std::holds_alternative<DataGraphDispatch>(command)) {
             const auto &dispatch = std::get<DataGraphDispatch>(command);
-            profiledCommands.push_back({"DataGraphDispatch", dispatch.profileName});
+            profilingData.commands.push_back({"DataGraphDispatch", dispatch.profileName});
         } else if (std::holds_alternative<GraphicsDispatch>(command)) {
             const auto &dispatch = std::get<GraphicsDispatch>(command);
-            profiledCommands.push_back({"GraphicsDispatch", dispatch.profileName});
+            profilingData.commands.push_back({"GraphicsDispatch", dispatch.profileName});
         }
     }
-    std::vector<ProfiledMemoryUsage> memoryUsages;
+    return profilingData;
+}
+
+MemoryProfilingData Compute::getMemoryProfilingData() const {
+    MemoryProfilingData profilingData;
     for (const auto &pipeline : _pipelines) {
         if (pipeline.isDataGraphPipeline()) {
-            memoryUsages.push_back({pipeline.debugName(), pipeline.getDataGraphPipelineMemoryRequirement()});
+            profilingData.usages.push_back({pipeline.debugName(), pipeline.getDataGraphPipelineMemoryRequirement()});
         }
     }
-    writeProfilingData(timestamps, timestampPeriod, profiledCommands, memoryUsages, profilingPath, iteration,
-                       repeatCount);
+    return profilingData;
 }
 
 void Compute::dumpNeuralDebugDatabase(const std::filesystem::path &neuralDebugDatabaseDumpDir) const {

--- a/src/compute.hpp
+++ b/src/compute.hpp
@@ -6,6 +6,7 @@
 
 #include "context.hpp"
 #include "data_manager.hpp"
+#include "json_writer.hpp"
 #include "perf_counter.hpp"
 #include "pipeline.hpp"
 
@@ -163,8 +164,11 @@ class Compute {
     vk::raii::CommandBuffer &getCommandBuffer();
     void prepareCommandBuffer();
 
-    /// \brief Write profiling data to file
-    void writeProfilingFile(const std::filesystem::path &profilingPath, int iteration, int repeatCount) const;
+    /// \brief Collect runtime timestamp profiling data
+    RuntimeProfilingData getRuntimeProfilingData() const;
+
+    /// \brief Collect data graph pipeline memory usage
+    MemoryProfilingData getMemoryProfilingData() const;
 
     void dumpNeuralDebugDatabase(const std::filesystem::path &neuralDebugDatabaseDumpDir) const;
     void dumpNeuralStatistics(const std::filesystem::path &neuralStatisticsDumpDir,

--- a/src/json_writer.cpp
+++ b/src/json_writer.cpp
@@ -13,7 +13,7 @@ namespace mlsdk::scenariorunner {
 using json = nlohmann::json;
 
 namespace {
-json _profilingDataJsonOutput;
+json _profilingDataJsonOutput = json::object();
 
 struct CommandTimestamps {
     CommandTimestamps() = default;
@@ -95,21 +95,23 @@ void writePerfCounters(std::vector<PerformanceCounter> &perfCounters, std::files
     ostream.close();
 }
 
-void writeProfilingData(const std::vector<uint64_t> &timestamps, const float timestampPeriod,
-                        const std::vector<ProfiledCommand> &profiledCommands,
-                        const std::vector<ProfiledMemoryUsage> &memoryUsages, const std::filesystem::path &path,
+void writeProfilingData(const std::optional<RuntimeProfilingData> &runtimeProfilingData,
+                        const MemoryProfilingData &memoryProfilingData, const std::filesystem::path &path,
                         const int iteration, const int repeatCount) {
-    if (profiledCommands.size() * 2 != timestamps.size()) {
-        throw std::runtime_error("Cannot map all timestamps to their respective commands");
+    if (runtimeProfilingData.has_value()) {
+        const auto &[timestamps, timestampPeriod, commands] = runtimeProfilingData.value();
+        if (commands.size() * 2 != timestamps.size()) {
+            throw std::runtime_error("Cannot map all timestamps to their respective commands");
+        }
+        for (size_t idx = 0, commandIdx = 0; idx < timestamps.size(); idx += 2, ++commandIdx) {
+            _profilingDataJsonOutput["Timestamps"] += CommandTimestamps(
+                commands[commandIdx], {timestamps[idx], timestamps[idx + 1]}, timestampPeriod, iteration);
+        }
     }
-    for (size_t idx = 0, commandIdx = 0; idx < timestamps.size(); idx += 2, ++commandIdx) {
-        _profilingDataJsonOutput["Timestamps"] += CommandTimestamps(
-            profiledCommands[commandIdx], {timestamps[idx], timestamps[idx + 1]}, timestampPeriod, iteration);
-    }
-    for (size_t idx = 0; idx < memoryUsages.size(); ++idx) {
+    for (const auto &memoryUsage : memoryProfilingData.usages) {
         _profilingDataJsonOutput["Memory Usage"] += {{"Command type", "DataGraphDispatch"},
-                                                     {"Command name", memoryUsages[idx].commandName},
-                                                     {"Session memory [bytes]", memoryUsages[idx].sessionMemoryBytes},
+                                                     {"Command name", memoryUsage.commandName},
+                                                     {"Session memory [bytes]", memoryUsage.sessionMemoryBytes},
                                                      {"Iteration", iteration}};
     }
     // Check if this is the last iteration
@@ -117,6 +119,7 @@ void writeProfilingData(const std::vector<uint64_t> &timestamps, const float tim
         std::ofstream dumpFile(path.string());
         dumpFile << _profilingDataJsonOutput.dump(4);
         dumpFile.close();
+        _profilingDataJsonOutput = json::object();
     }
 }
 

--- a/src/json_writer.hpp
+++ b/src/json_writer.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -23,10 +24,19 @@ struct ProfiledMemoryUsage {
     uint64_t sessionMemoryBytes{};
 };
 
+struct RuntimeProfilingData {
+    std::vector<uint64_t> timestamps;
+    float timestampPeriod{};
+    std::vector<ProfiledCommand> commands;
+};
+
+struct MemoryProfilingData {
+    std::vector<ProfiledMemoryUsage> usages;
+};
+
 void writePerfCounters(std::vector<PerformanceCounter> &perfCounters, std::filesystem::path &path);
 
-void writeProfilingData(const std::vector<uint64_t> &timestamps, float timestampPeriod,
-                        const std::vector<ProfiledCommand> &profiledCommands,
-                        const std::vector<ProfiledMemoryUsage> &memoryUsages, const std::filesystem::path &path,
+void writeProfilingData(const std::optional<RuntimeProfilingData> &runtimeProfilingData,
+                        const MemoryProfilingData &memoryProfilingData, const std::filesystem::path &path,
                         int iteration, int repeatCount);
 } // namespace mlsdk::scenariorunner

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -749,8 +749,8 @@ void Scenario::run(int repeatCount, bool dryRun) {
                 handleAliasedLayoutTransitions();
             }
             _compute.submitAndWaitOnFence(_perfCounters, i);
-            saveProfilingData(i, repeatCount);
         }
+        saveProfilingData(i, repeatCount, dryRun);
 
         // Skip reset after final run
         if (i + 1 < repeatCount) {
@@ -1428,10 +1428,15 @@ void Scenario::createPipeline(const uint32_t segmentIndex, const std::vector<Typ
     }
 }
 
-void Scenario::saveProfilingData(int iteration, int repeatCount) {
+void Scenario::saveProfilingData(int iteration, int repeatCount, bool dryRun) {
     // Save profiling data
     if (!_opts.profilingPath.empty()) {
-        _compute.writeProfilingFile(_opts.profilingPath, iteration, repeatCount);
+        std::optional<RuntimeProfilingData> runtimeProfilingData;
+        if (!dryRun) {
+            runtimeProfilingData = _compute.getRuntimeProfilingData();
+        }
+        const auto memoryProfilingData = _compute.getMemoryProfilingData();
+        writeProfilingData(runtimeProfilingData, memoryProfilingData, _opts.profilingPath, iteration, repeatCount);
         mlsdk::logging::info("Profiling data stored");
     }
 }

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -71,7 +71,7 @@ class Scenario {
     void setupCommands();
 
     /// \brief Save profiling data to file
-    void saveProfilingData(int iteration, int repeatCount);
+    void saveProfilingData(int iteration, int repeatCount, bool dryRun);
 
     /// \brief Save results of output resources to files
     void saveResults(bool dryRun);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(ScenarioRunnerTests
   image_formats_tests.cpp
   iresource_tests.cpp
   json_parser_tests.cpp
+  json_writer_tests.cpp
   logging_tests.cpp
   perf_counter_tests.cpp
   png_reader_tests.cpp

--- a/src/tests/json_writer_tests.cpp
+++ b/src/tests/json_writer_tests.cpp
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "json_writer.hpp"
+
+#include "nlohmann/json.hpp"
+#include "vgf-utils/temp_folder.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace mlsdk::scenariorunner {
+
+TEST(JsonWriter, WritesMemoryUsageWithoutTimestamps) {
+    TempFolder tempFolder("scenario_runner_json_writer_tests");
+    const auto profilingPath = tempFolder.relative("dry_run_profiling.json");
+    const MemoryProfilingData memoryProfilingData{{{"graph_ref/conv2d_graph_segment", 4096}}};
+
+    writeProfilingData(std::nullopt, memoryProfilingData, profilingPath, 0, 1);
+
+    std::ifstream dumpFile(profilingPath);
+    const auto profilingData = nlohmann::json::parse(dumpFile);
+
+    ASSERT_FALSE(profilingData.contains("Timestamps"));
+    ASSERT_TRUE(profilingData.contains("Memory Usage"));
+    ASSERT_EQ(profilingData["Memory Usage"].size(), 1);
+    EXPECT_EQ(profilingData["Memory Usage"][0]["Command type"], "DataGraphDispatch");
+    EXPECT_EQ(profilingData["Memory Usage"][0]["Command name"], "graph_ref/conv2d_graph_segment");
+    EXPECT_EQ(profilingData["Memory Usage"][0]["Session memory [bytes]"], 4096);
+}
+
+TEST(JsonWriter, WritesEmptyObjectWithoutProfilingData) { // cppcheck-suppress syntaxError
+    TempFolder tempFolder("scenario_runner_json_writer_tests");
+    const auto profilingPath = tempFolder.relative("empty_dry_run_profiling.json");
+
+    writeProfilingData(std::nullopt, {}, profilingPath, 0, 1);
+
+    std::ifstream dumpFile(profilingPath);
+    const auto profilingData = nlohmann::json::parse(dumpFile);
+
+    EXPECT_TRUE(profilingData.is_object());
+    EXPECT_TRUE(profilingData.empty());
+}
+
+} // namespace mlsdk::scenariorunner

--- a/src/tests/test_repeated_runs.py
+++ b/src/tests/test_repeated_runs.py
@@ -144,6 +144,25 @@ def test_conv2d_vgf_count(sdk_tools, resources_helper, numpy_helper):
     input = numpy_helper.generate(
         [1, 16, 16, 16], dtype=np.int8, filename="conv2dInput.npy"
     )
+    expected_command_name = "graph_ref/conv2d_graph_segment"
+
+    dry_run_dump_path = resources_helper.get_testenv_path(
+        "conv2dDryRunProfilingTest.json"
+    )
+    sdk_tools.run_scenario(
+        "test_vgf_graph/conv2d.json",
+        options=["--dry-run", "--profiling-dump-path", dry_run_dump_path.as_posix()],
+    )
+
+    with open(dry_run_dump_path, encoding="utf-8") as dump_file:
+        dry_run_profiling_data = json.load(dump_file)
+
+    dry_run_memory_usages = dry_run_profiling_data["Memory Usage"]
+    assert "Timestamps" not in dry_run_profiling_data
+    assert len(dry_run_memory_usages) == 1
+    assert dry_run_memory_usages[0]["Command name"] == expected_command_name
+    assert not resources_helper.get_testenv_path("conv2dOutput.npy").exists()
+
     dump_path = os.path.join(os.getcwd(), "conv2dProfilingTest.json")
     sdk_tools.run_scenario(
         "test_vgf_graph/conv2d.json",
@@ -153,7 +172,6 @@ def test_conv2d_vgf_count(sdk_tools, resources_helper, numpy_helper):
     with open(dump_path, encoding="utf-8") as dump_file:
         profiling_data = json.load(dump_file)
 
-    expected_command_name = "graph_ref/conv2d_graph_segment"
     timestamps = profiling_data["Timestamps"]
     memory_usages = profiling_data["Memory Usage"]
     assert len(timestamps) == 2
@@ -170,6 +188,8 @@ def test_conv2d_vgf_count(sdk_tools, resources_helper, numpy_helper):
 
     if os.path.exists(dump_path):
         os.remove(dump_path)
+    if dry_run_dump_path.exists():
+        dry_run_dump_path.unlink()
 
 
 def test_enable_pipeline_cache_repeat_run(


### PR DESCRIPTION
Write data graph pipeline memory requirements to profiling dump files during dry runs. Runtime timestamps are only available after command execution, so omit timestamp data when no runtime execution occurs.

Collect runtime and memory profiling data independently and serialize them together. Add coverage for profiling output without timestamps.

Change-Id: Id6f84815a9fd4a9473d22cffdd2214f4caedbc7b