### PR TITLE
refactor: use typed IDs for data graph runtime

### DIFF
--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -22,8 +22,8 @@ void DataManager::createImage(Guid guid, const ImageInfo &info) { _images.emplac
 
 void DataManager::createImage(Guid guid, ImageInfo &&info) { _images.emplace(guid, Image(std::move(info))); }
 
-void DataManager::createVgfView(Guid guid, const DataGraphInfo &info) {
-    _vgfViews.insert({guid, VgfView::createVgfView(info.src)});
+void DataManager::createVgfView(DataGraphId id, const DataGraphInfo &info) {
+    _vgfViews.insert({id, VgfView::createVgfView(info.src)});
 }
 
 void DataManager::createImageBarrier(Guid guid, const ImageBarrierData &data) {
@@ -117,11 +117,11 @@ const RawData &DataManager::getRawData(const Guid &guid) const {
     return _rawData.at(guid);
 }
 
-const VgfView &DataManager::getVgfView(const Guid &guid) const {
-    if (_vgfViews.find(guid) == _vgfViews.end()) {
+const VgfView &DataManager::getVgfView(DataGraphId id) const {
+    if (_vgfViews.find(id) == _vgfViews.end()) {
         throw std::runtime_error("Vgf not found");
     }
-    return _vgfViews.at(guid);
+    return _vgfViews.at(id);
 }
 
 const VulkanImageBarrier &DataManager::getImageBarrier(const Guid &guid) const {

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -8,6 +8,7 @@
 #include "buffer.hpp"
 #include "image.hpp"
 #include "raw_data.hpp"
+#include "resource_id.hpp"
 #include "tensor.hpp"
 #include "vgf_view.hpp"
 
@@ -24,7 +25,7 @@ class DataManager {
     void createImage(Guid guid, const ImageInfo &info);
     void createImage(Guid guid, ImageInfo &&info);
     void createRawData(Guid guid, const RawDataInfo &info);
-    void createVgfView(Guid guid, const DataGraphInfo &info);
+    void createVgfView(DataGraphId id, const DataGraphInfo &info);
     void createImageBarrier(Guid guid, const ImageBarrierData &data);
     void createTensorBarrier(Guid guid, const TensorBarrierData &data);
     void createMemoryBarrier(Guid guid, const MemoryBarrierData &data);
@@ -47,7 +48,7 @@ class DataManager {
     const Tensor &getTensor(const Guid &guid) const;
     const Image &getImage(const Guid &guid) const;
     const RawData &getRawData(const Guid &guid) const;
-    const VgfView &getVgfView(const Guid &guid) const;
+    const VgfView &getVgfView(DataGraphId id) const;
     const VulkanImageBarrier &getImageBarrier(const Guid &guid) const;
     const VulkanMemoryBarrier &getMemoryBarrier(const Guid &guid) const;
     const VulkanBufferBarrier &getBufferBarrier(const Guid &guid) const;
@@ -62,7 +63,7 @@ class DataManager {
     std::unordered_map<Guid, Tensor> _tensors;
     std::unordered_map<Guid, Image> _images;
     std::unordered_map<Guid, RawData> _rawData;
-    std::unordered_map<Guid, VgfView> _vgfViews;
+    std::unordered_map<DataGraphId, VgfView> _vgfViews;
     std::unordered_map<Guid, VulkanImageBarrier> _imageBarriers;
     std::unordered_map<Guid, VulkanMemoryBarrier> _memoryBarriers;
     std::unordered_map<Guid, VulkanBufferBarrier> _bufferBarriers;

--- a/src/resource_desc.hpp
+++ b/src/resource_desc.hpp
@@ -66,15 +66,6 @@ struct BufferDesc : ResourceDesc {
 };
 
 /**
- * @brief SpecializationConstantMap is used to map specialization constants to multiple shaders within a graph
- *
- */
-struct SpecializationConstantMap {
-    std::vector<SpecializationConstant> specializationConstants;
-    Guid shaderTarget;
-};
-
-/**
  * @brief DataGraphDesc describes a DataGraph file.
  *
  */

--- a/src/resource_id.hpp
+++ b/src/resource_id.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <variant>
 
 namespace mlsdk::scenariorunner {
@@ -45,3 +46,9 @@ using TypedResourceId =
     std::variant<BufferId, ImageId, TensorId, ShaderId, RawDataId, DataGraphId, GraphConstantResourceId>;
 
 } // namespace mlsdk::scenariorunner
+
+namespace std {
+template <typename Tag> struct hash<mlsdk::scenariorunner::ResourceId<Tag>> {
+    size_t operator()(mlsdk::scenariorunner::ResourceId<Tag> id) const noexcept { return hash<size_t>{}(id.value()); }
+};
+} // namespace std

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -61,7 +61,9 @@ struct ResolvedShaderSubstitution {
 
 /// \brief Compute data graph with typed bindings
 struct DispatchDataGraphData {
-    Guid dataGraphRef;
+    explicit DispatchDataGraphData(DataGraphId dataGraph) : dataGraph(dataGraph) {}
+
+    DataGraphId dataGraph;
     std::string debugName;
     std::vector<TypedBinding> bindings;
     std::vector<PushConstantMap> pushConstants;
@@ -112,27 +114,14 @@ std::vector<GraphConstantInfo> collectGraphConstants(const std::vector<GraphCons
     return constants;
 }
 
-const DataGraphDesc &getDataGraphDesc(const ScenarioSpec &spec, const Guid &guid) {
-    for (const auto &resource : spec.resources) {
-        if (resource->guid == guid) {
-            if (resource->resourceType != ResourceType::DataGraph) {
-                throw std::runtime_error("GUID does not reference a graph resource: " + resource->guidStr);
-            }
-            return static_cast<const DataGraphDesc &>(*resource);
-        }
-    }
-    throw std::runtime_error("Graph resource not found.");
-}
-
-void applyGraphResourceShaderMetadata(ShaderInfo &shaderInfo, const DataGraphDesc &dataGraph,
+void applyGraphResourceShaderMetadata(ShaderInfo &shaderInfo, const DataGraphInfo &dataGraph,
                                       const std::string &moduleName) {
     if (dataGraph.pushConstantsSize > 0) {
         shaderInfo.pushConstantsSize = dataGraph.pushConstantsSize;
     }
 
-    const Guid shaderTarget(moduleName);
     for (const auto &specializationConstantMap : dataGraph.specializationConstantMaps) {
-        if (specializationConstantMap.shaderTarget == shaderTarget) {
+        if (specializationConstantMap.shaderTarget == moduleName) {
             shaderInfo.specializationConstants = specializationConstantMap.specializationConstants;
             return;
         }
@@ -194,7 +183,8 @@ struct ResourceInfoFactory {
     RawDataInfo createInfo(const RawDataDesc &rawData) const { return {rawData.guidStr, rawData.src.value()}; }
 
     DataGraphInfo createInfo(const DataGraphDesc &dataGraph) const {
-        return {dataGraph.guidStr, dataGraph.src.value()};
+        return {dataGraph.guidStr, dataGraph.src.value(), dataGraph.pushConstantsSize,
+                dataGraph.specializationConstantMaps};
     }
 
     GraphConstantInfo createInfo(const GraphConstantDesc &graphConstant) const {
@@ -526,6 +516,10 @@ struct CommandDataFactory {
         return resolveResourceId<GraphConstantResourceId>(_resourceIds, guid, "Graph constant");
     }
 
+    DataGraphId getDataGraphId(const Guid &guid) const {
+        return resolveResourceId<DataGraphId>(_resourceIds, guid, "Data graph");
+    }
+
     DispatchComputeData createData(const DispatchComputeDesc &dispatchCompute) {
         DispatchComputeData data{getShaderId(dispatchCompute.shaderRef)};
         data.debugName = dispatchCompute.debugName;
@@ -592,8 +586,7 @@ struct CommandDataFactory {
     }
 
     DispatchDataGraphData createData(const DispatchDataGraphDesc &dispatchDataGraph) {
-        DispatchDataGraphData data;
-        data.dataGraphRef = dispatchDataGraph.dataGraphRef;
+        DispatchDataGraphData data{getDataGraphId(dispatchDataGraph.dataGraphRef)};
         data.debugName = dispatchDataGraph.debugName;
         data.bindings = convertBindings(_dataManager, dispatchDataGraph.bindings);
         data.pushConstants = dispatchDataGraph.pushConstants;
@@ -832,7 +825,7 @@ void Scenario::setupResources() {
             PerfCounterGuard guard(_perfCounters, "Parse VGF: " + dataGraph->guidStr, "Scenario Setup");
             const auto id = _resources.addDataGraph(resourceInfoFactory.createInfo(*dataGraph));
             _resourceIds.emplace(resource->guid, id);
-            _dataManager.createVgfView(resource->guid, _resources.get(id));
+            _dataManager.createVgfView(id, _resources.get(id));
         } break;
         case ResourceType::Tensor: {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
@@ -864,7 +857,9 @@ void Scenario::setupResources() {
         }
 
         const auto &dispatchDataGraph = static_cast<const DispatchDataGraphDesc &>(*command);
-        const auto &vgfView = _dataManager.getVgfView(dispatchDataGraph.dataGraphRef);
+        const auto dataGraph =
+            resolveResourceId<DataGraphId>(_resourceIds, dispatchDataGraph.dataGraphRef, "Data graph");
+        const auto &vgfView = _dataManager.getVgfView(dataGraph);
         const auto externalBindings = convertBindings(_dataManager, dispatchDataGraph.bindings);
         // Register aliases before creating resources so setup/allocation sees the complete group membership.
         for (const auto &alias : vgfView.getResourceAliases(externalBindings)) {
@@ -1272,7 +1267,7 @@ void Scenario::createFragmentPipeline(const DispatchFragmentData &dispatchFragme
 }
 
 void Scenario::createDataGraphPipeline(const DispatchDataGraphData &dispatchDataGraph, uint32_t &nQueries) {
-    const VgfView &vgfView = _dataManager.getVgfView(dispatchDataGraph.dataGraphRef);
+    const VgfView &vgfView = _dataManager.getVgfView(dispatchDataGraph.dataGraph);
     for (uint32_t segmentIndex = 0; segmentIndex < vgfView.getNumSegments(); ++segmentIndex) {
         const auto &sequenceBindings = vgfView.resolveBindings(segmentIndex, _dataManager, dispatchDataGraph.bindings);
         auto moduleName = vgfView.getModuleName(segmentIndex);
@@ -1379,7 +1374,7 @@ void Scenario::createPipeline(const uint32_t segmentIndex, const std::vector<Typ
         mlsdk::logging::debug("Graph Pipeline: " + vgfView.getModuleName(segmentIndex) + " created");
     } break;
     case ModuleType::SHADER: {
-        const auto &dataGraph = getDataGraphDesc(_scenarioSpec, dispatchDataGraph.dataGraphRef);
+        const auto &dataGraph = _resources.get(dispatchDataGraph.dataGraph);
         const auto moduleName = vgfView.getModuleName(segmentIndex);
         bool hasSPVModule = vgfView.hasSPVModule(segmentIndex);
         bool hasGLSLModule = vgfView.hasGLSLModule(segmentIndex);

--- a/src/tests/resource_manager_tests.cpp
+++ b/src/tests/resource_manager_tests.cpp
@@ -9,12 +9,20 @@
 
 #include <stdexcept>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 
 using namespace mlsdk::scenariorunner;
 
 static_assert(!std::is_same_v<BufferId, TensorId>);
 static_assert(!std::is_convertible_v<BufferId, TensorId>);
+
+TEST(ResourceId, SupportsUnorderedContainers) {
+    std::unordered_map<BufferId, std::string> buffers;
+    buffers.emplace(BufferId{3}, "buffer");
+
+    EXPECT_EQ(buffers.at(BufferId{3}), "buffer");
+}
 
 TEST(ResourceManager, AssignsIdsIndependentlyPerType) {
     ResourceManager resources;
@@ -26,7 +34,7 @@ TEST(ResourceManager, AssignsIdsIndependentlyPerType) {
     BufferInfo bufferB{};
     bufferB.debugName = "buffer_b";
     RawDataInfo rawData{"raw_data", "data.npy"};
-    DataGraphInfo dataGraph{"data_graph", "graph.vgf"};
+    DataGraphInfo dataGraph{"data_graph", "graph.vgf", 0, {}};
     GraphConstantInfo graphConstant{"constant", vk::Format::eR32Sfloat, {1}};
 
     const auto bufferAId = resources.addBuffer(std::move(bufferA));
@@ -60,7 +68,7 @@ TEST(ResourceManager, PreservesResourceInfo) {
     EXPECT_EQ(resources.get(shaderId).pushConstantsSize, 16U);
 
     const auto rawDataId = resources.addRawData({"raw_data", "data.npy"});
-    const auto dataGraphId = resources.addDataGraph({"data_graph", "graph.vgf"});
+    const auto dataGraphId = resources.addDataGraph({"data_graph", "graph.vgf", 0, {}});
     GraphConstantInfo graphConstant{"constant", vk::Format::eR32Sint, {2}};
     graphConstant.data = {1, 2, 3, 4, 5, 6, 7, 8};
     const auto graphConstantId = resources.addGraphConstant(std::move(graphConstant));

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -71,12 +71,6 @@ struct RawDataInfo {
     std::string src;
 };
 
-/// \brief Information needed to load a data graph from a file
-struct DataGraphInfo {
-    std::string debugName;
-    std::string src;
-};
-
 /// \brief Structure that describes N-dimensional data
 ///
 /// \note We don't account for any specialized meta-data like
@@ -164,6 +158,20 @@ enum class ShaderType {
 struct SpecializationConstant {
     int id{};
     Constant value;
+};
+
+/// \brief Maps specialization constants to a shader within a graph
+struct SpecializationConstantMap {
+    std::vector<SpecializationConstant> specializationConstants;
+    std::string shaderTarget;
+};
+
+/// \brief Information needed to load and configure a data graph
+struct DataGraphInfo {
+    std::string debugName;
+    std::string src;
+    uint32_t pushConstantsSize{};
+    std::vector<SpecializationConstantMap> specializationConstantMaps;
 };
 
 /// \brief ShaderInfo describes a shader.


### PR DESCRIPTION
Store VGF runtime views by DataGraphId and resolve JSON UIDs through a unified typed resource map before creating data graph commands.


Change-Id: Icd46a3730b97f9eca682fbab4a4a7af5c1cda343