### PR TITLE
fix: convert VGF image shapes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,8 @@
   now use the required zero per-stage feedback entries.
 - Fixed tensor staging transfers to respect tensor memory-group and image
   subresource offsets.
+- Fixed VGF image shape handling for custom shaders, preventing swapped image
+  extents and invalid depth values.
 
 ## Version 0.10.0 – *Optical Flow, VGF Runtime & APK Packaging*
 

--- a/src/tests/vgf_view_tests.cpp
+++ b/src/tests/vgf_view_tests.cpp
@@ -153,10 +153,10 @@ std::filesystem::path writeVgfWithInputAndIntermediateBuffer(TempFolder &tempFol
 }
 
 std::filesystem::path writeVgfWithSampledIntermediateImage(TempFolder &tempFolder, uint32_t addressModeU,
-                                                           uint32_t addressModeV) {
+                                                           uint32_t addressModeV,
+                                                           const std::vector<int64_t> &shape = {1, 16, 8, 4}) {
     auto encoder = vgflib::CreateEncoder(123);
 
-    const std::vector<int64_t> shape{16, 16, 1, 1};
     const auto module = encoder->AddModule(vgflib::ModuleType::COMPUTE, "sampled_image", "main");
     const auto image =
         encoder->AddIntermediateResource(vgflib::ToDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER),
@@ -226,6 +226,7 @@ TEST(VgfView, IntermediateSampledImageUsesVgfSamplerConfig) {
     const auto result = view.createIntermediateResources(creator);
 
     ASSERT_EQ(creator.images.size(), 1);
+    EXPECT_EQ(creator.images.front().shape, (std::vector<int64_t>{1, 8, 16, 1}));
     const auto &samplerSettings = creator.images.front().samplerSettings;
     EXPECT_EQ(samplerSettings.minFilter, FilterMode::Linear);
     EXPECT_EQ(samplerSettings.magFilter, FilterMode::Nearest);
@@ -255,6 +256,30 @@ TEST(VgfView, IntermediateSampledImageAcceptsDistinctVgfAddressModes) {
     EXPECT_EQ(samplerSettings.addressModeV, AddressMode::ClampEdge);
     EXPECT_EQ(samplerSettings.addressModeW, AddressMode::ClampEdge);
     EXPECT_TRUE(result.memoryGroups.empty());
+}
+
+TEST(VgfView, IntermediateSampledImageRejectsInvalidVgfShapes) {
+    TempFolder tempFolder("vgf_view");
+    const std::vector<std::pair<std::vector<int64_t>, std::string>> invalidShapes{
+        {{16, 8}, "VGF image resources must have shape [H, W, C] or [1, H, W, C]"},
+        {{2, 16, 8, 4}, "VGF image resources must have a batch size of 1"},
+        {{1, 16, 8, 3}, "VGF image channel count 3 does not match format component count 4"},
+    };
+
+    for (const auto &[shape, expectedMessage] : invalidShapes) {
+        const auto vgfPath = writeVgfWithSampledIntermediateImage(tempFolder, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+                                                                  VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, shape);
+
+        auto view = VgfView::createVgfView(vgfPath.string());
+        CapturingResourceCreator creator;
+
+        try {
+            view.createIntermediateResources(creator);
+            FAIL() << "Expected invalid VGF image shape to be rejected";
+        } catch (const std::runtime_error &error) {
+            EXPECT_EQ(error.what(), expectedMessage);
+        }
+    }
 }
 
 TEST(VgfView, ResolveBindingsReportsTensorShapeMismatchWithJsonLine) {

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -80,6 +80,29 @@ std::string formatShape(const std::vector<int64_t> &shape) {
     return s;
 }
 
+std::vector<int64_t> getScenarioImageShape(const vgflib::DataView<int64_t> &vgfShape, vk::Format format) {
+    if (vgfShape.size() != 3 && vgfShape.size() != 4) {
+        throw std::runtime_error("VGF image resources must have shape [H, W, C] or [1, H, W, C]");
+    }
+
+    const auto heightIndex = static_cast<uint32_t>(vgfShape.size() - 3);
+    if (vgfShape.size() == 4 && vgfShape[0] != 1) {
+        throw std::runtime_error("VGF image resources must have a batch size of 1");
+    }
+
+    const auto channels = vgfShape[heightIndex + 2];
+    const auto formatChannels = static_cast<int64_t>(numComponentsFromVkFormat(format));
+    if (channels != formatChannels) {
+        throw std::runtime_error("VGF image channel count " + std::to_string(channels) +
+                                 " does not match format component count " + std::to_string(formatChannels));
+    }
+
+    // VGF stores the logical HWC or NHWC shape for all views of a value,
+    // including aliased tensor and image resources. Convert it to ImageInfo's
+    // [N, W, H, depth] layout; the image channel count is encoded in the format.
+    return {1, vgfShape[heightIndex + 1], vgfShape[heightIndex], 1};
+}
+
 struct ModelInterfaceLookup {
     uint32_t mrtIndex;
     bool isOutput;
@@ -495,7 +518,7 @@ void VgfView::validateResource(const IResourceViewer &resourceViewer, uint32_t v
         const auto &actualImageShape = image.shape();
 
         auto dims = resourceTableDecoder->getTensorShape(vgfMrtIndex);
-        const std::vector<int64_t> expectedImageShape(dims.begin(), dims.end());
+        const auto expectedImageShape = getScenarioImageShape(dims, vk::Format(format));
         if (actualImageShape != expectedImageShape) {
             throw std::runtime_error(getVgfContext() + " has shape " + formatShape(expectedImageShape) +
                                      " but scenario image '" + image.debugName() + "' has shape " +
@@ -557,7 +580,7 @@ VgfResourceCreationResult VgfView::createIntermediateResources(IResourceCreator 
 
                 ImageInfo info{};
                 info.debugName = std::move(debugName);
-                info.shape = std::vector<int64_t>(shape.begin(), shape.end());
+                info.shape = getScenarioImageShape(shape, vk::Format(format));
                 info.format = vk::Format(format);
                 info.targetFormat = info.format;
                 info.isInput = false;


### PR DESCRIPTION
Convert VGF HWC and NHWC image metadata to Scenario Runner's image representation. This prevents swapped extents and invalid depth values for non-square custom shader images.

Validate VGF image batch and channel dimensions and cover the conversion with a non-square regression test.

Change-Id: I5b2eb6434773caf302913624f69e9128275ab0cb