### PR TITLE
refactor: use typed IDs for memory groups

### DIFF
--- a/src/group_manager.cpp
+++ b/src/group_manager.cpp
@@ -10,17 +10,33 @@
 
 namespace mlsdk::scenariorunner {
 
-void GroupManager::addResourceToGroup(const Guid &group, const Guid &resource, ResourceIdType resourceIdType) {
+MemoryGroupId GroupManager::createMemoryGroup() {
+    if (_finalized) {
+        throw std::runtime_error("Cannot create memory group after finalization");
+    }
+    const MemoryGroupId group{_nextGroupId++};
+    _groupResources.emplace(group, std::vector<MemoryResourceId>{});
+    return group;
+}
+
+void GroupManager::addResourceToGroup(MemoryGroupId group, MemoryResourceId resource) {
     if (_finalized) {
         throw std::runtime_error("Cannot add resource to memory group after finalization");
+    }
+    const auto groupIt = _groupResources.find(group);
+    if (groupIt == _groupResources.end()) {
+        throw std::runtime_error("Memory group does not exist");
     }
     const auto [resourceIt, inserted] = _resourceToGroup.emplace(resource, group);
     if (!inserted && resourceIt->second != group) {
         throw std::runtime_error("Resource already belongs to a different group");
     }
+    if (!inserted) {
+        return;
+    }
     logging::debug("addResourceToGroup count of resources: " + std::to_string(_resourceToGroup.size()) +
-                   " added type: " + std::to_string(static_cast<int>(resourceIdType)));
-    _groupResources[group].insert({resource, resourceIdType});
+                   " added type: " + std::to_string(resource.index()));
+    groupIt->second.push_back(resource);
 }
 
 void GroupManager::finalize() {
@@ -37,7 +53,7 @@ void GroupManager::finalize() {
     _finalized = true;
 }
 
-size_t GroupManager::getAliasCount(const Guid &resource) const {
+size_t GroupManager::getAliasCount(MemoryResourceId resource) const {
     const auto it = _resourceToGroup.find(resource);
     if (it != _resourceToGroup.end()) {
         return _groupResources.at(it->second).size();
@@ -45,21 +61,9 @@ size_t GroupManager::getAliasCount(const Guid &resource) const {
     return 0;
 }
 
-bool GroupManager::isAliased(const Guid &resource) const { return getAliasCount(resource) > 1; }
+bool GroupManager::isAliased(MemoryResourceId resource) const { return getAliasCount(resource) > 1; }
 
-bool GroupManager::hasAliasOfType(const Guid &resource, ResourceIdType resourceIdType) const {
-    if (const auto group = getGroupForResource(resource); group.has_value()) {
-        // Group found, look for requested type
-        for (const auto &[aliasResource, aliasType] : _groupResources.at(*group)) {
-            if (aliasResource != resource && aliasType == resourceIdType) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-std::shared_ptr<ResourceMemoryManager> GroupManager::getMemoryManager(const Guid &resource) {
+std::shared_ptr<ResourceMemoryManager> GroupManager::getMemoryManager(MemoryResourceId resource) {
     if (!_finalized) {
         throw std::runtime_error("Memory groups must be finalized before accessing memory managers");
     }
@@ -70,7 +74,7 @@ std::shared_ptr<ResourceMemoryManager> GroupManager::getMemoryManager(const Guid
     return std::make_shared<ResourceMemoryManager>();
 }
 
-std::optional<Guid> GroupManager::getGroupForResource(const Guid &resource) const {
+std::optional<MemoryGroupId> GroupManager::getGroupForResource(MemoryResourceId resource) const {
     const auto it = _resourceToGroup.find(resource);
     if (it != _resourceToGroup.end()) {
         return it->second;
@@ -80,12 +84,12 @@ std::optional<Guid> GroupManager::getGroupForResource(const Guid &resource) cons
 
 const GroupResources &GroupManager::getGroups() const { return _groupResources; }
 
-std::vector<GroupResourceEntry> GroupManager::getResourcesInGroup(const Guid &group) const {
+std::vector<MemoryResourceId> GroupManager::getResourcesInGroup(MemoryGroupId group) const {
     const auto it = _groupResources.find(group);
     if (it == _groupResources.end()) {
         return {};
     }
-    return {it->second.begin(), it->second.end()};
+    return it->second;
 }
 
 } // namespace mlsdk::scenariorunner

--- a/src/group_manager.hpp
+++ b/src/group_manager.hpp
@@ -7,39 +7,38 @@
 
 #include "scenario_runner.hpp"
 
-#include <set>
 #include <unordered_map>
 
 namespace mlsdk::scenariorunner {
 
 class GroupManager : public IGroupManager {
   public:
-    /// Create or add resource to group
-    void addResourceToGroup(const Guid &group, const Guid &resource, ResourceIdType resourceIdType) override;
+    MemoryGroupId createMemoryGroup() override;
+
+    /// Add resource to group
+    void addResourceToGroup(MemoryGroupId group, MemoryResourceId resource) override;
 
     /// Complete group registration and create the shared memory managers.
     void finalize() override;
 
     /// Return size of group that resource belongs to
-    size_t getAliasCount(const Guid &resource) const override;
+    size_t getAliasCount(MemoryResourceId resource) const override;
 
-    bool isAliased(const Guid &resource) const override;
-
-    ///  Returns true if resource is aliased with any resource of type
-    bool hasAliasOfType(const Guid &resource, ResourceIdType resourceIdType) const override;
+    bool isAliased(MemoryResourceId resource) const override;
 
     // Get memory manager, shared if resource is aliased.
-    std::shared_ptr<ResourceMemoryManager> getMemoryManager(const Guid &resource) override;
+    std::shared_ptr<ResourceMemoryManager> getMemoryManager(MemoryResourceId resource) override;
     const GroupResources &getGroups() const override;
 
-    std::optional<Guid> getGroupForResource(const Guid &resource) const;
-    std::vector<GroupResourceEntry> getResourcesInGroup(const Guid &group) const;
+    std::optional<MemoryGroupId> getGroupForResource(MemoryResourceId resource) const;
+    std::vector<MemoryResourceId> getResourcesInGroup(MemoryGroupId group) const;
 
   private:
     bool _finalized{false};
-    std::unordered_map<Guid, Guid> _resourceToGroup;
+    size_t _nextGroupId{};
+    std::unordered_map<MemoryResourceId, MemoryGroupId> _resourceToGroup;
     GroupResources _groupResources;
-    std::unordered_map<Guid, std::shared_ptr<ResourceMemoryManager>> _groupMemoryManagers;
+    std::unordered_map<MemoryGroupId, std::shared_ptr<ResourceMemoryManager>> _groupMemoryManagers;
 };
 
 } // namespace mlsdk::scenariorunner

--- a/src/resource_id.hpp
+++ b/src/resource_id.hpp
@@ -33,6 +33,7 @@ struct ShaderIdTag;
 struct RawDataIdTag;
 struct DataGraphIdTag;
 struct GraphConstantResourceIdTag;
+struct MemoryGroupIdTag;
 
 using BufferId = ResourceId<BufferIdTag>;
 using ImageId = ResourceId<ImageIdTag>;
@@ -41,6 +42,7 @@ using ShaderId = ResourceId<ShaderIdTag>;
 using RawDataId = ResourceId<RawDataIdTag>;
 using DataGraphId = ResourceId<DataGraphIdTag>;
 using GraphConstantResourceId = ResourceId<GraphConstantResourceIdTag>;
+using MemoryGroupId = ResourceId<MemoryGroupIdTag>;
 
 using MemoryResourceId = std::variant<BufferId, ImageId, TensorId>;
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -438,7 +438,7 @@ class Creator final : public IResourceCreator {
         const Guid guid(info.debugName);
         const auto id = _resources.addBuffer(std::move(info));
         _dataManager.createBuffer(guid, _resources.get(id));
-        _createdResources.push_back({guid, ResourceIdType::Buffer});
+        _createdResources.push_back({guid, id});
         return id;
     }
 
@@ -446,7 +446,7 @@ class Creator final : public IResourceCreator {
         const Guid guid(info.debugName);
         const auto id = _resources.addTensor(std::move(info));
         _dataManager.createTensor(guid, _resources.get(id));
-        _createdResources.push_back({guid, ResourceIdType::Tensor});
+        _createdResources.push_back({guid, id});
         return id;
     }
 
@@ -454,57 +454,51 @@ class Creator final : public IResourceCreator {
         const Guid guid(info.debugName);
         const auto id = _resources.addImage(std::move(info));
         _dataManager.createImage(guid, _resources.get(id));
-        _createdResources.push_back({guid, ResourceIdType::Image});
+        _createdResources.push_back({guid, id});
         return id;
     }
 
     void setupCreatedNonTensorResources() {
-        for (const auto &[guid, type] : _createdResources) {
-            switch (type) {
-            case ResourceIdType::Buffer:
-                _dataManager.getBufferMut(guid).setup(_ctx, _groupManager.getMemoryManager(guid));
-                break;
-            case ResourceIdType::Image:
-                _dataManager.getImageMut(guid).setup(_ctx, _groupManager.getMemoryManager(guid));
-                break;
-            default:
-                break;
+        for (const auto &[guid, id] : _createdResources) {
+            if (std::holds_alternative<BufferId>(id)) {
+                _dataManager.getBufferMut(guid).setup(_ctx, _groupManager.getMemoryManager(id));
+            } else if (std::holds_alternative<ImageId>(id)) {
+                _dataManager.getImageMut(guid).setup(_ctx, _groupManager.getMemoryManager(id));
             }
         }
     }
 
     void setupCreatedTensorResources() {
-        for (const auto &[guid, type] : _createdResources) {
-            if (type == ResourceIdType::Tensor) {
-                _dataManager.getTensorMut(guid).setup(_ctx, _groupManager.getMemoryManager(guid));
+        for (const auto &[guid, id] : _createdResources) {
+            if (std::holds_alternative<TensorId>(id)) {
+                _dataManager.getTensorMut(guid).setup(_ctx, _groupManager.getMemoryManager(id));
             }
         }
     }
 
     void allocateCreatedResources() {
-        for (const auto &[guid, type] : _createdResources) {
-            switch (type) {
-            case ResourceIdType::Buffer:
+        for (const auto &[guid, id] : _createdResources) {
+            if (std::holds_alternative<BufferId>(id)) {
                 _dataManager.getBufferMut(guid).allocateMemory(_ctx);
-                break;
-            case ResourceIdType::Image:
+            } else if (std::holds_alternative<ImageId>(id)) {
                 _dataManager.getImageMut(guid).allocateMemory(_ctx);
-                break;
-            case ResourceIdType::Tensor:
+            } else if (std::holds_alternative<TensorId>(id)) {
                 _dataManager.getTensorMut(guid).allocateMemory(_ctx);
-                break;
-            default:
-                break;
             }
         }
     }
 
   private:
+    struct CreatedResource {
+        Guid guid;
+        MemoryResourceId id;
+    };
+
     const Context &_ctx;
     ResourceManager &_resources;
     DataManager &_dataManager;
     GroupManager &_groupManager;
-    std::vector<GroupResourceEntry> _createdResources;
+    std::vector<CreatedResource> _createdResources;
 };
 
 const TypedResourceId &resolveTypedResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceIds,
@@ -527,15 +521,24 @@ Id resolveResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceId
     return *id;
 }
 
-GroupResourceEntry getGroupResourceEntry(const ResourceManager &resources, const MemoryResourceId &resourceId) {
-    if (const auto *id = std::get_if<BufferId>(&resourceId)) {
-        return {Guid(resources.get(*id).debugName), ResourceIdType::Buffer};
+template <typename Key>
+MemoryGroupId getOrCreateMemoryGroup(GroupManager &groupManager, std::unordered_map<Key, MemoryGroupId> &memoryGroupIds,
+                                     const Key &key) {
+    const auto existingGroup = memoryGroupIds.find(key);
+    if (existingGroup != memoryGroupIds.end()) {
+        return existingGroup->second;
     }
-    if (const auto *id = std::get_if<ImageId>(&resourceId)) {
-        return {Guid(resources.get(*id).debugName), ResourceIdType::Image};
+    const auto group = groupManager.createMemoryGroup();
+    memoryGroupIds.emplace(key, group);
+    return group;
+}
+
+void registerMemoryGroup(GroupManager &groupManager, std::unordered_map<Guid, MemoryGroupId> &memoryGroupIds,
+                         MemoryResourceId resource, const std::optional<MemoryGroup> &memoryGroup) {
+    if (memoryGroup.has_value()) {
+        const auto group = getOrCreateMemoryGroup(groupManager, memoryGroupIds, memoryGroup->memoryUid);
+        groupManager.addResourceToGroup(group, resource);
     }
-    const auto id = std::get<TensorId>(resourceId);
-    return {Guid(resources.get(id).debugName), ResourceIdType::Tensor};
 }
 
 struct CommandDataFactory {
@@ -828,36 +831,11 @@ void Scenario::run(int repeatCount, bool dryRun) {
 
 void Scenario::setupResources() {
     mlsdk::logging::info("Setup resources, count: " + std::to_string(_scenarioSpec.resources.size()));
-    // Handle memory groups
-    for (const auto &resource : _scenarioSpec.resources) {
-        switch (resource->resourceType) {
-        case ResourceType::Buffer: {
-            const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
-            if (buffer->memoryGroup.has_value()) {
-                _groupManager.addResourceToGroup(buffer->memoryGroup->memoryUid, buffer->guid, ResourceIdType::Buffer);
-            }
-        } break;
-        case ResourceType::Image: {
-            const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
-            if (image->memoryGroup.has_value()) {
-                _groupManager.addResourceToGroup(image->memoryGroup->memoryUid, image->guid, ResourceIdType::Image);
-            }
-        } break;
-        case ResourceType::Tensor: {
-            const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
-            if (tensor->memoryGroup.has_value()) {
-                _groupManager.addResourceToGroup(tensor->memoryGroup->memoryUid, tensor->guid, ResourceIdType::Tensor);
-            }
-        } break;
-        default:
-            // Skip the other types of resources
-            continue;
-        }
-    }
-
     // Setup resource info
     // (Memory for Tensors and Images is allocated in next pass)
     ResourceInfoFactory resourceInfoFactory;
+    std::unordered_map<Guid, MemoryGroupId> jsonMemoryGroupIds;
+
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
         case ResourceType::Buffer: {
@@ -865,6 +843,7 @@ void Scenario::setupResources() {
             const auto id = _resources.addBuffer(resourceInfoFactory.createInfo(*buffer));
             _resourceIds.emplace(resource->guid, id);
             _dataManager.createBuffer(resource->guid, _resources.get(id));
+            registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, buffer->memoryGroup);
         } break;
         case ResourceType::RawData: {
             const auto &rawData = reinterpret_cast<const std::unique_ptr<RawDataDesc> &>(resource);
@@ -877,6 +856,7 @@ void Scenario::setupResources() {
             const auto id = _resources.addImage(resourceInfoFactory.createInfo(*image));
             _resourceIds.emplace(resource->guid, id);
             _dataManager.createImage(resource->guid, _resources.get(id));
+            registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, image->memoryGroup);
         } break;
         case ResourceType::DataGraph: {
             const auto &dataGraph = reinterpret_cast<const std::unique_ptr<DataGraphDesc> &>(resource);
@@ -890,6 +870,7 @@ void Scenario::setupResources() {
             const auto id = _resources.addTensor(resourceInfoFactory.createInfo(*tensor, _opts.captureFrame));
             _resourceIds.emplace(resource->guid, id);
             _dataManager.createTensor(resource->guid, _resources.get(id));
+            registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, tensor->memoryGroup);
         } break;
         case ResourceType::Shader: {
             const auto &shader = reinterpret_cast<const std::unique_ptr<ShaderDesc> &>(resource);
@@ -909,6 +890,8 @@ void Scenario::setupResources() {
     }
 
     Creator vgfResourceCreator{_ctx, _resources, _dataManager, _groupManager};
+    std::unordered_map<DataGraphId, std::unordered_map<uint32_t, MemoryGroupId>> vgfMemoryGroupIds;
+
     for (const auto &command : _scenarioSpec.commands) {
         if (command->commandType != CommandType::DispatchDataGraph) {
             continue;
@@ -921,9 +904,10 @@ void Scenario::setupResources() {
         const auto externalBindings = convertBindings(_dataManager, dispatchDataGraph.bindings);
         const auto creationResult = vgfView.createIntermediateResources(vgfResourceCreator);
         for (const auto &[aliasGroupId, resourceIds] : creationResult.memoryGroups) {
+            auto &aliasGroupIds = vgfMemoryGroupIds[dataGraph];
+            const auto group = getOrCreateMemoryGroup(_groupManager, aliasGroupIds, aliasGroupId);
             for (const auto &resourceId : resourceIds) {
-                const auto [resourceGuid, resourceType] = getGroupResourceEntry(_resources, resourceId);
-                _groupManager.addResourceToGroup(Guid(std::to_string(aliasGroupId)), resourceGuid, resourceType);
+                _groupManager.addResourceToGroup(group, resourceId);
             }
         }
 
@@ -934,8 +918,9 @@ void Scenario::setupResources() {
                 continue;
             }
             const auto resourceId = getMemoryResourceId(binding.resourceRef);
-            const auto [resourceGuid, resourceType] = getGroupResourceEntry(_resources, resourceId);
-            _groupManager.addResourceToGroup(Guid(std::to_string(*aliasGroupId)), resourceGuid, resourceType);
+            auto &aliasGroupIds = vgfMemoryGroupIds[dataGraph];
+            const auto group = getOrCreateMemoryGroup(_groupManager, aliasGroupIds, *aliasGroupId);
+            _groupManager.addResourceToGroup(group, resourceId);
         }
     }
     _groupManager.finalize();
@@ -945,11 +930,13 @@ void Scenario::setupResources() {
         switch (resource->resourceType) {
         case ResourceType::Buffer: {
             auto &bufferRef = _dataManager.getBufferMut(resource->guid);
-            bufferRef.setup(_ctx, _groupManager.getMemoryManager(resource->guid));
+            const auto id = resolveResourceId<BufferId>(_resourceIds, resource->guid, "Buffer");
+            bufferRef.setup(_ctx, _groupManager.getMemoryManager(id));
         } break;
         case ResourceType::Image: {
             auto &imageRef = _dataManager.getImageMut(resource->guid);
-            imageRef.setup(_ctx, _groupManager.getMemoryManager(resource->guid));
+            const auto id = resolveResourceId<ImageId>(_resourceIds, resource->guid, "Image");
+            imageRef.setup(_ctx, _groupManager.getMemoryManager(id));
         } break;
         default:
             break; // No action
@@ -961,7 +948,8 @@ void Scenario::setupResources() {
     for (const auto &resource : _scenarioSpec.resources) {
         if (resource->resourceType == ResourceType::Tensor) {
             auto &tensorRef = _dataManager.getTensorMut(resource->guid);
-            tensorRef.setup(_ctx, _groupManager.getMemoryManager(resource->guid));
+            const auto id = resolveResourceId<TensorId>(_resourceIds, resource->guid, "Tensor");
+            tensorRef.setup(_ctx, _groupManager.getMemoryManager(id));
         }
     }
     vgfResourceCreator.setupCreatedTensorResources();
@@ -1005,7 +993,8 @@ void Scenario::setupResources() {
             auto &tensorRec = _dataManager.getTensorMut(tensor->guid);
             tensorRec.allocateMemory(_ctx);
             PerfCounterGuard guard(_perfCounters, "Load Tensor: " + tensor->guidStr, "Scenario Setup");
-            if (tensor->src || !_groupManager.isAliased(tensor->guid)) {
+            const auto id = resolveResourceId<TensorId>(_resourceIds, tensor->guid, "Tensor");
+            if (tensor->src || !_groupManager.isAliased(id)) {
                 tensorRec.fillFromDescription(_ctx, *tensor);
             }
         } break;
@@ -1014,7 +1003,8 @@ void Scenario::setupResources() {
             auto &imageRec = _dataManager.getImageMut(image->guid);
             imageRec.allocateMemory(_ctx);
             PerfCounterGuard guard(_perfCounters, "Load Image: " + image->guidStr, "Scenario Setup");
-            if (image->src || !_groupManager.isAliased(image->guid)) {
+            const auto id = resolveResourceId<ImageId>(_resourceIds, image->guid, "Image");
+            if (image->src || !_groupManager.isAliased(id)) {
                 imageRec.fillFromDescription(_ctx, *image);
             } else {
                 imageRec.transitionLayout(_ctx, vk::ImageLayout::eGeneral);
@@ -1025,7 +1015,8 @@ void Scenario::setupResources() {
             auto &bufferRec = _dataManager.getBufferMut(buffer->guid);
             bufferRec.allocateMemory(_ctx);
             PerfCounterGuard guard(_perfCounters, "Load Buffer: " + buffer->guidStr, "Scenario Setup");
-            if (buffer->src || !_groupManager.isAliased(buffer->guid)) {
+            const auto id = resolveResourceId<BufferId>(_resourceIds, buffer->guid, "Buffer");
+            if (buffer->src || !_groupManager.isAliased(id)) {
                 bufferRec.fillFromDescription(_ctx, *buffer);
             }
         } break;
@@ -1110,9 +1101,9 @@ void Scenario::setupCommands() {
 bool Scenario::hasAliasedOptimalTensors() const {
     // If any tensors in any memgroup have optimal tiling
     for ([[maybe_unused]] const auto &[_, resources] : _groupManager.getGroups()) {
-        for ([[maybe_unused]] const auto &[resource, type] : resources) {
-            if (_dataManager.hasTensor(resource) &&
-                _dataManager.getTensor(resource).tiling() == vk::TensorTilingARM::eOptimal) {
+        for (const auto &resource : resources) {
+            const auto *tensor = std::get_if<TensorId>(&resource);
+            if (tensor != nullptr && _resources.get(*tensor).tiling == Tiling::Optimal) {
                 return true;
             }
         }
@@ -1126,15 +1117,17 @@ void Scenario::handleAliasedLayoutTransitions() {
     for ([[maybe_unused]] const auto &[_, resources] : _groupManager.getGroups()) {
         bool allLinear = true;
         bool allOptimal = true;
-        for ([[maybe_unused]] const auto &[resource, type] : resources) {
-            if (_dataManager.hasTensor(resource)) {
-                if (_dataManager.getTensor(resource).tiling() == vk::TensorTilingARM::eLinear) {
+        for (const auto &resource : resources) {
+            if (const auto *tensor = std::get_if<TensorId>(&resource)) {
+                if (_resources.get(*tensor).tiling == Tiling::Linear) {
                     allOptimal = false;
                 } else {
                     allLinear = false;
                 }
-            } else if (_dataManager.hasImage(resource)) {
-                if (_dataManager.getImage(resource).tiling() == vk::ImageTiling::eLinear) {
+            } else if (const auto *image = std::get_if<ImageId>(&resource)) {
+                const auto tiling =
+                    _resources.get(*image).tiling.value_or(resources.size() > 1 ? Tiling::Linear : Tiling::Optimal);
+                if (tiling == Tiling::Linear) {
                     allOptimal = false;
                 } else {
                     allLinear = false;
@@ -1173,7 +1166,8 @@ void Scenario::handleAliasedLayoutTransitions() {
         //  Tensor → requires image to be in eTensorAliasingARM
         if (resource->resourceType == ResourceType::Tensor) {
             const auto &tensorDesc = static_cast<const TensorDesc &>(*resource);
-            if (_groupManager.getAliasCount(tensorDesc.guid) != 2) {
+            const auto tensorId = resolveResourceId<TensorId>(_resourceIds, tensorDesc.guid, "Tensor");
+            if (_groupManager.getAliasCount(tensorId) != 2) {
                 continue;
             }
             if (!tensorDesc.tiling.has_value()) {
@@ -1189,7 +1183,8 @@ void Scenario::handleAliasedLayoutTransitions() {
                 }
                 const auto &imageDesc = static_cast<const ImageDesc &>(*imageResource);
 
-                if (_groupManager.getAliasCount(imageDesc.guid) != 2) {
+                const auto imageId = resolveResourceId<ImageId>(_resourceIds, imageDesc.guid, "Image");
+                if (_groupManager.getAliasCount(imageId) != 2) {
                     continue;
                 }
                 if (!imageDesc.tiling.has_value()) {
@@ -1215,7 +1210,8 @@ void Scenario::handleAliasedLayoutTransitions() {
                 }
                 const auto &tensorDesc = static_cast<const TensorDesc &>(*tensorResource);
 
-                if (_groupManager.getAliasCount(tensorDesc.guid) != 2) {
+                const auto tensorId = resolveResourceId<TensorId>(_resourceIds, tensorDesc.guid, "Tensor");
+                if (_groupManager.getAliasCount(tensorId) != 2) {
                     continue;
                 }
                 if (!tensorDesc.tiling.has_value()) {

--- a/src/scenario_runner.hpp
+++ b/src/scenario_runner.hpp
@@ -5,47 +5,28 @@
 
 #pragma once
 
-#include "guid.hpp"
+#include "resource_id.hpp"
 #include "vulkan_memory_manager.hpp"
 
 #include <memory>
-#include <set>
 #include <unordered_map>
-#include <utility>
+#include <vector>
 
 namespace mlsdk::scenariorunner {
 
-/// All resource types
-enum class ResourceIdType {
-    Unknown,
-    /// These may alias
-    Buffer,
-    Image,
-    Tensor,
-    /// Other resources
-    RawData,
-    Shader,
-    VgfView,
-    BufferBarrier,
-    ImageBarrier,
-    MemoryBarrier,
-    TensorBarrier,
-};
-
-using GroupResourceEntry = std::pair<Guid, ResourceIdType>;
-using GroupResources = std::unordered_map<Guid, std::set<GroupResourceEntry>>;
+using GroupResources = std::unordered_map<MemoryGroupId, std::vector<MemoryResourceId>>;
 
 /// Managing memory groups, all aliasing resources belong to a shared memory manager.
 class IGroupManager {
   public:
     virtual ~IGroupManager() = default;
 
-    virtual void addResourceToGroup(const Guid &group, const Guid &resource, ResourceIdType resourceIdType) = 0;
+    virtual MemoryGroupId createMemoryGroup() = 0;
+    virtual void addResourceToGroup(MemoryGroupId group, MemoryResourceId resource) = 0;
     virtual void finalize() = 0;
-    virtual size_t getAliasCount(const Guid &resource) const = 0;
-    virtual bool isAliased(const Guid &resource) const = 0;
-    virtual bool hasAliasOfType(const Guid &resource, ResourceIdType resourceIdType) const = 0;
-    virtual std::shared_ptr<ResourceMemoryManager> getMemoryManager(const Guid &resource) = 0;
+    virtual size_t getAliasCount(MemoryResourceId resource) const = 0;
+    virtual bool isAliased(MemoryResourceId resource) const = 0;
+    virtual std::shared_ptr<ResourceMemoryManager> getMemoryManager(MemoryResourceId resource) = 0;
     virtual const GroupResources &getGroups() const = 0;
 };
 

--- a/src/tests/group_manager_tests.cpp
+++ b/src/tests/group_manager_tests.cpp
@@ -11,27 +11,22 @@
 using namespace mlsdk::scenariorunner;
 
 TEST(GroupManager, GroupHandling) {
-    const Guid group0("group0");
-    const Guid tensor0("tensor0");
-    const Guid image0("image0");
+    const TensorId tensor0{0};
+    const ImageId image0{0};
+    const ImageId image1{1};
     GroupManager gm;
-    gm.addResourceToGroup(group0, tensor0, ResourceIdType::Tensor);
+    const auto group0 = gm.createMemoryGroup();
+    gm.addResourceToGroup(group0, tensor0);
     ASSERT_EQ(gm.getAliasCount(tensor0), 1U);
     ASSERT_FALSE(gm.isAliased(tensor0));
-    ASSERT_EQ(gm.getAliasCount(image0), 0U);
-    ASSERT_FALSE(gm.isAliased(image0));
-    ASSERT_FALSE(gm.hasAliasOfType(tensor0, ResourceIdType::Image));
-    ASSERT_FALSE(gm.hasAliasOfType(image0, ResourceIdType::Tensor));
-    ASSERT_FALSE(gm.hasAliasOfType(group0, ResourceIdType::Tensor));
+    ASSERT_EQ(gm.getAliasCount(image1), 0U);
+    ASSERT_FALSE(gm.isAliased(image1));
 
-    gm.addResourceToGroup(group0, image0, ResourceIdType::Image);
+    gm.addResourceToGroup(group0, image0);
     ASSERT_EQ(gm.getAliasCount(tensor0), 2U);
     ASSERT_TRUE(gm.isAliased(tensor0));
     ASSERT_EQ(gm.getAliasCount(image0), 2U);
     ASSERT_TRUE(gm.isAliased(image0));
-    ASSERT_TRUE(gm.hasAliasOfType(tensor0, ResourceIdType::Image));
-    ASSERT_TRUE(gm.hasAliasOfType(image0, ResourceIdType::Tensor));
-
     ASSERT_THROW(static_cast<void>(gm.getMemoryManager(tensor0)), std::runtime_error);
     gm.finalize();
     auto mmTensor = gm.getMemoryManager(tensor0);
@@ -41,24 +36,24 @@ TEST(GroupManager, GroupHandling) {
 }
 
 TEST(GroupManager, DuplicateResourceRegistrationToDifferentGroupThrows) {
-    const Guid group0("group0");
-    const Guid group1("group1");
-    const Guid tensor0("tensor0");
+    const TensorId tensor0{0};
     GroupManager gm;
+    const auto group0 = gm.createMemoryGroup();
+    const auto group1 = gm.createMemoryGroup();
 
-    gm.addResourceToGroup(group0, tensor0, ResourceIdType::Tensor);
+    gm.addResourceToGroup(group0, tensor0);
 
-    ASSERT_THROW(gm.addResourceToGroup(group1, tensor0, ResourceIdType::Tensor), std::runtime_error);
+    ASSERT_THROW(gm.addResourceToGroup(group1, tensor0), std::runtime_error);
 }
 
 TEST(GroupManager, GroupQueries) {
-    const Guid group0("group0");
-    const Guid tensor0("tensor0");
-    const Guid image0("image0");
+    const TensorId tensor0{0};
+    const ImageId image0{0};
     GroupManager gm;
+    const auto group0 = gm.createMemoryGroup();
 
-    gm.addResourceToGroup(group0, tensor0, ResourceIdType::Tensor);
-    gm.addResourceToGroup(group0, image0, ResourceIdType::Image);
+    gm.addResourceToGroup(group0, tensor0);
+    gm.addResourceToGroup(group0, image0);
 
     const auto group = gm.getGroupForResource(tensor0);
     ASSERT_TRUE(group.has_value());
@@ -73,12 +68,13 @@ TEST(GroupManager, GroupQueries) {
 }
 
 TEST(GroupManager, FinalizationPreventsFurtherRegistration) {
-    const Guid group("group");
     GroupManager gm;
-    gm.addResourceToGroup(group, Guid("buffer0"), ResourceIdType::Buffer);
+    const auto group = gm.createMemoryGroup();
+    gm.addResourceToGroup(group, BufferId{0});
 
     gm.finalize();
 
-    ASSERT_THROW(gm.addResourceToGroup(group, Guid("buffer1"), ResourceIdType::Buffer), std::runtime_error);
+    ASSERT_THROW(static_cast<void>(gm.createMemoryGroup()), std::runtime_error);
+    ASSERT_THROW(gm.addResourceToGroup(group, BufferId{1}), std::runtime_error);
     ASSERT_THROW(gm.finalize(), std::runtime_error);
 }


### PR DESCRIPTION
Add MemoryGroupId and use typed resource IDs throughout GroupManager. Register JSON groups as resources are created and map VGF alias IDs to runtime memory groups in Scenario.

Keep JSON UID translation local to Scenario.

Change-Id: I305d9b656e32701c992169a8c9a0906133b0ee43