### PR TITLE
fix: use tensor memory offsets during upload

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,8 @@
 - Fixed pipeline-cache miss handling for all pipeline types by checking pipeline
   creation feedback as well as compile-required results. Data graph pipelines
   now use the required zero per-stage feedback entries.
+- Fixed tensor staging transfers to respect tensor memory-group and image
+  subresource offsets.
 
 ## Version 0.10.0 – *Optical Flow, VGF Runtime & APK Packaging*
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -169,22 +169,23 @@ void Tensor::fillFromDescription(const Context &ctx, const TensorDesc &desc) con
 }
 
 void Tensor::fill(const void *data, size_t size) const {
-    if (size < memSize()) {
+    if (size < _size) {
         mlsdk::logging::warning("Tensor data size " + std::to_string(size) +
-                                " is different from allocated memory size " + std::to_string(memSize()));
-    } else if (size > memSize()) {
-        const std::string msg = "Allocated Tensor memory is less than data size: " + std::to_string(memSize()) +
-                                " vs " + std::to_string(size);
-        throw std::runtime_error(msg);
+                                " is different from allocated memory size " + std::to_string(_size));
+    } else if (size > _size) {
+        throw std::runtime_error("Allocated Tensor memory is less than data size: " + std::to_string(_size) + " vs " +
+                                 std::to_string(size));
     }
-    void *pDeviceMemory = _memoryManager->mapStagingBufferMemory(0, memSize());
-    std::memcpy(pDeviceMemory, data, size);
+    const auto stagingOffset = _memoryManager->getSubresourceOffset() + _memoryOffset;
+    void *pStagingMemory = _memoryManager->mapStagingBufferMemory(stagingOffset, _size);
+    std::memcpy(pStagingMemory, data, size);
     _memoryManager->unmapStagingBufferMemory();
 }
 
 void Tensor::fillZero() const {
-    void *pDeviceMemory = _memoryManager->mapStagingBufferMemory(0, memSize());
-    std::memset(pDeviceMemory, 0, memSize());
+    const auto stagingOffset = _memoryManager->getSubresourceOffset() + _memoryOffset;
+    void *pStagingMemory = _memoryManager->mapStagingBufferMemory(stagingOffset, _size);
+    std::memset(pStagingMemory, 0, _size);
     _memoryManager->unmapStagingBufferMemory();
 }
 
@@ -229,9 +230,9 @@ std::vector<char> Tensor::getTensorData(const Context &ctx) const {
     const auto dSize = dataSize();
 
     std::vector<char> out;
-    // 2) If padded/tiled (memSize != dataSize) *and* a 4D tensor with strides,
+    // 2) If padded/tiled (_size != dataSize) *and* a 4D tensor with strides,
     //    walk element-by-element using those strides to lay out the data correctly
-    if (memSize() != dSize && _shape.size() == _strides.size() && _shape.size() == 4) {
+    if (_size != dSize && _shape.size() == _strides.size() && _shape.size() == 4) {
         out.reserve(dSize);
         const int64_t elementSize{elementSizeFromVkFormat(dataType())};
         for (int64_t a = 0; a < _shape[0]; ++a) {
@@ -247,9 +248,9 @@ std::vector<char> Tensor::getTensorData(const Context &ctx) const {
             }
         }
     } else {
-        if (memSize() != dataSize()) {
-            mlsdk::logging::warning("Tensor data size " + std::to_string(dataSize()) +
-                                    " is different from allocated memory size " + std::to_string(memSize()));
+        if (_size != dSize) {
+            mlsdk::logging::warning("Tensor data size " + std::to_string(dSize) +
+                                    " is different from allocated memory size " + std::to_string(_size));
         }
 
         // 3) Otherwise data is contiguous: bulk copy

--- a/src/tests/tensor_tests.cpp
+++ b/src/tests/tensor_tests.cpp
@@ -9,6 +9,7 @@
 #include "tensor.hpp"
 #include "utils.hpp"
 
+#include <memory>
 #include <numeric>
 #include <vector>
 
@@ -16,12 +17,13 @@
 using namespace mlsdk::scenariorunner;
 
 Tensor &prepareTensor(Context &ctx, DataManager &dm, const Guid &guid, const std::vector<int64_t> &shape,
-                      vk::Format format) {
+                      vk::Format format, uint64_t memoryOffset = 0) {
     TensorInfo info;
     info.debugName = "test_tensor";
     info.shape = shape;
     info.format = format;
     info.tiling = Tiling::Linear;
+    info.memoryOffset = memoryOffset;
     dm.createTensor(guid, info);
     auto &tensor = dm.getTensorMut(guid);
     tensor.setup(ctx);
@@ -158,5 +160,57 @@ TEST(TensorInMemoryTransfer, DownloadReturnsUploadedData) {
     EXPECT_EQ(tensorData.shape, shape);
     ASSERT_TRUE(tensorData.format.has_value());
     EXPECT_EQ(tensorData.format.value(), fmt);
+    EXPECT_EQ(tensorData.data, payload);
+}
+
+TEST(TensorInMemoryTransfer, UploadAndDownloadRespectMemoryOffset) {
+    ScenarioOptions opts{};
+    Context ctx{opts};
+    DataManager dm;
+    const Guid guid("tensor_memory_offset");
+    const std::vector<int64_t> shape{2, 3, 1};
+    const vk::Format format = vk::Format::eR8Uint;
+    constexpr uint64_t memoryOffset = 4096;
+
+    auto &tensor = prepareTensor(ctx, dm, guid, shape, format, memoryOffset);
+    std::vector<char> payload(bytesFor(format, shape));
+    std::iota(payload.begin(), payload.end(), static_cast<char>(1));
+
+    TensorDataView view{payload.data(), payload.size(), shape, format};
+    ASSERT_NO_THROW(tensor.upload(ctx, view));
+
+    const auto tensorData = tensor.download(ctx);
+    EXPECT_EQ(tensorData.data, payload);
+}
+
+TEST(TensorInMemoryTransfer, UploadAndDownloadRespectImageSubresourceOffset) {
+    ScenarioOptions opts{};
+    Context ctx{opts};
+    DataManager dm;
+    const Guid guid("tensor_image_subresource_offset");
+    const std::vector<int64_t> shape{2, 3, 1};
+    const vk::Format format = vk::Format::eR8Uint;
+    constexpr vk::DeviceSize subresourceOffset = 4096;
+
+    auto memoryManager = std::make_shared<ResourceMemoryManager>();
+    // Image::setup records a linear image's VkSubresourceLayout::offset this way.
+    memoryManager->updateSubResourceOffset(subresourceOffset);
+
+    TensorInfo info;
+    info.debugName = "test_tensor_image_subresource_offset";
+    info.shape = shape;
+    info.format = format;
+    info.tiling = Tiling::Linear;
+    dm.createTensor(guid, info);
+
+    auto &tensor = dm.getTensorMut(guid);
+    tensor.setup(ctx, memoryManager);
+    tensor.allocateMemory(ctx);
+
+    std::vector<char> payload(bytesFor(format, shape));
+    std::iota(payload.begin(), payload.end(), static_cast<char>(1));
+    ASSERT_NO_THROW(tensor.upload(ctx, {payload.data(), payload.size(), shape, format}));
+
+    const auto tensorData = tensor.download(ctx);
     EXPECT_EQ(tensorData.data, payload);
 }


### PR DESCRIPTION
Apply subresource and tensor memory offsets when filling staging memory.

Change-Id: I2a4c1ffac6ab2c4c200420cb9ab482f0cc68516e