### PR TITLE
chore: [vgf-runtime] prepare shared test utilities

### DIFF
--- a/src/vgf_runtime/CMakeLists.txt
+++ b/src/vgf_runtime/CMakeLists.txt
@@ -84,6 +84,7 @@ if(SCENARIO_RUNNER_BUILD_TESTS)
     add_executable(vgf_runtime_tests
         tests/utils.hpp
         tests/vgf/session_tests.cpp
+        tests/vgf/utils.hpp
         tests/vgf/workload_tests.cpp
     )
     target_link_libraries(vgf_runtime_tests PRIVATE

--- a/src/vgf_runtime/src/utils.hpp
+++ b/src/vgf_runtime/src/utils.hpp
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace vgf_runtime {
+namespace detail {
+namespace utils {
+
+[[noreturn]] inline void throwNotImplemented(const char *api) {
+    throw std::runtime_error(std::string(api) + " is not implemented yet");
+}
+
+inline vk::DeviceSize elementCount(const std::vector<int64_t> &shape) {
+    if (shape.empty()) {
+        return 0;
+    }
+    vk::DeviceSize elements = 1;
+    for (const int64_t dimension : shape) {
+        if (dimension <= 0) {
+            return 0;
+        }
+        elements *= static_cast<vk::DeviceSize>(dimension);
+    }
+    return elements;
+}
+
+} // namespace utils
+
+namespace vulkan_helpers {
+
+inline uint32_t findMemoryType(const vk::raii::PhysicalDevice &physicalDevice, uint32_t memoryTypeBits,
+                               vk::MemoryPropertyFlags requiredFlags) {
+    const auto memoryProperties = physicalDevice.getMemoryProperties();
+    for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; ++i) {
+        const bool supportsType = (memoryTypeBits & (uint32_t{1} << i)) != 0;
+        const bool hasFlags = (memoryProperties.memoryTypes[i].propertyFlags & requiredFlags) == requiredFlags;
+        if (supportsType && hasFlags) {
+            return i;
+        }
+    }
+    throw std::runtime_error("Cannot find a compatible memory type");
+}
+
+} // namespace vulkan_helpers
+} // namespace detail
+} // namespace vgf_runtime

--- a/src/vgf_runtime/tests/utils.hpp
+++ b/src/vgf_runtime/tests/utils.hpp
@@ -4,7 +4,7 @@
  */
 #pragma once
 
-#include "vgf/encoder.hpp"
+#include "../src/utils.hpp"
 
 #include <gtest/gtest.h>
 #include <spirv-tools/libspirv.hpp>
@@ -15,15 +15,13 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
-#include <functional>
-#include <iostream>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
-namespace mlsdk::vgf_runtime::test {
+namespace vgf_runtime::test {
 
 struct MaxpoolSpvasmBindings {
     uint32_t inputSet;
@@ -31,16 +29,6 @@ struct MaxpoolSpvasmBindings {
     uint32_t outputSet;
     uint32_t outputBinding;
 };
-
-inline std::string writeVgf(const std::function<void(mlsdk::vgflib::Encoder &)> &populate) {
-    auto encoder = mlsdk::vgflib::CreateEncoder(VK_HEADER_VERSION);
-    populate(*encoder);
-    encoder->Finish();
-
-    std::stringstream stream;
-    EXPECT_TRUE(encoder->WriteTo(stream));
-    return stream.str();
-}
 
 inline void replaceAll(std::string &text, std::string_view from, std::string_view to) {
     size_t pos = 0;
@@ -74,8 +62,9 @@ inline std::vector<uint32_t> assembleSpirv(std::string_view text) {
     return spirvModule;
 }
 
-inline std::vector<uint32_t> assembleMaxpoolSpirv(std::string_view name, MaxpoolSpvasmBindings bindings) {
-    std::ifstream templateFile(VGF_RUNTIME_MAXPOOL_16X16_TO_8X8_SPVASM);
+inline std::vector<uint32_t> assembleMaxpoolSpirvFromTemplate(std::string_view name, const char *templatePath,
+                                                              MaxpoolSpvasmBindings bindings) {
+    std::ifstream templateFile(templatePath);
     std::string spvasm((std::istreambuf_iterator<char>(templateFile)), {});
     replaceAll(spvasm, "INPUT_SET", std::to_string(bindings.inputSet));
     replaceAll(spvasm, "INPUT_BINDING", std::to_string(bindings.inputBinding));
@@ -89,21 +78,18 @@ inline std::vector<uint32_t> assembleMaxpoolSpirv(std::string_view name, Maxpool
     }
 }
 
-inline std::string makeMaxpoolVgf() {
-    const auto &code = assembleMaxpoolSpirv("maxpool_set0", {0, 0, 1, 1});
-    return writeVgf([&](mlsdk::vgflib::Encoder &encoder) {
-        const auto module = encoder.AddModule(mlsdk::vgflib::ModuleType::GRAPH, "maxpool", "main", code);
-        const auto input =
-            encoder.AddInputResource(VK_DESCRIPTOR_TYPE_TENSOR_ARM, VK_FORMAT_R8_SINT, {1, 16, 16, 16}, {});
-        const auto output =
-            encoder.AddOutputResource(VK_DESCRIPTOR_TYPE_TENSOR_ARM, VK_FORMAT_R8_SINT, {1, 8, 8, 16}, {});
-        const auto inputBinding = encoder.AddBindingSlot(0, input);
-        const auto outputBinding = encoder.AddBindingSlot(1, output);
-        const auto inputSet = encoder.AddDescriptorSetInfo({inputBinding}, 0);
-        const auto outputSet = encoder.AddDescriptorSetInfo({outputBinding}, 1);
-        encoder.AddSegmentInfo(module, "maxpool_graph_segment", {inputSet, outputSet}, {inputBinding}, {outputBinding},
-                               {});
-    });
+inline std::vector<uint32_t> assembleMaxpool16x16To8x8Spirv(std::string_view name, MaxpoolSpvasmBindings bindings) {
+    return assembleMaxpoolSpirvFromTemplate(name, VGF_RUNTIME_MAXPOOL_16X16_TO_8X8_SPVASM, bindings);
+}
+
+inline std::vector<uint32_t> assembleMaxpool8x8To4x4Spirv(std::string_view name, MaxpoolSpvasmBindings bindings) {
+    return assembleMaxpoolSpirvFromTemplate(name, VGF_RUNTIME_MAXPOOL_8X8_TO_4X4_SPVASM, bindings);
+}
+
+inline std::vector<uint32_t> assembleAddInt32BuffersSpirv() {
+    std::ifstream templateFile(VGF_RUNTIME_ADD_INT32_BUFFERS_SPVASM);
+    std::string spvasm((std::istreambuf_iterator<char>(templateFile)), {});
+    return assembleSpirv(spvasm);
 }
 
 inline bool hasExtension(const std::vector<vk::ExtensionProperties> &extensions, const char *name) {
@@ -123,18 +109,82 @@ inline uint32_t findDataGraphQueueFamily(const vk::raii::PhysicalDevice &physica
     return UINT32_MAX;
 }
 
-inline uint32_t findMemoryType(const vk::raii::PhysicalDevice &physicalDevice, uint32_t memoryTypeBits,
-                               vk::MemoryPropertyFlags requiredFlags) {
-    const auto memoryProperties = physicalDevice.getMemoryProperties();
-    for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; ++i) {
-        const bool supportsType = (memoryTypeBits & (uint32_t{1} << i)) != 0;
-        const bool hasFlags = (memoryProperties.memoryTypes[i].propertyFlags & requiredFlags) == requiredFlags;
-        if (supportsType && hasFlags) {
-            return i;
+class RuntimeSessionExecutionTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        const vk::ApplicationInfo applicationInfo("vgf-runtime-test", 1, nullptr, 0, VK_API_VERSION_1_3);
+        instance = vk::raii::Instance(context, vk::InstanceCreateInfo({}, &applicationInfo));
+
+        for (auto &candidate : vk::raii::PhysicalDevices(instance)) {
+            const auto extensions = candidate.enumerateDeviceExtensionProperties();
+            if (!hasExtension(extensions, VK_ARM_DATA_GRAPH_EXTENSION_NAME) ||
+                !hasExtension(extensions, VK_ARM_TENSORS_EXTENSION_NAME)) {
+                continue;
+            }
+            const auto candidateQueueFamilyIndex = findDataGraphQueueFamily(candidate);
+            if (candidateQueueFamilyIndex != UINT32_MAX) {
+                physicalDevice = candidate;
+                queueFamilyIndex = candidateQueueFamilyIndex;
+                break;
+            }
         }
+        if (queueFamilyIndex == UINT32_MAX) {
+            GTEST_SKIP() << "No Vulkan device with VK_ARM_data_graph, VK_ARM_tensors, and compute queue support";
+        }
+
+        const float queuePriority = 1.0F;
+        const vk::DeviceQueueCreateInfo queueCreateInfo({}, queueFamilyIndex, 1, &queuePriority);
+
+        vk::PhysicalDeviceFeatures deviceFeatures;
+        deviceFeatures.shaderInt16 = true;
+        deviceFeatures.shaderInt64 = true;
+
+        vulkan12Features.storageBuffer8BitAccess = true;
+        vulkan12Features.shaderInt8 = true;
+        vulkan12Features.vulkanMemoryModel = true;
+
+        vulkan13Features.synchronization2 = true;
+        vulkan13Features.maintenance4 = true;
+        vulkan13Features.pipelineCreationCacheControl = true;
+        vulkan13Features.pNext = &vulkan12Features;
+
+        tensorFeatures.tensors = true;
+        tensorFeatures.shaderTensorAccess = true;
+        tensorFeatures.tensorNonPacked = true;
+        tensorFeatures.pNext = &vulkan13Features;
+
+        dataGraphFeatures.dataGraph = true;
+        dataGraphFeatures.dataGraphShaderModule = true;
+        dataGraphFeatures.pNext = &tensorFeatures;
+
+        void *featureChain = &dataGraphFeatures;
+        const auto extensions = physicalDevice.enumerateDeviceExtensionProperties();
+        std::vector<const char *> deviceExtensions = {VK_ARM_DATA_GRAPH_EXTENSION_NAME, VK_ARM_TENSORS_EXTENSION_NAME};
+        if (hasExtension(extensions, VK_EXT_SHADER_REPLICATED_COMPOSITES_EXTENSION_NAME)) {
+            replicatedCompositesFeatures.shaderReplicatedComposites = true;
+            replicatedCompositesFeatures.pNext = featureChain;
+            featureChain = &replicatedCompositesFeatures;
+            deviceExtensions.push_back(VK_EXT_SHADER_REPLICATED_COMPOSITES_EXTENSION_NAME);
+        }
+        device = vk::raii::Device(
+            physicalDevice,
+            {vk::DeviceCreateFlags(), queueCreateInfo, {}, deviceExtensions, &deviceFeatures, featureChain});
+        queue = device.getQueue(queueFamilyIndex, 0);
     }
-    throw std::runtime_error("Cannot find a compatible memory type");
-}
+
+    vk::raii::Context context;
+    vk::raii::Instance instance{nullptr};
+    vk::raii::PhysicalDevice physicalDevice{nullptr};
+    vk::raii::Device device{nullptr};
+    vk::raii::Queue queue{nullptr};
+    uint32_t queueFamilyIndex = UINT32_MAX;
+
+    vk::PhysicalDeviceVulkan12Features vulkan12Features;
+    vk::PhysicalDeviceVulkan13Features vulkan13Features;
+    vk::PhysicalDeviceTensorFeaturesARM tensorFeatures;
+    vk::PhysicalDeviceDataGraphFeaturesARM dataGraphFeatures;
+    vk::PhysicalDeviceShaderReplicatedCompositesFeaturesEXT replicatedCompositesFeatures;
+};
 
 struct Tensor {
     Tensor(const vk::raii::PhysicalDevice &physicalDevice, const vk::raii::Device &device, vk::Format format,
@@ -149,9 +199,9 @@ struct Tensor {
         const auto memoryRequirements =
             device.getTensorMemoryRequirementsARM(vk::TensorMemoryRequirementsInfoARM(*tensor));
         memorySize = memoryRequirements.memoryRequirements.size;
-        const auto memoryType =
-            findMemoryType(physicalDevice, memoryRequirements.memoryRequirements.memoryTypeBits,
-                           vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent);
+        const auto memoryType = detail::vulkan_helpers::findMemoryType(
+            physicalDevice, memoryRequirements.memoryRequirements.memoryTypeBits,
+            vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent);
         memory = vk::raii::DeviceMemory(device, {memorySize, memoryType});
         device.bindTensorMemoryARM(vk::BindTensorMemoryInfoARM(*tensor, *memory, 0));
     }
@@ -159,11 +209,7 @@ struct Tensor {
     size_t numElements() const { return Tensor::numElements(shape); }
 
     static size_t numElements(const std::vector<int64_t> &shape) {
-        size_t count = 1;
-        for (const auto dim : shape) {
-            count *= static_cast<size_t>(dim);
-        }
-        return count;
+        return static_cast<size_t>(detail::utils::elementCount(shape));
     }
 
     void fill(int8_t value, size_t elements) const {
@@ -199,9 +245,9 @@ struct Buffer {
         : buffer(device, vk::BufferCreateInfo({}, size, vk::BufferUsageFlagBits::eStorageBuffer)) {
         const auto memoryRequirements = buffer.getMemoryRequirements();
         memorySize = memoryRequirements.size;
-        const auto memoryType =
-            findMemoryType(physicalDevice, memoryRequirements.memoryTypeBits,
-                           vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent);
+        const auto memoryType = detail::vulkan_helpers::findMemoryType(
+            physicalDevice, memoryRequirements.memoryTypeBits,
+            vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent);
         memory = vk::raii::DeviceMemory(device, {memorySize, memoryType});
         buffer.bindMemory(*memory, 0);
     }
@@ -225,6 +271,24 @@ struct Buffer {
     vk::raii::Buffer buffer{nullptr};
     vk::DeviceSize memorySize = 0;
 };
+
+inline std::vector<int32_t> addVectors(const std::vector<int32_t> &lhs, const std::vector<int32_t> &rhs) {
+    std::vector<int32_t> result(lhs.size());
+    std::transform(lhs.begin(), lhs.end(), rhs.begin(), result.begin(), std::plus<>());
+    return result;
+}
+
+inline std::vector<int32_t> int32WordsFromBytes(const std::vector<int8_t> &bytes, size_t words) {
+    std::vector<int32_t> result(words);
+    for (size_t word = 0; word < words; ++word) {
+        uint32_t value = 0;
+        for (size_t byte = 0; byte < sizeof(int32_t); ++byte) {
+            value |= static_cast<uint32_t>(static_cast<uint8_t>(bytes[word * sizeof(int32_t) + byte])) << (byte * 8);
+        }
+        result[word] = static_cast<int32_t>(value);
+    }
+    return result;
+}
 
 inline std::vector<int8_t> makeMaxpoolInput(const std::vector<int64_t> &shape, uint32_t seed = 0) {
     const auto batch = shape[0];
@@ -277,4 +341,4 @@ inline std::vector<int8_t> expectedMaxpool(const std::vector<int8_t> &input, con
     return expected;
 }
 
-} // namespace mlsdk::vgf_runtime::test
+} // namespace vgf_runtime::test

--- a/src/vgf_runtime/tests/vgf/session_tests.cpp
+++ b/src/vgf_runtime/tests/vgf/session_tests.cpp
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "../utils.hpp"
+#include "utils.hpp"
 #include <vgf_runtime/runtime.hpp>
 
 #include <gtest/gtest.h>
@@ -21,99 +21,13 @@
 namespace {
 
 using namespace mlsdk::vgf_runtime;
-using namespace mlsdk::vgf_runtime::test;
+using namespace vgf_runtime::test;
 
-class VgfRuntimeFullTest : public ::testing::Test {
-  protected:
-    void SetUp() override {
-        const vk::ApplicationInfo applicationInfo("vgf-runtime-full-test", 1, nullptr, 0, VK_API_VERSION_1_3);
-        instance = vk::raii::Instance(context, vk::InstanceCreateInfo({}, &applicationInfo));
-
-        for (auto &candidate : vk::raii::PhysicalDevices(instance)) {
-            const auto extensions = candidate.enumerateDeviceExtensionProperties();
-            if (!hasExtension(extensions, VK_ARM_DATA_GRAPH_EXTENSION_NAME) ||
-                !hasExtension(extensions, VK_ARM_TENSORS_EXTENSION_NAME)) {
-                continue;
-            }
-            const auto candidateQueueFamilyIndex = findDataGraphQueueFamily(candidate);
-            if (candidateQueueFamilyIndex != UINT32_MAX) {
-                physicalDevice = candidate;
-                queueFamilyIndex = candidateQueueFamilyIndex;
-                break;
-            }
-        }
-        if (queueFamilyIndex == UINT32_MAX) {
-            GTEST_SKIP() << "No Vulkan device with VK_ARM_data_graph, VK_ARM_tensors, and compute queue support";
-        }
-
-        const float queuePriority = 1.0F;
-        const vk::DeviceQueueCreateInfo queueCreateInfo({}, queueFamilyIndex, 1, &queuePriority);
-
-        vk::PhysicalDeviceFeatures deviceFeatures;
-        deviceFeatures.shaderInt16 = true;
-        deviceFeatures.shaderInt64 = true;
-
-        vulkan12Features.storageBuffer8BitAccess = true;
-        vulkan12Features.shaderInt8 = true;
-        vulkan12Features.vulkanMemoryModel = true;
-
-        vulkan13Features.synchronization2 = true;
-        vulkan13Features.maintenance4 = true;
-        vulkan13Features.pipelineCreationCacheControl = true;
-        vulkan13Features.pNext = &vulkan12Features;
-
-        tensorFeatures.tensors = true;
-        tensorFeatures.shaderTensorAccess = true;
-        tensorFeatures.tensorNonPacked = true;
-        tensorFeatures.pNext = &vulkan13Features;
-
-        dataGraphFeatures.dataGraph = true;
-        dataGraphFeatures.dataGraphShaderModule = true;
-        dataGraphFeatures.pNext = &tensorFeatures;
-
-        void *featureChain = &dataGraphFeatures;
-        const auto extensions = physicalDevice.enumerateDeviceExtensionProperties();
-        std::vector<const char *> deviceExtensions = {VK_ARM_DATA_GRAPH_EXTENSION_NAME, VK_ARM_TENSORS_EXTENSION_NAME};
-        if (hasExtension(extensions, VK_EXT_SHADER_REPLICATED_COMPOSITES_EXTENSION_NAME)) {
-            replicatedCompositesFeatures.shaderReplicatedComposites = true;
-            replicatedCompositesFeatures.pNext = featureChain;
-            featureChain = &replicatedCompositesFeatures;
-            deviceExtensions.push_back(VK_EXT_SHADER_REPLICATED_COMPOSITES_EXTENSION_NAME);
-        }
-        device = vk::raii::Device(
-            physicalDevice,
-            {vk::DeviceCreateFlags(), queueCreateInfo, {}, deviceExtensions, &deviceFeatures, featureChain});
-        queue = device.getQueue(queueFamilyIndex, 0);
-    }
-
-    vk::raii::Context context;
-    vk::raii::Instance instance{nullptr};
-    vk::raii::PhysicalDevice physicalDevice{nullptr};
-    vk::raii::Device device{nullptr};
-    vk::raii::Queue queue{nullptr};
-    uint32_t queueFamilyIndex = UINT32_MAX;
-
-    vk::PhysicalDeviceVulkan12Features vulkan12Features;
-    vk::PhysicalDeviceVulkan13Features vulkan13Features;
-    vk::PhysicalDeviceTensorFeaturesARM tensorFeatures;
-    vk::PhysicalDeviceDataGraphFeaturesARM dataGraphFeatures;
-    vk::PhysicalDeviceShaderReplicatedCompositesFeaturesEXT replicatedCompositesFeatures;
-};
-
-std::vector<uint32_t> assembleSecondMaxpoolSpirv() {
-    std::ifstream templateFile(VGF_RUNTIME_MAXPOOL_8X8_TO_4X4_SPVASM);
-    std::string spvasm((std::istreambuf_iterator<char>(templateFile)), {});
-    replaceAll(spvasm, "INPUT_SET", "0");
-    replaceAll(spvasm, "INPUT_BINDING", "0");
-    replaceAll(spvasm, "OUTPUT_SET", "0");
-    replaceAll(spvasm, "OUTPUT_BINDING", "1");
-
-    return assembleSpirv(spvasm);
-}
+class VgfRuntimeFullTest : public RuntimeSessionExecutionTest {};
 
 std::string makeTwoSegmentMaxpoolVgf() {
-    const auto &firstCode = assembleMaxpoolSpirv("maxpool_16x16_to_8x8", {0, 0, 0, 1});
-    const auto &secondCode = assembleSecondMaxpoolSpirv();
+    const auto &firstCode = assembleMaxpool16x16To8x8Spirv("maxpool_16x16_to_8x8", {0, 0, 0, 1});
+    const auto &secondCode = assembleMaxpool8x8To4x4Spirv("maxpool_8x8_to_4x4", {0, 0, 0, 1});
     return writeVgf([&](mlsdk::vgflib::Encoder &encoder) {
         const auto firstModule =
             encoder.AddModule(mlsdk::vgflib::ModuleType::GRAPH, "maxpool_16x16_to_8x8", "main", firstCode);
@@ -140,14 +54,8 @@ std::string makeTwoSegmentMaxpoolVgf() {
     });
 }
 
-std::vector<uint32_t> assembleAddInt32BuffersSpirv() {
-    std::ifstream templateFile(VGF_RUNTIME_ADD_INT32_BUFFERS_SPVASM);
-    std::string spvasm((std::istreambuf_iterator<char>(templateFile)), {});
-    return assembleSpirv(spvasm);
-}
-
 std::string makeOutputBufferAliasedToIntermediateTensorVgf() {
-    const auto &maxpoolCode = assembleSecondMaxpoolSpirv();
+    const auto &maxpoolCode = assembleMaxpool8x8To4x4Spirv("maxpool_8x8_to_4x4", {0, 0, 0, 1});
     const auto &addCode = assembleAddInt32BuffersSpirv();
     return writeVgf([&](mlsdk::vgflib::Encoder &encoder) {
         constexpr uint32_t aliasGroup = 17;
@@ -348,24 +256,6 @@ std::string makeIndependentAliasGroupsVgf() {
     });
 }
 
-std::vector<int32_t> addVectors(const std::vector<int32_t> &lhs, const std::vector<int32_t> &rhs) {
-    std::vector<int32_t> result(lhs.size());
-    std::transform(lhs.begin(), lhs.end(), rhs.begin(), result.begin(), std::plus<>());
-    return result;
-}
-
-std::vector<int32_t> int32WordsFromBytes(const std::vector<int8_t> &bytes, size_t words) {
-    std::vector<int32_t> result(words);
-    for (size_t word = 0; word < words; ++word) {
-        uint32_t value = 0;
-        for (size_t byte = 0; byte < sizeof(int32_t); ++byte) {
-            value |= static_cast<uint32_t>(static_cast<uint8_t>(bytes[word * sizeof(int32_t) + byte])) << (byte * 8);
-        }
-        result[word] = static_cast<int32_t>(value);
-    }
-    return result;
-}
-
 struct Image {
     Image(const vk::raii::PhysicalDevice &physicalDevice, const vk::raii::Device &device)
         : image(device, vk::ImageCreateInfo({}, vk::ImageType::e2D, vk::Format::eR8G8B8A8Snorm, {2, 2, 1}, 1, 1,
@@ -373,8 +263,8 @@ struct Image {
                                             vk::ImageUsageFlagBits::eSampled, vk::SharingMode::eExclusive)) {
         const auto memoryRequirements = image.getMemoryRequirements();
         memorySize = memoryRequirements.size;
-        const auto memoryType =
-            findMemoryType(physicalDevice, memoryRequirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal);
+        const auto memoryType = vgf_runtime::detail::vulkan_helpers::findMemoryType(
+            physicalDevice, memoryRequirements.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal);
         memory = vk::raii::DeviceMemory(device, {memorySize, memoryType});
         image.bindMemory(*memory, 0);
     }

--- a/src/vgf_runtime/tests/vgf/utils.hpp
+++ b/src/vgf_runtime/tests/vgf/utils.hpp
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "../utils.hpp"
+
+#include "vgf/encoder.hpp"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+
+namespace vgf_runtime::test {
+
+template <typename Populate> std::string writeVgf(Populate populate) {
+    auto encoder = mlsdk::vgflib::CreateEncoder(VK_HEADER_VERSION);
+    populate(*encoder);
+    encoder->Finish();
+
+    std::stringstream stream;
+    EXPECT_TRUE(encoder->WriteTo(stream));
+    return stream.str();
+}
+
+inline std::string makeMaxpoolVgf() {
+    const auto &code = assembleMaxpool16x16To8x8Spirv("maxpool_set0", {0, 0, 1, 1});
+    return writeVgf([&](mlsdk::vgflib::Encoder &encoder) {
+        const auto module = encoder.AddModule(mlsdk::vgflib::ModuleType::GRAPH, "maxpool", "main", code);
+        const auto input =
+            encoder.AddInputResource(VK_DESCRIPTOR_TYPE_TENSOR_ARM, VK_FORMAT_R8_SINT, {1, 16, 16, 16}, {});
+        const auto output =
+            encoder.AddOutputResource(VK_DESCRIPTOR_TYPE_TENSOR_ARM, VK_FORMAT_R8_SINT, {1, 8, 8, 16}, {});
+        const auto inputBinding = encoder.AddBindingSlot(0, input);
+        const auto outputBinding = encoder.AddBindingSlot(1, output);
+        const auto inputSet = encoder.AddDescriptorSetInfo({inputBinding}, 0);
+        const auto outputSet = encoder.AddDescriptorSetInfo({outputBinding}, 1);
+        encoder.AddSegmentInfo(module, "maxpool_graph_segment", {inputSet, outputSet}, {inputBinding}, {outputBinding},
+                               {});
+    });
+}
+
+} // namespace vgf_runtime::test

--- a/src/vgf_runtime/tests/vgf/workload_tests.cpp
+++ b/src/vgf_runtime/tests/vgf/workload_tests.cpp
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "../utils.hpp"
+#include "utils.hpp"
 #include <vgf_runtime/runtime.hpp>
 
 #include <gtest/gtest.h>
@@ -20,7 +20,7 @@ namespace {
 
 using namespace mlsdk::vgflib;
 using namespace mlsdk::vgf_runtime;
-using namespace mlsdk::vgf_runtime::test;
+using namespace vgf_runtime::test;
 
 template <typename T, typename U> bool viewEquals(DataView<T> view, std::initializer_list<U> expected) {
     return view.size() == expected.size() &&
@@ -37,7 +37,7 @@ bool pointsInside(const void *ptr, const std::string &buffer) {
 } // namespace
 
 TEST(VGF, DecodesSegmentsModulesBindingsResourcesAndDispatch) {
-    const auto &code = assembleMaxpoolSpirv("maxpool_set0", {0, 0, 0, 1});
+    const auto &code = assembleMaxpool16x16To8x8Spirv("maxpool_set0", {0, 0, 0, 1});
     const auto data = writeVgf([&](Encoder &encoder) {
         const auto module = encoder.AddModule(ModuleType::COMPUTE, "shader", "main", code);
         const auto input = encoder.AddInputResource(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_FORMAT_R32_SFLOAT, {4}, {4});
@@ -107,7 +107,7 @@ TEST(VGF, DecodesSegmentsModulesBindingsResourcesAndDispatch) {
 }
 
 TEST(VGF, DecodesConstantsSamplersAndFileBackedData) {
-    const auto &code = assembleMaxpoolSpirv("maxpool_set0", {0, 0, 1, 1});
+    const auto &code = assembleMaxpool16x16To8x8Spirv("maxpool_set0", {0, 0, 1, 1});
     const std::array<int32_t, 4> constantData = {1, 2, 3, 4};
     const auto data = writeVgf([&](Encoder &encoder) {
         const auto module = encoder.AddModule(ModuleType::GRAPH, "graph", "main", code);
@@ -160,7 +160,7 @@ TEST(VGF, DecodesConstantsSamplersAndFileBackedData) {
 }
 
 TEST(VGF, DecodesResourceAliasGroups) {
-    const auto &code = assembleMaxpoolSpirv("maxpool_set0", {0, 0, 0, 1});
+    const auto &code = assembleMaxpool16x16To8x8Spirv("maxpool_set0", {0, 0, 0, 1});
     const auto data = writeVgf([&](mlsdk::vgflib::Encoder &encoder) {
         constexpr uint32_t aliasGroup = 17;
         const auto module = encoder.AddModule(mlsdk::vgflib::ModuleType::COMPUTE, "shader", "main", code);


### PR DESCRIPTION
Extract common Vulkan/SPIR-V test helpers and VGF encoder helpers before introducing the new runtime API.

This keeps the old VGF runtime tests behavior-preserving while reducing helper churn in the foundation patch.


Change-Id: Ic08148a507d67c2f5f05fd71d191eab302382882