### PR TITLE
feat: add total profiling execution time

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@
 ### Profiling
 
 - Using --dry-run with --profiling-dump-path now outputs information about pipeline compilation
+- Add new entry "Total execution time [ms]" in json profiling.
 
 ### Bug Fixes
 

--- a/src/json_writer.cpp
+++ b/src/json_writer.cpp
@@ -15,6 +15,10 @@ using json = nlohmann::json;
 namespace {
 json _profilingDataJsonOutput = json::object();
 
+double calculateElapsedTimeInMilliseconds(uint64_t startTimestamp, uint64_t endTimestamp, float timestampPeriod) {
+    return static_cast<double>(endTimestamp - startTimestamp) * static_cast<double>(timestampPeriod) / 1000000.0;
+}
+
 struct CommandTimestamps {
     CommandTimestamps() = default;
     CommandTimestamps(const ProfiledCommand &command, const std::vector<uint64_t> &commandTimestamps,
@@ -34,8 +38,9 @@ void to_json(json &j, const CommandTimestamps &commandTimestamps) {
              {"Cycle count after command", commandTimestamps.timestamps[1]},
              {"Cycle count for command", commandTimestamps.timestamps[1] - commandTimestamps.timestamps[0]},
              {"Timestamp Period", commandTimestamps.period},
-             {"Time for command [ms]", float(commandTimestamps.timestamps[1] - commandTimestamps.timestamps[0]) *
-                                           commandTimestamps.period / 1000000.0f},
+             {"Time for command [ms]",
+              calculateElapsedTimeInMilliseconds(commandTimestamps.timestamps[0], commandTimestamps.timestamps[1],
+                                                 commandTimestamps.period)},
              {"Iteration", commandTimestamps.iteration + 1}};
 }
 
@@ -102,6 +107,12 @@ void writeProfilingData(const std::optional<RuntimeProfilingData> &runtimeProfil
         const auto &[timestamps, timestampPeriod, commands] = runtimeProfilingData.value();
         if (commands.size() * 2 != timestamps.size()) {
             throw std::runtime_error("Cannot map all timestamps to their respective commands");
+        }
+        if (!timestamps.empty()) {
+            const auto totalExecutionTime =
+                calculateElapsedTimeInMilliseconds(timestamps.front(), timestamps.back(), timestampPeriod);
+            _profilingDataJsonOutput["Total execution time [ms]"] =
+                _profilingDataJsonOutput.value("Total execution time [ms]", 0.0) + totalExecutionTime;
         }
         for (size_t idx = 0, commandIdx = 0; idx < timestamps.size(); idx += 2, ++commandIdx) {
             _profilingDataJsonOutput["Timestamps"] += CommandTimestamps(

--- a/src/tests/json_writer_tests.cpp
+++ b/src/tests/json_writer_tests.cpp
@@ -46,4 +46,19 @@ TEST(JsonWriter, WritesEmptyObjectWithoutProfilingData) { // cppcheck-suppress s
     EXPECT_TRUE(profilingData.empty());
 }
 
+TEST(JsonWriter, WritesTotalExecutionTimeAcrossIterations) {
+    TempFolder tempFolder("scenario_runner_json_writer_tests");
+    const auto profilingPath = tempFolder.relative("runtime_profiling.json");
+    const std::vector<ProfiledCommand> commands{{"ComputeDispatch", "first"}, {"ComputeDispatch", "second"}};
+
+    writeProfilingData(RuntimeProfilingData{{100, 150, 175, 250}, 2.0f, commands}, {}, profilingPath, 0, 2);
+    writeProfilingData(RuntimeProfilingData{{1000, 1100, 1200, 1400}, 2.0f, commands}, {}, profilingPath, 1, 2);
+
+    std::ifstream dumpFile(profilingPath);
+    const auto profilingData = nlohmann::json::parse(dumpFile);
+
+    ASSERT_TRUE(profilingData.contains("Total execution time [ms]"));
+    EXPECT_DOUBLE_EQ(profilingData["Total execution time [ms]"].get<double>(), 0.0011);
+}
+
 } // namespace mlsdk::scenariorunner


### PR DESCRIPTION
Report the elapsed GPU time from the first profiled command to the last and accumulate it across repeated runs.
Add a common timestamp conversion helper for command and total timings.

Change-Id: I2e51f7b909a151a0a70620ebda53db6e9eb802b5