### PR TITLE
feat: use graph constant binding IDs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 
 ### Build, Packaging & Developer Experience
 
+- Updated Scenario Runner to consume explicit VGF graph constant bindings.
 - Updated Scenario Runner `--version` output to report the package version and include git revision and dependency revision information.
 - Added KosmicKrisp support on Darwin.
 - Added startup logging for Vulkan API and driver versions and common device

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -548,17 +548,17 @@ void Pipeline::graphComputePipelineCommon(const Context &ctx, uint32_t segmentIn
                                           bool enableNeuralStatistics,
                                           vk::NeuralAcceleratorStatisticsModeARM neuralStatisticsMode) {
     // Setup constant resource info
-    auto constantIndexes = vgfView.getSegmentConstantIndexes(segmentIndex);
+    const auto &constantBindings = vgfView.getSegmentConstantBindings(segmentIndex);
     std::vector<vk::TensorDescriptionARM> constantTensorDescriptions;
-    constantTensorDescriptions.reserve(constantIndexes.size());
+    constantTensorDescriptions.reserve(constantBindings.size());
 
     std::vector<vk::DataGraphPipelineConstantARM> constantInfos;
-    constantInfos.reserve(constantIndexes.size());
+    constantInfos.reserve(constantBindings.size());
 
     std::vector<vk::DataGraphPipelineConstantTensorSemiStructuredSparsityInfoARM> sparsityInfos;
-    sparsityInfos.reserve(constantIndexes.size());
+    sparsityInfos.reserve(constantBindings.size());
 
-    for (uint32_t constantIndex : constantIndexes) {
+    for (const auto &[graphConstantId, constantIndex] : constantBindings) {
         void *pNext = nullptr;
 
         auto constantData = vgfView.getConstantData(constantIndex);
@@ -581,7 +581,7 @@ void Pipeline::graphComputePipelineCommon(const Context &ctx, uint32_t segmentIn
                                                 static_cast<uint32_t>(shape.size()), shape.begin(),
                                                 nullptr, // pStrides
                                                 vk::TensorUsageFlagBitsARM::eDataGraph, pNext);
-        constantInfos.emplace_back(constantIndex, constantData.begin(), &constantTensorDescriptions.back());
+        constantInfos.emplace_back(graphConstantId, constantData.begin(), &constantTensorDescriptions.back());
     }
 
     // Compile SPIR-V code

--- a/src/tests/vgf_view_tests.cpp
+++ b/src/tests/vgf_view_tests.cpp
@@ -14,10 +14,12 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <functional>
 #include <string>
+#include <vector>
 
 using namespace mlsdk::scenariorunner;
 namespace vgflib = mlsdk::vgflib;
@@ -56,7 +58,7 @@ std::filesystem::path writeVgfWithTensorInterfaceResources(TempFolder &tempFolde
     encoder->AddModelSequenceInputsOutputs({inputBinding}, {"inputTensor"}, {outputBinding}, {"outputTensor"});
     encoder->AddSegmentInfo(module, "tensor_interface_segment",
                             std::vector<vgflib::DescriptorSetInfoRef>{descriptorSet}, {inputBinding}, {outputBinding},
-                            {}, {1, 1, 1});
+                            std::vector<vgflib::GraphConstantBindingRef>{}, {1, 1, 1});
     encoder->Finish();
 
     const std::string vgfPath = tempFolder.relative("scenario_runner_vgf_view_tensor_interface.vgf").string();
@@ -96,7 +98,8 @@ std::filesystem::path writeVgfWithIntermediateBuffer(TempFolder &tempFolder, vk:
 
     encoder->AddModelSequenceInputsOutputs({}, {}, {}, {});
     encoder->AddSegmentInfo(module, "buffer_size_segment", std::vector<vgflib::DescriptorSetInfoRef>{descriptorSet}, {},
-                            std::vector<vgflib::BindingSlotRef>{binding}, {}, {1, 1, 1});
+                            std::vector<vgflib::BindingSlotRef>{binding},
+                            std::vector<vgflib::GraphConstantBindingRef>{}, {1, 1, 1});
     encoder->Finish();
 
     const std::string vgfPath = tempFolder.relative("scenario_runner_vgf_view_buffer_size.vgf").string();
@@ -121,7 +124,8 @@ std::filesystem::path writeVgfWithSampledIntermediateImage(TempFolder &tempFolde
 
     encoder->AddModelSequenceInputsOutputs({}, {}, {}, {});
     encoder->AddSegmentInfo(module, "sampled_image_segment", std::vector<vgflib::DescriptorSetInfoRef>{descriptorSet},
-                            {}, std::vector<vgflib::BindingSlotRef>{binding}, {}, {1, 1, 1});
+                            {}, std::vector<vgflib::BindingSlotRef>{binding},
+                            std::vector<vgflib::GraphConstantBindingRef>{}, {1, 1, 1});
     encoder->Finish();
 
     const auto suffix = std::to_string(addressModeU) + "_" + std::to_string(addressModeV);

--- a/src/vgf_runtime/include/vgf_runtime/workload_frontends/vgf.hpp
+++ b/src/vgf_runtime/include/vgf_runtime/workload_frontends/vgf.hpp
@@ -67,7 +67,8 @@ struct ResourceInfo {
 
 /** @brief Decoded constant payload and metadata for a segment resource. */
 struct ConstantInfo {
-    uint32_t index = 0;
+    uint32_t graphConstantId = 0;
+    uint32_t constantIndex = 0;
     uint32_t resourceIndex = 0;
     vk::Format format = vk::Format::eUndefined;
     vgflib::DataView<int64_t> shape;

--- a/src/vgf_runtime/src/session.cpp
+++ b/src/vgf_runtime/src/session.cpp
@@ -981,7 +981,7 @@ void Session::Impl::configureSegment(uint32_t segmentIndex) {
                                                     static_cast<uint32_t>(constant.shape.size()), constant.shape.data(),
                                                     constant.stride.empty() ? nullptr : constant.stride.data(),
                                                     vk::TensorUsageFlagBitsARM::eDataGraph);
-            constants.emplace_back(constant.index, constant.data.data(), &constantTensorDescriptions.back());
+            constants.emplace_back(constant.graphConstantId, constant.data.data(), &constantTensorDescriptions.back());
         }
 
         const vk::DataGraphPipelineShaderModuleCreateInfoARM shaderModuleInfo(

--- a/src/vgf_runtime/src/workload_frontends/vgf.cpp
+++ b/src/vgf_runtime/src/workload_frontends/vgf.cpp
@@ -75,7 +75,8 @@ uint32_t VGF::getNumResources() const { return static_cast<uint32_t>(impl_->mode
 uint32_t VGF::getNumConstants() const { return static_cast<uint32_t>(impl_->constants->size()); }
 
 uint32_t VGF::getNumConstants(uint32_t segmentIndex) const {
-    return static_cast<uint32_t>(impl_->modelSequenceTable->getSegmentConstantIndexes(segmentIndex).size());
+    const auto handle = impl_->modelSequenceTable->getSegmentConstantBindingsHandle(segmentIndex);
+    return static_cast<uint32_t>(impl_->modelSequenceTable->getGraphConstantBindingsSize(handle));
 }
 
 SegmentInfo VGF::getSegment(uint32_t segmentIndex) const {
@@ -118,10 +119,13 @@ ResourceInfo VGF::getResource(uint32_t resourceIndex) const {
 }
 
 ConstantInfo VGF::getConstant(uint32_t segmentIndex, uint32_t index) const {
-    const auto constantIndexes = impl_->modelSequenceTable->getSegmentConstantIndexes(segmentIndex);
-    const uint32_t constantIndex = constantIndexes[index];
+    const auto handle = impl_->modelSequenceTable->getSegmentConstantBindingsHandle(segmentIndex);
+    const auto binding = impl_->modelSequenceTable->getGraphConstantBinding(handle, index);
+    const uint32_t graphConstantId = binding.graphConstantId;
+    const uint32_t constantIndex = binding.constantIndex;
     const uint32_t resourceIndex = impl_->constants->getConstantMrtIndex(constantIndex);
-    return {constantIndex,
+    return {graphConstantId,
+            constantIndex,
             resourceIndex,
             vk::Format(impl_->modelResourceTable->getVkFormat(resourceIndex)),
             impl_->modelResourceTable->getTensorShape(resourceIndex),

--- a/src/vgf_runtime/tests/vgf/workload_tests.cpp
+++ b/src/vgf_runtime/tests/vgf/workload_tests.cpp
@@ -115,12 +115,17 @@ TEST(VGF, DecodesConstantsSamplersAndFileBackedData) {
                                                     {4, 4, 1}, {});
         encoder.AddSamplerConfig(image, VK_FILTER_LINEAR, VK_FILTER_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
                                  VK_SAMPLER_ADDRESS_MODE_REPEAT, VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK);
+        const std::array<int32_t, 4> unusedConstantData = {9, 10, 11, 12};
+        const auto unusedConstantResource = encoder.AddConstantResource(VK_FORMAT_R32_SINT, {4}, {});
         const auto constantResource = encoder.AddConstantResource(VK_FORMAT_R32_SINT, {4}, {});
+        encoder.AddConstant(unusedConstantResource, unusedConstantData.data(),
+                            unusedConstantData.size() * sizeof(int32_t), 0);
         const auto constant =
             encoder.AddConstant(constantResource, constantData.data(), constantData.size() * sizeof(int32_t), 1);
         const auto imageBinding = encoder.AddBindingSlot(0, image);
         const auto descriptorSet = encoder.AddDescriptorSetInfo({imageBinding}, 0);
-        encoder.AddSegmentInfo(module, "graph_segment", {descriptorSet}, {imageBinding}, {}, {constant});
+        encoder.AddSegmentInfo(module, "graph_segment", {descriptorSet}, {imageBinding}, {},
+                               {GraphConstantBindingRef{10000, constant}});
     });
 
     const auto path = std::filesystem::current_path() / "vgf_runtime_file_test.vgf";
@@ -134,8 +139,8 @@ TEST(VGF, DecodesConstantsSamplersAndFileBackedData) {
 
     EXPECT_EQ(vgf.getNumSegments(), 1);
     EXPECT_EQ(vgf.getNumSPIRVModules(), 1);
-    EXPECT_EQ(vgf.getNumResources(), 2);
-    EXPECT_EQ(vgf.getNumConstants(), 1);
+    EXPECT_EQ(vgf.getNumResources(), 3);
+    EXPECT_EQ(vgf.getNumConstants(), 2);
     EXPECT_EQ(vgf.getNumConstants(0), 1);
 
     const auto segment = vgf.getSegment(0);
@@ -143,15 +148,16 @@ TEST(VGF, DecodesConstantsSamplersAndFileBackedData) {
     const auto module = vgf.getSPIRVModule(segment.moduleIndex);
     EXPECT_EQ(module.name, "graph");
 
-    const auto constantResource = vgf.getResource(1);
+    const auto constantResource = vgf.getResource(2);
     EXPECT_EQ(constantResource.category, ResourceCategory::CONSTANT);
     EXPECT_FALSE(constantResource.descriptorType.has_value());
     EXPECT_EQ(constantResource.format, vk::Format::eR32Sint);
     EXPECT_TRUE(viewEquals(constantResource.shape, {4}));
 
     const auto constant = vgf.getConstant(0, 0);
-    EXPECT_EQ(constant.index, 0);
-    EXPECT_EQ(constant.resourceIndex, 1);
+    EXPECT_EQ(constant.graphConstantId, 10000);
+    EXPECT_EQ(constant.constantIndex, 1);
+    EXPECT_EQ(constant.resourceIndex, 2);
     EXPECT_EQ(constant.format, vk::Format::eR32Sint);
     EXPECT_TRUE(viewEquals(constant.shape, {4}));
     EXPECT_EQ(constant.sparsityDimension, 1);

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -344,8 +344,16 @@ vgflib::DataView<uint32_t> VgfView::getDispatchShape(uint32_t segmentIndex) cons
     return sequenceTableDecoder->getSegmentDispatchShape(segmentIndex);
 }
 
-vgflib::DataView<uint32_t> VgfView::getSegmentConstantIndexes(uint32_t segmentIndex) const {
-    return sequenceTableDecoder->getSegmentConstantIndexes(segmentIndex);
+std::vector<vgflib::GraphConstantBinding> VgfView::getSegmentConstantBindings(uint32_t segmentIndex) const {
+    const auto *handle = sequenceTableDecoder->getSegmentConstantBindingsHandle(segmentIndex);
+    const auto size = sequenceTableDecoder->getGraphConstantBindingsSize(handle);
+
+    std::vector<vgflib::GraphConstantBinding> bindings;
+    bindings.reserve(size);
+    for (uint32_t bindingIdx = 0; bindingIdx < size; ++bindingIdx) {
+        bindings.push_back(sequenceTableDecoder->getGraphConstantBinding(handle, bindingIdx));
+    }
+    return bindings;
 }
 
 vgflib::FormatType VgfView::getConstantFormat(uint32_t constantIndex) const {

--- a/src/vgf_view.hpp
+++ b/src/vgf_view.hpp
@@ -45,7 +45,7 @@ class VgfView {
     std::string getHLSLModuleCode(uint32_t segmentIndex) const;
     vgflib::DataView<uint32_t> getDispatchShape(uint32_t segmentIndex) const;
 
-    vgflib::DataView<uint32_t> getSegmentConstantIndexes(uint32_t segmentIndex) const;
+    std::vector<vgflib::GraphConstantBinding> getSegmentConstantBindings(uint32_t segmentIndex) const;
     vgflib::FormatType getConstantFormat(uint32_t constantIndex) const;
     int64_t getConstantSparsityDimension(uint32_t constantIndex) const;
     vgflib::DataView<int64_t> getConstantShape(uint32_t constantIndex) const;


### PR DESCRIPTION
Consume explicit VGF graph constant bindings in Scenario Runner and VGF Runtime. Constant table indexes are now used to fetch payload data, while graph constant IDs are passed to Vulkan.

Add tests for non-identity bindings and overlapping segment-local graph constant IDs so multi-segment VGFs can bind distinct payloads correctly.

Change-Id: If138cdce45cfe6bd0865de3f18e1bc8a95bb2542