### PR TITLE
refactor: finalize memory groups before setup

### DIFF
--- a/src/group_manager.cpp
+++ b/src/group_manager.cpp
@@ -11,6 +11,9 @@
 namespace mlsdk::scenariorunner {
 
 void GroupManager::addResourceToGroup(const Guid &group, const Guid &resource, ResourceIdType resourceIdType) {
+    if (_finalized) {
+        throw std::runtime_error("Cannot add resource to memory group after finalization");
+    }
     const auto [resourceIt, inserted] = _resourceToGroup.emplace(resource, group);
     if (!inserted && resourceIt->second != group) {
         throw std::runtime_error("Resource already belongs to a different group");
@@ -18,6 +21,20 @@ void GroupManager::addResourceToGroup(const Guid &group, const Guid &resource, R
     logging::debug("addResourceToGroup count of resources: " + std::to_string(_resourceToGroup.size()) +
                    " added type: " + std::to_string(static_cast<int>(resourceIdType)));
     _groupResources[group].insert({resource, resourceIdType});
+}
+
+void GroupManager::finalize() {
+    if (_finalized) {
+        throw std::runtime_error("Memory groups are already finalized");
+    }
+    for (const auto &[group, resources] : _groupResources) {
+        auto manager = std::make_shared<ResourceMemoryManager>();
+        if (resources.size() > 1) {
+            manager->markShared();
+        }
+        _groupMemoryManagers.emplace(group, std::move(manager));
+    }
+    _finalized = true;
 }
 
 size_t GroupManager::getAliasCount(const Guid &resource) const {
@@ -43,14 +60,11 @@ bool GroupManager::hasAliasOfType(const Guid &resource, ResourceIdType resourceI
 }
 
 std::shared_ptr<ResourceMemoryManager> GroupManager::getMemoryManager(const Guid &resource) {
+    if (!_finalized) {
+        throw std::runtime_error("Memory groups must be finalized before accessing memory managers");
+    }
     if (const auto group = getGroupForResource(resource); group.has_value()) {
-        // Create one memory manager per group on first access.
-        const auto [manager, inserted] =
-            _groupMemoryManagers.emplace(*group, std::make_shared<ResourceMemoryManager>());
-        if (inserted && isAliased(resource)) {
-            manager->second->markShared();
-        }
-        return manager->second;
+        return _groupMemoryManagers.at(*group);
     }
     // Not a group, create new one
     return std::make_shared<ResourceMemoryManager>();

--- a/src/group_manager.hpp
+++ b/src/group_manager.hpp
@@ -17,6 +17,9 @@ class GroupManager : public IGroupManager {
     /// Create or add resource to group
     void addResourceToGroup(const Guid &group, const Guid &resource, ResourceIdType resourceIdType) override;
 
+    /// Complete group registration and create the shared memory managers.
+    void finalize() override;
+
     /// Return size of group that resource belongs to
     size_t getAliasCount(const Guid &resource) const override;
 
@@ -33,6 +36,7 @@ class GroupManager : public IGroupManager {
     std::vector<GroupResourceEntry> getResourcesInGroup(const Guid &group) const;
 
   private:
+    bool _finalized{false};
     std::unordered_map<Guid, Guid> _resourceToGroup;
     GroupResources _groupResources;
     std::unordered_map<Guid, std::shared_ptr<ResourceMemoryManager>> _groupMemoryManagers;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -867,6 +867,7 @@ void Scenario::setupResources() {
         }
         vgfView.createIntermediateResources(vgfResourceCreator);
     }
+    _groupManager.finalize();
 
     // Setup aliasing resources, foundation before accessing tensors
     for (const auto &resource : _scenarioSpec.resources) {

--- a/src/scenario_runner.hpp
+++ b/src/scenario_runner.hpp
@@ -41,6 +41,7 @@ class IGroupManager {
     virtual ~IGroupManager() = default;
 
     virtual void addResourceToGroup(const Guid &group, const Guid &resource, ResourceIdType resourceIdType) = 0;
+    virtual void finalize() = 0;
     virtual size_t getAliasCount(const Guid &resource) const = 0;
     virtual bool isAliased(const Guid &resource) const = 0;
     virtual bool hasAliasOfType(const Guid &resource, ResourceIdType resourceIdType) const = 0;

--- a/src/tests/group_manager_tests.cpp
+++ b/src/tests/group_manager_tests.cpp
@@ -32,6 +32,8 @@ TEST(GroupManager, GroupHandling) {
     ASSERT_TRUE(gm.hasAliasOfType(tensor0, ResourceIdType::Image));
     ASSERT_TRUE(gm.hasAliasOfType(image0, ResourceIdType::Tensor));
 
+    ASSERT_THROW(static_cast<void>(gm.getMemoryManager(tensor0)), std::runtime_error);
+    gm.finalize();
     auto mmTensor = gm.getMemoryManager(tensor0);
     auto mmImage = gm.getMemoryManager(image0);
     ASSERT_EQ(mmTensor, mmImage);
@@ -68,4 +70,15 @@ TEST(GroupManager, GroupQueries) {
 
     const auto resources = gm.getResourcesInGroup(group0);
     ASSERT_EQ(resources.size(), 2U);
+}
+
+TEST(GroupManager, FinalizationPreventsFurtherRegistration) {
+    const Guid group("group");
+    GroupManager gm;
+    gm.addResourceToGroup(group, Guid("buffer0"), ResourceIdType::Buffer);
+
+    gm.finalize();
+
+    ASSERT_THROW(gm.addResourceToGroup(group, Guid("buffer1"), ResourceIdType::Buffer), std::runtime_error);
+    ASSERT_THROW(gm.finalize(), std::runtime_error);
 }


### PR DESCRIPTION
Close memory group registration before resource setup. Create shared memory managers during finalization so alias state is complete before any resource accesses it.

Change-Id: I7a64af8f92df60b6d8ac606f85aa22994f0211ee