### PR TITLE
refactor: store VGF resource info by typed ID

### DIFF
--- a/src/iresource.hpp
+++ b/src/iresource.hpp
@@ -7,6 +7,7 @@
 #include "buffer.hpp"
 #include "guid.hpp"
 #include "image.hpp"
+#include "resource_id.hpp"
 #include "tensor.hpp"
 
 namespace mlsdk::scenariorunner {
@@ -16,10 +17,9 @@ class IResourceCreator {
   public:
     virtual ~IResourceCreator() = default;
 
-    // Create buffer resource and setup and allocate memory in buffer
-    virtual void createBuffer(Guid guid, BufferInfo &&info) = 0;
-    virtual void createTensor(Guid guid, TensorInfo &&info) = 0;
-    virtual void createImage(Guid guid, ImageInfo &&info) = 0;
+    virtual BufferId createBuffer(BufferInfo &&info) = 0;
+    virtual TensorId createTensor(TensorInfo &&info) = 0;
+    virtual ImageId createImage(ImageInfo &&info) = 0;
 };
 
 /// @brief Interface for accessing resources in an identifier agnostic way. Derived class handle the resource

--- a/src/resource_id.hpp
+++ b/src/resource_id.hpp
@@ -42,6 +42,8 @@ using RawDataId = ResourceId<RawDataIdTag>;
 using DataGraphId = ResourceId<DataGraphIdTag>;
 using GraphConstantResourceId = ResourceId<GraphConstantResourceIdTag>;
 
+using MemoryResourceId = std::variant<BufferId, ImageId, TensorId>;
+
 using TypedResourceId =
     std::variant<BufferId, ImageId, TensorId, ShaderId, RawDataId, DataGraphId, GraphConstantResourceId>;
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -430,22 +430,32 @@ std::vector<TypedBinding> convertBindings(const DataManager &dataManager,
 
 class Creator final : public IResourceCreator {
   public:
-    Creator(const Context &ctx, DataManager &dataManager, GroupManager &groupManager)
-        : _ctx{ctx}, _dataManager{dataManager}, _groupManager{groupManager} {}
+    Creator(const Context &ctx, ResourceManager &resources, DataManager &dataManager, GroupManager &groupManager)
+        : _ctx{ctx}, _resources{resources}, _dataManager{dataManager}, _groupManager{groupManager} {}
 
-    void createBuffer(Guid guid, BufferInfo &&info) override {
-        _dataManager.createBuffer(guid, std::move(info));
+    BufferId createBuffer(BufferInfo &&info) override {
+        // Use the generated resource name as the DataManager key until it accepts typed IDs.
+        const Guid guid(info.debugName);
+        const auto id = _resources.addBuffer(std::move(info));
+        _dataManager.createBuffer(guid, _resources.get(id));
         _createdResources.push_back({guid, ResourceIdType::Buffer});
+        return id;
     }
 
-    void createTensor(Guid guid, TensorInfo &&info) override {
-        _dataManager.createTensor(guid, std::move(info));
+    TensorId createTensor(TensorInfo &&info) override {
+        const Guid guid(info.debugName);
+        const auto id = _resources.addTensor(std::move(info));
+        _dataManager.createTensor(guid, _resources.get(id));
         _createdResources.push_back({guid, ResourceIdType::Tensor});
+        return id;
     }
 
-    void createImage(Guid guid, ImageInfo &&info) override {
-        _dataManager.createImage(guid, std::move(info));
+    ImageId createImage(ImageInfo &&info) override {
+        const Guid guid(info.debugName);
+        const auto id = _resources.addImage(std::move(info));
+        _dataManager.createImage(guid, _resources.get(id));
         _createdResources.push_back({guid, ResourceIdType::Image});
+        return id;
     }
 
     void setupCreatedNonTensorResources() {
@@ -491,23 +501,41 @@ class Creator final : public IResourceCreator {
 
   private:
     const Context &_ctx;
+    ResourceManager &_resources;
     DataManager &_dataManager;
     GroupManager &_groupManager;
     std::vector<GroupResourceEntry> _createdResources;
 };
 
-template <typename Id>
-Id resolveResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceIds, const Guid &guid,
-                     std::string_view expectedType) {
+const TypedResourceId &resolveTypedResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceIds,
+                                              const Guid &guid, std::string_view expectedType) {
     const auto resource = resourceIds.find(guid);
     if (resource == resourceIds.end()) {
         throw std::runtime_error(std::string(expectedType) + " resource not found.");
     }
-    const auto *id = std::get_if<Id>(&resource->second);
+    return resource->second;
+}
+
+template <typename Id>
+Id resolveResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceIds, const Guid &guid,
+                     std::string_view expectedType) {
+    const auto &resourceId = resolveTypedResourceId(resourceIds, guid, expectedType);
+    const auto *id = std::get_if<Id>(&resourceId);
     if (id == nullptr) {
         throw std::runtime_error("Resource UID has the wrong type; expected " + std::string(expectedType) + ".");
     }
     return *id;
+}
+
+GroupResourceEntry getGroupResourceEntry(const ResourceManager &resources, const MemoryResourceId &resourceId) {
+    if (const auto *id = std::get_if<BufferId>(&resourceId)) {
+        return {Guid(resources.get(*id).debugName), ResourceIdType::Buffer};
+    }
+    if (const auto *id = std::get_if<ImageId>(&resourceId)) {
+        return {Guid(resources.get(*id).debugName), ResourceIdType::Image};
+    }
+    const auto id = std::get<TensorId>(resourceId);
+    return {Guid(resources.get(id).debugName), ResourceIdType::Tensor};
 }
 
 struct CommandDataFactory {
@@ -729,6 +757,20 @@ Scenario::Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec)
 
 const ShaderInfo &Scenario::getShader(ShaderId id) const { return _resources.get(id); }
 
+MemoryResourceId Scenario::getMemoryResourceId(const Guid &guid) const {
+    const auto &resourceId = resolveTypedResourceId(_resourceIds, guid, "Memory");
+    if (const auto *id = std::get_if<BufferId>(&resourceId)) {
+        return *id;
+    }
+    if (const auto *id = std::get_if<ImageId>(&resourceId)) {
+        return *id;
+    }
+    if (const auto *id = std::get_if<TensorId>(&resourceId)) {
+        return *id;
+    }
+    throw std::runtime_error("Resource UID has the wrong type; expected a memory resource.");
+}
+
 const ShaderInfo &Scenario::getSubstitutionShader(const std::vector<ResolvedShaderSubstitution> &shaderSubstitutions,
                                                   const std::string &moduleName) const {
     for (const auto &shaderSub : shaderSubstitutions) {
@@ -866,7 +908,7 @@ void Scenario::setupResources() {
         mlsdk::logging::debug(resourceType(resource) + ": " + resource->guidStr + " loaded");
     }
 
-    Creator vgfResourceCreator{_ctx, _dataManager, _groupManager};
+    Creator vgfResourceCreator{_ctx, _resources, _dataManager, _groupManager};
     for (const auto &command : _scenarioSpec.commands) {
         if (command->commandType != CommandType::DispatchDataGraph) {
             continue;
@@ -877,11 +919,24 @@ void Scenario::setupResources() {
             resolveResourceId<DataGraphId>(_resourceIds, dispatchDataGraph.dataGraphRef, "Data graph");
         const auto &vgfView = _dataManager.getVgfView(dataGraph);
         const auto externalBindings = convertBindings(_dataManager, dispatchDataGraph.bindings);
-        // Register aliases before creating resources so setup/allocation sees the complete group membership.
-        for (const auto &alias : vgfView.getResourceAliases(externalBindings)) {
-            _groupManager.addResourceToGroup(alias.group, alias.resource, alias.resourceType);
+        const auto creationResult = vgfView.createIntermediateResources(vgfResourceCreator);
+        for (const auto &[aliasGroupId, resourceIds] : creationResult.memoryGroups) {
+            for (const auto &resourceId : resourceIds) {
+                const auto [resourceGuid, resourceType] = getGroupResourceEntry(_resources, resourceId);
+                _groupManager.addResourceToGroup(Guid(std::to_string(aliasGroupId)), resourceGuid, resourceType);
+            }
         }
-        vgfView.createIntermediateResources(vgfResourceCreator);
+
+        // External resources are resolved for each dispatch because bindings may differ.
+        for (const auto &binding : externalBindings) {
+            const auto aliasGroupId = vgfView.getModelResourceAliasGroup(binding.id);
+            if (!aliasGroupId.has_value()) {
+                continue;
+            }
+            const auto resourceId = getMemoryResourceId(binding.resourceRef);
+            const auto [resourceGuid, resourceType] = getGroupResourceEntry(_resources, resourceId);
+            _groupManager.addResourceToGroup(Guid(std::to_string(*aliasGroupId)), resourceGuid, resourceType);
+        }
     }
     _groupManager.finalize();
 

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -78,6 +78,7 @@ class Scenario {
 
     bool hasAliasedOptimalTensors() const;
     void handleAliasedLayoutTransitions();
+    MemoryResourceId getMemoryResourceId(const Guid &guid) const;
     const ShaderInfo &getShader(ShaderId id) const;
     const ShaderInfo &getSubstitutionShader(const std::vector<ResolvedShaderSubstitution> &shaderSubstitutions,
                                             const std::string &moduleName) const;

--- a/src/tests/vgf_view_tests.cpp
+++ b/src/tests/vgf_view_tests.cpp
@@ -28,13 +28,27 @@ namespace {
 
 class CapturingResourceCreator final : public IResourceCreator {
   public:
-    void createBuffer(Guid guid, BufferInfo &&info) override { buffers.push_back({guid, std::move(info)}); }
-    void createTensor(Guid guid, TensorInfo &&info) override { tensors.push_back({guid, std::move(info)}); }
-    void createImage(Guid guid, ImageInfo &&info) override { images.push_back({guid, std::move(info)}); }
+    BufferId createBuffer(BufferInfo &&info) override {
+        const BufferId id{buffers.size()};
+        buffers.push_back(std::move(info));
+        return id;
+    }
 
-    std::vector<std::pair<Guid, BufferInfo>> buffers;
-    std::vector<std::pair<Guid, TensorInfo>> tensors;
-    std::vector<std::pair<Guid, ImageInfo>> images;
+    TensorId createTensor(TensorInfo &&info) override {
+        const TensorId id{tensors.size()};
+        tensors.push_back(std::move(info));
+        return id;
+    }
+
+    ImageId createImage(ImageInfo &&info) override {
+        const ImageId id{images.size()};
+        images.push_back(std::move(info));
+        return id;
+    }
+
+    std::vector<BufferInfo> buffers;
+    std::vector<TensorInfo> tensors;
+    std::vector<ImageInfo> images;
 };
 
 std::filesystem::path writeVgfWithTensorInterfaceResources(TempFolder &tempFolder) {
@@ -108,6 +122,36 @@ std::filesystem::path writeVgfWithIntermediateBuffer(TempFolder &tempFolder, vk:
     return vgfPath;
 }
 
+std::filesystem::path writeVgfWithInputAndIntermediateBuffer(TempFolder &tempFolder) {
+    auto encoder = vgflib::CreateEncoder(123);
+    constexpr uint32_t aliasGroupId = 17;
+    const std::vector<int64_t> shape{1};
+
+    const auto module = encoder->AddModule(vgflib::ModuleType::COMPUTE, "resource_indexes", "main");
+    const auto input = encoder->AddInputResource(vgflib::ToDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER),
+                                                 vgflib::ToFormatType(VK_FORMAT_R8_UINT), shape, {});
+    const auto intermediate =
+        encoder->AddIntermediateResource(vgflib::ToDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER),
+                                         vgflib::ToFormatType(VK_FORMAT_R8_UINT), shape, {});
+    encoder->SetAliasGroup(input, aliasGroupId);
+    encoder->SetAliasGroup(intermediate, aliasGroupId);
+    const auto inputBinding = encoder->AddBindingSlot(0, input);
+    const auto intermediateBinding = encoder->AddBindingSlot(1, intermediate);
+    const auto descriptorSet =
+        encoder->AddDescriptorSetInfo(std::vector<vgflib::BindingSlotRef>{inputBinding, intermediateBinding});
+
+    encoder->AddModelSequenceInputsOutputs({inputBinding}, {"input"}, {}, {});
+    encoder->AddSegmentInfo(module, "resource_indexes_segment",
+                            std::vector<vgflib::DescriptorSetInfoRef>{descriptorSet}, {inputBinding},
+                            {intermediateBinding}, std::vector<vgflib::GraphConstantBindingRef>{}, {1, 1, 1});
+    encoder->Finish();
+
+    const std::string vgfPath = tempFolder.relative("scenario_runner_vgf_view_resource_indexes.vgf").string();
+    std::ofstream output(vgfPath, std::ios::binary);
+    encoder->WriteTo(output);
+    return vgfPath;
+}
+
 std::filesystem::path writeVgfWithSampledIntermediateImage(TempFolder &tempFolder, uint32_t addressModeU,
                                                            uint32_t addressModeV) {
     auto encoder = vgflib::CreateEncoder(123);
@@ -145,12 +189,30 @@ TEST(VgfView, IntermediateBufferSizeUsesVgfFormatElementSize) {
     auto view = VgfView::createVgfView(vgfPath.string());
     CapturingResourceCreator creator;
 
-    view.createIntermediateResources(creator);
+    const auto result = view.createIntermediateResources(creator);
 
     ASSERT_EQ(creator.buffers.size(), 1);
-    EXPECT_EQ(creator.buffers.front().second.size, elementCount * sizeof(uint16_t));
+    EXPECT_EQ(creator.buffers.front().size, elementCount * sizeof(uint16_t));
     EXPECT_TRUE(creator.tensors.empty());
     EXPECT_TRUE(creator.images.empty());
+    EXPECT_TRUE(result.memoryGroups.empty());
+}
+
+TEST(VgfView, IntermediateResourceAliasesUseCreatedIds) {
+    TempFolder tempFolder("vgf_view");
+    const auto vgfPath = writeVgfWithInputAndIntermediateBuffer(tempFolder);
+
+    auto view = VgfView::createVgfView(vgfPath.string());
+    CapturingResourceCreator creator;
+
+    const auto result = view.createIntermediateResources(creator);
+
+    ASSERT_EQ(creator.buffers.size(), 1);
+    ASSERT_EQ(result.memoryGroups.size(), 1);
+    ASSERT_EQ(result.memoryGroups.at(17).size(), 1);
+    EXPECT_EQ(std::get<BufferId>(result.memoryGroups.at(17).front()), BufferId{0});
+    EXPECT_EQ(view.getModelResourceAliasGroup(0), 17);
+    EXPECT_THROW(view.getModelResourceAliasGroup(99), std::runtime_error);
 }
 
 TEST(VgfView, IntermediateSampledImageUsesVgfSamplerConfig) {
@@ -161,10 +223,10 @@ TEST(VgfView, IntermediateSampledImageUsesVgfSamplerConfig) {
     auto view = VgfView::createVgfView(vgfPath.string());
     CapturingResourceCreator creator;
 
-    view.createIntermediateResources(creator);
+    const auto result = view.createIntermediateResources(creator);
 
     ASSERT_EQ(creator.images.size(), 1);
-    const auto &samplerSettings = creator.images.front().second.samplerSettings;
+    const auto &samplerSettings = creator.images.front().samplerSettings;
     EXPECT_EQ(samplerSettings.minFilter, FilterMode::Linear);
     EXPECT_EQ(samplerSettings.magFilter, FilterMode::Nearest);
     EXPECT_EQ(samplerSettings.addressModeU, AddressMode::ClampBorder);
@@ -174,6 +236,7 @@ TEST(VgfView, IntermediateSampledImageUsesVgfSamplerConfig) {
     EXPECT_EQ(samplerSettings.mipFilter, FilterMode::Nearest);
     EXPECT_TRUE(creator.buffers.empty());
     EXPECT_TRUE(creator.tensors.empty());
+    EXPECT_TRUE(result.memoryGroups.empty());
 }
 
 TEST(VgfView, IntermediateSampledImageAcceptsDistinctVgfAddressModes) {
@@ -184,13 +247,14 @@ TEST(VgfView, IntermediateSampledImageAcceptsDistinctVgfAddressModes) {
     auto view = VgfView::createVgfView(vgfPath.string());
     CapturingResourceCreator creator;
 
-    view.createIntermediateResources(creator);
+    const auto result = view.createIntermediateResources(creator);
 
     ASSERT_EQ(creator.images.size(), 1);
-    const auto &samplerSettings = creator.images.front().second.samplerSettings;
+    const auto &samplerSettings = creator.images.front().samplerSettings;
     EXPECT_EQ(samplerSettings.addressModeU, AddressMode::Repeat);
     EXPECT_EQ(samplerSettings.addressModeV, AddressMode::ClampEdge);
     EXPECT_EQ(samplerSettings.addressModeW, AddressMode::ClampEdge);
+    EXPECT_TRUE(result.memoryGroups.empty());
 }
 
 TEST(VgfView, ResolveBindingsReportsTensorShapeMismatchWithJsonLine) {

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -31,7 +31,7 @@ std::string_view categoryToSuffix(vgflib::ResourceCategory category) {
     }
 }
 
-std::string createResourceGuidStr(uint32_t index, vgflib::ResourceCategory category) {
+std::string createResourceName(uint32_t index, vgflib::ResourceCategory category) {
     return std::string("Resource_").append(std::to_string(index)).append(categoryToSuffix(category));
 }
 
@@ -115,23 +115,6 @@ std::optional<uint32_t> findModelInterfaceMrtIndex(const vgflib::ModelSequenceTa
     const auto result = findModelInterfaceResource(decoder, bindingId);
     return result ? std::optional<uint32_t>{result->mrtIndex} : std::nullopt;
 }
-
-ResourceIdType getResourceIdType(vgflib::DescriptorType descriptorType) {
-    switch (vk::DescriptorType(vgflib::ToVkDescriptorType(descriptorType))) {
-    case vk::DescriptorType::eUniformBuffer:
-    case vk::DescriptorType::eStorageBuffer:
-        return ResourceIdType::Buffer;
-    case vk::DescriptorType::eCombinedImageSampler:
-    case vk::DescriptorType::eStorageImage:
-        return ResourceIdType::Image;
-    case vk::DescriptorType::eTensorARM:
-        return ResourceIdType::Tensor;
-    default:
-        throw std::runtime_error("Resource type from VGF file not found");
-    }
-}
-
-Guid createVgfAliasGroupGuid(uint32_t aliasGroupId) { return Guid(std::to_string(aliasGroupId)); }
 
 std::runtime_error unsupportedVgfSamplerValue(const std::string &field, const std::string &value) {
     return std::runtime_error("Unsupported VGF sampler " + field + ": " + value);
@@ -401,7 +384,7 @@ std::pair<std::vector<TypedBinding>, VgfView::MrtIndexes> VgfView::getBindings(u
             const auto expectedType = resourceTableDecoder->getDescriptorType(mrtIndex);
             const auto vkDescriptorType = getVkDescriptorType(expectedType.value_or(DESCRIPTOR_TYPE_UNKNOWN));
             auto bindingId = sequenceTableDecoder->getBindingSlotBinding(handle, slot);
-            auto guidStr = createResourceGuidStr(mrtIndex, resourceTableDecoder->getCategory(mrtIndex));
+            auto guidStr = createResourceName(mrtIndex, resourceTableDecoder->getCategory(mrtIndex));
             TypedBinding binding;
             binding.set = set;
             binding.id = bindingId;
@@ -450,40 +433,12 @@ std::vector<TypedBinding> VgfView::resolveBindings(uint32_t segmentIndex, const 
     return bindings;
 }
 
-std::vector<ResourceAlias> VgfView::getResourceAliases(const std::vector<TypedBinding> &externalBindings) const {
-    std::vector<ResourceAlias> aliases;
-
-    for (const auto &externalBinding : externalBindings) {
-        const auto mrtIndex = findModelInterfaceMrtIndex(*sequenceTableDecoder, externalBinding.id);
-        if (!mrtIndex.has_value()) {
-            continue;
-        }
-
-        const auto aliasGroupId = resourceTableDecoder->getAliasGroupId(*mrtIndex);
-        if (!aliasGroupId.has_value()) {
-            continue;
-        }
-
-        const auto type = resourceTableDecoder->getDescriptorType(*mrtIndex);
-        const auto descriptorType = type.value_or(DESCRIPTOR_TYPE_UNKNOWN);
-        aliases.push_back(
-            {createVgfAliasGroupGuid(*aliasGroupId), externalBinding.resourceRef, getResourceIdType(descriptorType)});
+std::optional<uint32_t> VgfView::getModelResourceAliasGroup(uint32_t bindingId) const {
+    const auto resourceIndex = findModelInterfaceMrtIndex(*sequenceTableDecoder, bindingId);
+    if (!resourceIndex.has_value()) {
+        throw std::runtime_error("No model interface resource found for binding ID " + std::to_string(bindingId));
     }
-
-    size_t numResources = resourceTableDecoder->size();
-    for (uint32_t resourceIndex = 0; resourceIndex < numResources; ++resourceIndex) {
-        auto resourceCategory = resourceTableDecoder->getCategory(resourceIndex);
-        if (resourceCategory == vgflib::ResourceCategory::INTERMEDIATE) {
-            auto guidStr = createResourceGuidStr(resourceIndex, resourceCategory);
-            const Guid guid(guidStr);
-            if (const auto aliasGroupId = resourceTableDecoder->getAliasGroupId(resourceIndex)) {
-                const auto type = resourceTableDecoder->getDescriptorType(resourceIndex);
-                const auto descriptorType = type.value_or(DESCRIPTOR_TYPE_UNKNOWN);
-                aliases.push_back({createVgfAliasGroupGuid(*aliasGroupId), guid, getResourceIdType(descriptorType)});
-            }
-        }
-    }
-    return aliases;
+    return resourceTableDecoder->getAliasGroupId(*resourceIndex);
 }
 
 void VgfView::validateResource(const IResourceViewer &resourceViewer, uint32_t vgfMrtIndex,
@@ -561,14 +516,19 @@ void VgfView::validateResource(const IResourceViewer &resourceViewer, uint32_t v
     }
 }
 
-void VgfView::createIntermediateResources(IResourceCreator &creator) const {
-    // Iterate over all VGF Resources, create intermediates
+VgfResourceCreationResult VgfView::createIntermediateResources(IResourceCreator &creator) const {
+    // Iterate over all VGF resources, recording aliases and creating intermediates.
     size_t numResources = resourceTableDecoder->size();
+    VgfResourceCreationResult result;
     for (uint32_t resourceIndex = 0; resourceIndex < numResources; ++resourceIndex) {
         auto resourceCategory = resourceTableDecoder->getCategory(resourceIndex);
         if (resourceCategory == vgflib::ResourceCategory::INTERMEDIATE) {
-            auto guidStr = createResourceGuidStr(resourceIndex, resourceCategory);
-            const Guid guid(guidStr);
+            const auto addResource = [&](MemoryResourceId id) {
+                if (const auto aliasGroupId = resourceTableDecoder->getAliasGroupId(resourceIndex)) {
+                    result.memoryGroups[*aliasGroupId].push_back(id);
+                }
+            };
+            auto debugName = createResourceName(resourceIndex, resourceCategory);
             const auto shape = resourceTableDecoder->getTensorShape(resourceIndex);
             const auto type = resourceTableDecoder->getDescriptorType(resourceIndex);
             const auto descriptorType = type.value_or(DESCRIPTOR_TYPE_UNKNOWN);
@@ -579,24 +539,24 @@ void VgfView::createIntermediateResources(IResourceCreator &creator) const {
                     bufferSize(shape, vk::Format(resourceTableDecoder->getVkFormat(resourceIndex)));
 
                 // Create Scenario Runner buffer resource
-                BufferInfo info{std::move(guidStr), expectedBufferSize};
-                creator.createBuffer(guid, std::move(info));
+                BufferInfo info{std::move(debugName), expectedBufferSize};
+                addResource(creator.createBuffer(std::move(info)));
             } break;
             case DESCRIPTOR_TYPE_TENSOR_ARM: {
                 auto format = resourceTableDecoder->getVkFormat(resourceIndex);
 
-                auto info = TensorInfo{std::move(guidStr), std::vector<int64_t>(shape.begin(), shape.end()),
+                auto info = TensorInfo{std::move(debugName), std::vector<int64_t>(shape.begin(), shape.end()),
                                        vk::Format(format), -1, false};
 
                 // Create Scenario Runner tensor
-                creator.createTensor(guid, std::move(info));
+                addResource(creator.createTensor(std::move(info)));
             } break;
             case DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
             case DESCRIPTOR_TYPE_STORAGE_IMAGE: {
                 auto format = resourceTableDecoder->getVkFormat(resourceIndex);
 
                 ImageInfo info{};
-                info.debugName = std::move(guidStr);
+                info.debugName = std::move(debugName);
                 info.shape = std::vector<int64_t>(shape.begin(), shape.end());
                 info.format = vk::Format(format);
                 info.targetFormat = info.format;
@@ -608,14 +568,15 @@ void VgfView::createIntermediateResources(IResourceCreator &creator) const {
                     applyVgfSamplerConfigIfPresent(*resourceTableDecoder, resourceIndex, info);
                 }
 
-                creator.createImage(guid, std::move(info));
+                addResource(creator.createImage(std::move(info)));
             } break;
             default:
                 throw std::runtime_error("Unknown resource type: " + std::to_string(descriptorType) +
-                                         " read from VGF file for uid: " + guidStr);
+                                         " read from VGF file for resource: " + debugName);
             }
         }
     }
+    return result;
 }
 
 } // namespace mlsdk::scenariorunner

--- a/src/vgf_view.hpp
+++ b/src/vgf_view.hpp
@@ -21,10 +21,8 @@ namespace mlsdk::scenariorunner {
 
 class DataManager;
 
-struct ResourceAlias {
-    Guid group;
-    Guid resource;
-    ResourceIdType resourceType;
+struct VgfResourceCreationResult {
+    std::map<uint32_t, std::vector<MemoryResourceId>> memoryGroups;
 };
 
 class VgfView {
@@ -53,8 +51,8 @@ class VgfView {
 
     std::vector<TypedBinding> resolveBindings(uint32_t segmentIndex, const DataManager &dataManager,
                                               const std::vector<TypedBinding> &externalBindings) const;
-    std::vector<ResourceAlias> getResourceAliases(const std::vector<TypedBinding> &externalBindings) const;
-    void createIntermediateResources(IResourceCreator &creator) const;
+    std::optional<uint32_t> getModelResourceAliasGroup(uint32_t bindingId) const;
+    VgfResourceCreationResult createIntermediateResources(IResourceCreator &creator) const;
 
   private:
     // Map of (set, binding) to vgfMrtIndex


### PR DESCRIPTION
Return typed IDs for aliased VGF intermediate resources and group them by their VGF alias group. Create intermediate resources and resolve external resources for each data graph dispatch.

Keep the remaining GUID compatibility in Scenario while the data and group managers use their existing GUID-based interfaces.

Change-Id: I3367341433fb49981089bd42fcab537766e28724