### PR TITLE
refactor: use typed IDs for raw data runtime

### DIFF
--- a/src/commands.hpp
+++ b/src/commands.hpp
@@ -122,7 +122,7 @@ struct DispatchFragmentDesc : CommandDesc {
  */
 struct PushConstantMap {
     Guid pushDataRef;
-    Guid shaderTarget;
+    std::string shaderTarget;
 };
 
 /**

--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -42,8 +42,8 @@ void DataManager::createBufferBarrier(Guid guid, const BufferBarrierData &data) 
     _bufferBarriers.insert({guid, VulkanBufferBarrier(data)});
 }
 
-void DataManager::createRawData(Guid guid, const RawDataInfo &info) {
-    _rawData.insert({guid, RawData(info.debugName, info.src)});
+void DataManager::createRawData(RawDataId id, const RawDataInfo &info) {
+    _rawData.insert({id, RawData(info.debugName, info.src)});
 }
 
 bool DataManager::hasBuffer(Guid guid) const { return _buffers.find(guid) != _buffers.end(); }
@@ -52,7 +52,7 @@ bool DataManager::hasTensor(Guid guid) const { return _tensors.find(guid) != _te
 
 bool DataManager::hasImage(Guid guid) const { return _images.find(guid) != _images.end(); }
 
-bool DataManager::hasRawData(Guid guid) const { return _rawData.find(guid) != _rawData.end(); }
+bool DataManager::hasRawData(RawDataId id) const { return _rawData.find(id) != _rawData.end(); }
 
 bool DataManager::hasImageBarrier(Guid guid) const { return _imageBarriers.find(guid) != _imageBarriers.end(); }
 
@@ -110,11 +110,11 @@ const Image &DataManager::getImage(const Guid &guid) const {
     return _images.at(guid);
 }
 
-const RawData &DataManager::getRawData(const Guid &guid) const {
-    if (_rawData.find(guid) == _rawData.end()) {
+const RawData &DataManager::getRawData(RawDataId id) const {
+    if (_rawData.find(id) == _rawData.end()) {
         throw std::runtime_error("RawData not found");
     }
-    return _rawData.at(guid);
+    return _rawData.at(id);
 }
 
 const VgfView &DataManager::getVgfView(DataGraphId id) const {

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -24,7 +24,7 @@ class DataManager {
     void createTensor(Guid guid, TensorInfo &&info);
     void createImage(Guid guid, const ImageInfo &info);
     void createImage(Guid guid, ImageInfo &&info);
-    void createRawData(Guid guid, const RawDataInfo &info);
+    void createRawData(RawDataId id, const RawDataInfo &info);
     void createVgfView(DataGraphId id, const DataGraphInfo &info);
     void createImageBarrier(Guid guid, const ImageBarrierData &data);
     void createTensorBarrier(Guid guid, const TensorBarrierData &data);
@@ -34,7 +34,7 @@ class DataManager {
     bool hasBuffer(Guid guid) const;
     bool hasTensor(Guid guid) const;
     bool hasImage(Guid guid) const;
-    bool hasRawData(Guid guid) const;
+    bool hasRawData(RawDataId id) const;
     bool hasImageBarrier(Guid guid) const;
     bool hasTensorBarrier(Guid guid) const;
     bool hasMemoryBarrier(Guid guid) const;
@@ -47,7 +47,7 @@ class DataManager {
     const Buffer &getBuffer(const Guid &guid) const;
     const Tensor &getTensor(const Guid &guid) const;
     const Image &getImage(const Guid &guid) const;
-    const RawData &getRawData(const Guid &guid) const;
+    const RawData &getRawData(RawDataId id) const;
     const VgfView &getVgfView(DataGraphId id) const;
     const VulkanImageBarrier &getImageBarrier(const Guid &guid) const;
     const VulkanMemoryBarrier &getMemoryBarrier(const Guid &guid) const;
@@ -62,7 +62,7 @@ class DataManager {
     std::unordered_map<Guid, Buffer> _buffers;
     std::unordered_map<Guid, Tensor> _tensors;
     std::unordered_map<Guid, Image> _images;
-    std::unordered_map<Guid, RawData> _rawData;
+    std::unordered_map<RawDataId, RawData> _rawData;
     std::unordered_map<DataGraphId, VgfView> _vgfViews;
     std::unordered_map<Guid, VulkanImageBarrier> _imageBarriers;
     std::unordered_map<Guid, VulkanMemoryBarrier> _memoryBarriers;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -32,7 +32,7 @@ struct DispatchComputeData {
     ComputeDispatch computeDispatch{};
     ShaderId shader;
     bool implicitBarrier{true};
-    std::optional<Guid> pushDataRef;
+    std::optional<RawDataId> pushData;
 };
 
 /// \brief Fragment (graphics) data with typed bindings
@@ -51,7 +51,12 @@ struct DispatchFragmentData {
     std::vector<Attachment> colorAttachments;
     std::optional<vk::Extent2D> renderExtent;
     bool implicitBarrier{true};
-    std::optional<Guid> pushDataRef;
+    std::optional<RawDataId> pushData;
+};
+
+struct ResolvedPushConstantMap {
+    RawDataId pushData;
+    std::string shaderTarget;
 };
 
 struct ResolvedShaderSubstitution {
@@ -66,7 +71,7 @@ struct DispatchDataGraphData {
     DataGraphId dataGraph;
     std::string debugName;
     std::vector<TypedBinding> bindings;
-    std::vector<PushConstantMap> pushConstants;
+    std::vector<ResolvedPushConstantMap> pushConstants;
     std::vector<ResolvedShaderSubstitution> shaderSubstitutions;
     bool implicitBarrier{true};
 };
@@ -128,12 +133,11 @@ void applyGraphResourceShaderMetadata(ShaderInfo &shaderInfo, const DataGraphInf
     }
 }
 
-std::optional<Guid> getGraphPushDataRef(const std::vector<PushConstantMap> &pushConstants,
-                                        const std::string &moduleName) {
-    const Guid shaderTarget(moduleName);
+std::optional<RawDataId> getGraphPushData(const std::vector<ResolvedPushConstantMap> &pushConstants,
+                                          const std::string &moduleName) {
     for (const auto &pushConstant : pushConstants) {
-        if (pushConstant.shaderTarget == shaderTarget) {
-            return pushConstant.pushDataRef;
+        if (pushConstant.shaderTarget == moduleName) {
+            return pushConstant.pushData;
         }
     }
     return std::nullopt;
@@ -520,6 +524,13 @@ struct CommandDataFactory {
         return resolveResourceId<DataGraphId>(_resourceIds, guid, "Data graph");
     }
 
+    std::optional<RawDataId> getRawDataId(const std::optional<Guid> &guid) const {
+        if (!guid) {
+            return std::nullopt;
+        }
+        return resolveResourceId<RawDataId>(_resourceIds, *guid, "Raw data");
+    }
+
     DispatchComputeData createData(const DispatchComputeDesc &dispatchCompute) {
         DispatchComputeData data{getShaderId(dispatchCompute.shaderRef)};
         data.debugName = dispatchCompute.debugName;
@@ -529,7 +540,7 @@ struct CommandDataFactory {
         data.computeDispatch.gwcz = dispatchCompute.rangeND[2];
         data.computeDispatch.profileName = dispatchCompute.debugName;
         data.implicitBarrier = dispatchCompute.implicitBarrier;
-        data.pushDataRef = dispatchCompute.pushDataRef;
+        data.pushData = getRawDataId(dispatchCompute.pushDataRef);
         return data;
     }
 
@@ -548,7 +559,7 @@ struct CommandDataFactory {
             data.renderExtent = vk::Extent2D(extent[0], extent[1]);
         }
         data.implicitBarrier = dispatchFragment.implicitBarrier;
-        data.pushDataRef = dispatchFragment.pushDataRef;
+        data.pushData = getRawDataId(dispatchFragment.pushDataRef);
         return data;
     }
 
@@ -589,7 +600,12 @@ struct CommandDataFactory {
         DispatchDataGraphData data{getDataGraphId(dispatchDataGraph.dataGraphRef)};
         data.debugName = dispatchDataGraph.debugName;
         data.bindings = convertBindings(_dataManager, dispatchDataGraph.bindings);
-        data.pushConstants = dispatchDataGraph.pushConstants;
+        data.pushConstants.reserve(dispatchDataGraph.pushConstants.size());
+        for (const auto &pushConstant : dispatchDataGraph.pushConstants) {
+            data.pushConstants.push_back(
+                {resolveResourceId<RawDataId>(_resourceIds, pushConstant.pushDataRef, "Raw data"),
+                 pushConstant.shaderTarget});
+        }
         data.shaderSubstitutions.reserve(dispatchDataGraph.shaderSubstitutions.size());
         for (const auto &substitution : dispatchDataGraph.shaderSubstitutions) {
             data.shaderSubstitutions.push_back({getShaderId(substitution.shaderRef), substitution.target});
@@ -812,7 +828,7 @@ void Scenario::setupResources() {
             const auto &rawData = reinterpret_cast<const std::unique_ptr<RawDataDesc> &>(resource);
             const auto id = _resources.addRawData(resourceInfoFactory.createInfo(*rawData));
             _resourceIds.emplace(resource->guid, id);
-            _dataManager.createRawData(resource->guid, _resources.get(id));
+            _dataManager.createRawData(id, _resources.get(id));
         } break;
         case ResourceType::Image: {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
@@ -1167,10 +1183,10 @@ void Scenario::handleAliasedLayoutTransitions() {
     }
 }
 
-std::pair<const char *, size_t> getPushConstantData(const std::optional<Guid> &pushDataRef,
+std::pair<const char *, size_t> getPushConstantData(const std::optional<RawDataId> &pushData,
                                                     const DataManager &dataManager) {
-    if (pushDataRef) {
-        const auto &rawData = dataManager.getRawData(pushDataRef.value());
+    if (pushData) {
+        const auto &rawData = dataManager.getRawData(pushData.value());
         return std::make_pair(rawData.data(), rawData.size());
     }
     return std::make_pair(nullptr, 0U);
@@ -1187,7 +1203,7 @@ void Scenario::createComputePipeline(const DispatchComputeData &dispatchCompute,
     PerfCounterGuard guard(_perfCounters, "Create Pipeline: " + shaderInfo.debugName, "Pipeline Setup");
     _compute.createPipeline(args, shaderInfo);
     _compute.registerWriteTimestamp(nQueries++, vk::PipelineStageFlagBits2::eComputeShader);
-    const auto [pushConstantData, pushConstantSize] = getPushConstantData(dispatchCompute.pushDataRef, _dataManager);
+    const auto [pushConstantData, pushConstantSize] = getPushConstantData(dispatchCompute.pushData, _dataManager);
     _compute.registerPipelineFenced(_dataManager, dispatchCompute.bindings, pushConstantData, pushConstantSize,
                                     dispatchCompute.implicitBarrier, dispatchCompute.computeDispatch);
     _compute.registerWriteTimestamp(nQueries++, vk::PipelineStageFlagBits2::eComputeShader);
@@ -1254,7 +1270,7 @@ void Scenario::createFragmentPipeline(const DispatchFragmentData &dispatchFragme
 
     _compute.createPipeline(args, vertexShaderInfo, fragmentShaderInfo, colorAttachmentFormats);
     _compute.registerWriteTimestamp(nQueries++, vk::PipelineStageFlagBits2::eColorAttachmentOutput);
-    const auto [pushConstantData, pushConstantSize] = getPushConstantData(dispatchFragment.pushDataRef, _dataManager);
+    const auto [pushConstantData, pushConstantSize] = getPushConstantData(dispatchFragment.pushData, _dataManager);
 
     GraphicsDispatchInfo dispatchInfo{};
     dispatchInfo.colorAttachments = std::move(attachmentInfos);
@@ -1424,7 +1440,7 @@ void Scenario::createPipeline(const uint32_t segmentIndex, const std::vector<Typ
         auto dispatchShape = vgfView.getDispatchShape(segmentIndex);
         _compute.registerWriteTimestamp(nQueries++, vk::PipelineStageFlagBits2::eComputeShader);
         const auto [pushConstantData, pushConstantSize] =
-            getPushConstantData(getGraphPushDataRef(dispatchDataGraph.pushConstants, moduleName), _dataManager);
+            getPushConstantData(getGraphPushData(dispatchDataGraph.pushConstants, moduleName), _dataManager);
         _compute.registerPipelineFenced(_dataManager, sequenceBindings, pushConstantData, pushConstantSize,
                                         dispatchDataGraph.implicitBarrier,
                                         {dispatchShape[0], dispatchShape[1], dispatchShape[2], profileName});

--- a/src/tests/json_parser_tests.cpp
+++ b/src/tests/json_parser_tests.cpp
@@ -908,7 +908,7 @@ TEST(JsonParser, Commands) {
 
         const auto &pushConstant = commandPtr->pushConstants.at(0);
         ASSERT_TRUE(pushConstant.pushDataRef == Guid("RawData1"));
-        ASSERT_TRUE(pushConstant.shaderTarget == Guid("Shader1"));
+        ASSERT_TRUE(pushConstant.shaderTarget == "Shader1");
     }
 
     {


### PR DESCRIPTION
Store runtime raw data by RawDataId and resolve JSON push-data UIDs through the unified typed resource map when creating commands.


Change-Id: Icd57306617337b492b2144f0bf42bc04c96692a3