### PR TITLE
refactor: add in-memory upload/download for buffer

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -57,7 +57,8 @@ void Buffer::fillFromDescription(const Context &ctx, const BufferDesc &buffer) c
     if (buffer.src.has_value()) {
         MemoryMap mapped(buffer.src.value());
         auto dataPtr = vgfutils::numpy::parse(mapped);
-        fill(ctx, dataPtr.ptr, dataPtr.size());
+        BufferDataView view{dataPtr.ptr, dataPtr.size()};
+        upload(ctx, view);
     } else {
         fillZero(ctx);
     }
@@ -82,13 +83,28 @@ void Buffer::fillZero(const Context &ctx) const {
     _memoryManager->uploadData(ctx, _memoryOffset, size());
 }
 
-void Buffer::store(const Context &ctx, const std::string &filename) const {
-    _memoryManager->downloadData(ctx, _memoryOffset, size());
+void Buffer::upload(const Context &ctx, const BufferDataView &data) const {
+    if (data.size != this->size()) {
+        throw std::runtime_error("Buffer::upload: size mismatch");
+    }
+    fill(ctx, data.data, data.size);
+}
 
+BufferData Buffer::download(const Context &ctx) const {
+    _memoryManager->downloadData(ctx, _memoryOffset, size());
     ScopeExit<void()> onScopeExitRun([&] { _memoryManager->unmapStagingBufferMemory(); });
-    vgfutils::numpy::DataPtr data(
-        reinterpret_cast<const char *>(_memoryManager->mapStagingBufferMemory(_memoryOffset, size())), {size()},
-        vgfutils::numpy::DType('i', 1));
+
+    BufferData bd;
+    bd.data.resize(size());
+    const auto *mapped = static_cast<const char *>(_memoryManager->mapStagingBufferMemory(_memoryOffset, size()));
+    std::memcpy(bd.data.data(), mapped, bd.data.size());
+    return bd;
+}
+
+void Buffer::store(const Context &ctx, const std::string &filename) const {
+    const auto bufferContents = download(ctx);
+    vgfutils::numpy::DataPtr data(bufferContents.data.data(), {static_cast<int64_t>(bufferContents.data.size())},
+                                  vgfutils::numpy::DType('i', 1));
     vgfutils::numpy::write(filename, data);
 }
 

--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "context.hpp"
+#include "resource_data.hpp"
 #include "resource_desc.hpp"
 #include "types.hpp"
 #include "vulkan_memory_manager.hpp"
@@ -51,6 +52,22 @@ class Buffer {
 
     /// \brief Fills the buffer with zeros
     void fillZero(const Context &ctx) const;
+
+    /// \brief Upload in‑memory data into this buffer (host → device)
+    ///
+    /// Copies the provided bytes to device‑local memory via a staging transfer
+    /// The payload size must exactly match `size()`
+    /// \param ctx   Vulkan context
+    /// \param data  BufferDataView containing bytes for upload
+    void upload(const Context &ctx, const BufferDataView &data) const;
+
+    /// \brief Download buffer contents (device → host)
+    ///
+    /// Reads the current buffer contents into an owned byte vector
+    /// Buffers are untyped; only raw bytes are returned
+    /// \param ctx Vulkan context
+    /// \return BufferData containing a copy of the bytes
+    BufferData download(const Context &ctx) const;
 
     /// \brief Retrieves the buffer data and writes it to a file
     void store(const Context &ctx, const std::string &filename) const;

--- a/src/resource_data.hpp
+++ b/src/resource_data.hpp
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "types.hpp"
+
+namespace mlsdk::scenariorunner {
+
+struct BufferDataView {
+    const void *data{nullptr};
+    size_t size{0};
+};
+
+struct BufferData {
+    std::vector<char> data; // owned bytes
+};
+
+} // namespace mlsdk::scenariorunner

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ include(gtest)
 include(CTest)
 
 add_executable(ScenarioRunnerTests
+  buffer_tests.cpp
   dds_reader_tests.cpp
   guid_tests.cpp
   group_manager_tests.cpp

--- a/src/tests/buffer_tests.cpp
+++ b/src/tests/buffer_tests.cpp
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "buffer.hpp"
+#include "data_manager.hpp"
+#include "resource_data.hpp"
+#include "scenario.hpp"
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <vector>
+
+using namespace mlsdk::scenariorunner;
+
+Buffer &prepareBuffer(Context &ctx, DataManager &dm, const Guid &guid, uint32_t sizeBytes) {
+    BufferInfo info;
+    info.size = sizeBytes;
+    dm.createBuffer(guid, info);
+    auto &buf = dm.getBufferMut(guid);
+    buf.setup(ctx);
+    buf.allocateMemory(ctx);
+    return buf;
+}
+
+TEST(BufferInMemoryTransfer, UploadThrowsOnSizeMismatch) {
+    ScenarioOptions opts{};
+    Context ctx{opts};
+    DataManager dm;
+
+    const Guid guid("buf_mismatch");
+    auto &buf = prepareBuffer(ctx, dm, guid, /*sizeBytes*/ 16);
+
+    std::vector<char> small(8, static_cast<char>(0x7B));
+    BufferDataView view{small.data(), small.size()};
+    EXPECT_THROW(buf.upload(ctx, view), std::runtime_error);
+}
+
+TEST(BufferInMemoryTransfer, UploadSucceedsAndPersistsCopy) {
+    ScenarioOptions opts{};
+    Context ctx{opts};
+    DataManager dm;
+
+    const Guid guid("buf_upload_ok");
+    auto &buf = prepareBuffer(ctx, dm, guid, /*sizeBytes*/ 16);
+
+    std::vector<char> payload(16);
+    std::iota(payload.begin(), payload.end(), static_cast<char>(0));
+    BufferDataView view{payload.data(), payload.size()};
+    ASSERT_NO_THROW(buf.upload(ctx, view));
+
+    // Mutate source to ensure Buffer keeps a copy, not an alias
+    std::fill(payload.begin(), payload.end(), static_cast<char>(0xAA));
+
+    const auto bufferData = buf.download(ctx);
+    ASSERT_EQ(bufferData.data.size(), static_cast<size_t>(buf.size()));
+
+    for (size_t i = 0; i < bufferData.data.size(); ++i) {
+        EXPECT_EQ(static_cast<unsigned char>(bufferData.data[i]), static_cast<unsigned char>(i))
+            << "mismatch at index " << i;
+    }
+}
+
+TEST(BufferInMemoryTransfer, DownloadReturnsUploadedData) {
+    ScenarioOptions opts{};
+    Context ctx{opts};
+    DataManager dm;
+
+    const Guid guid("buf_download_ok");
+    auto &buf = prepareBuffer(ctx, dm, guid, /*sizeBytes*/ 12);
+
+    std::vector<char> payload(12);
+    std::iota(payload.begin(), payload.end(), static_cast<char>(0));
+    BufferDataView view{payload.data(), payload.size()};
+    buf.upload(ctx, view);
+
+    const auto bufferData = buf.download(ctx);
+    ASSERT_EQ(bufferData.data.size(), payload.size());
+    EXPECT_EQ(bufferData.data, payload);
+}


### PR DESCRIPTION
- Add BufferData/View types
- Add Buffer::upload/download
- Route fillFromDescription()/store() via new methods

Change-Id: I8b4c4bc1c449fccd6a6a200bd9c50315054e173f