### PR TITLE
refactor: enable repeated scenario runs with in memory data

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -53,17 +53,6 @@ uint32_t Buffer::size() const { return _size; }
 
 const std::string &Buffer::debugName() const { return _debugName; }
 
-void Buffer::fillFromDescription(const Context &ctx, const BufferDesc &buffer) const {
-    if (buffer.src.has_value()) {
-        MemoryMap mapped(buffer.src.value());
-        auto dataPtr = vgfutils::numpy::parse(mapped);
-        BufferDataView view{dataPtr.ptr, dataPtr.size()};
-        upload(ctx, view);
-    } else {
-        fillZero(ctx);
-    }
-}
-
 void Buffer::fill(const Context &ctx, const void *ptr, size_t size) const {
     if (size != this->size()) {
         throw std::runtime_error("Buffer::fill: size mismatch");

--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -7,7 +7,6 @@
 
 #include "context.hpp"
 #include "resource_data.hpp"
-#include "resource_desc.hpp"
 #include "types.hpp"
 #include "vulkan_memory_manager.hpp"
 
@@ -40,8 +39,6 @@ class Buffer {
     /// \brief Get buffer debug name
     /// \return Debug name associated with the buffer
     const std::string &debugName() const;
-
-    void fillFromDescription(const Context &ctx, const BufferDesc &buffer) const;
 
     /// \brief Fills the buffer with the given data
     ///

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -301,7 +301,8 @@ int runScenarioRunner(int argc, const char **argv) {
         if (parser.is_used("--repeat")) {
             repeatCount = parser.get<int>("--repeat");
             if (repeatCount <= 0) {
-                throw std::runtime_error("Expected positive number for repeat");
+                throw std::runtime_error("Repeat count must be greater than zero; received " +
+                                         std::to_string(repeatCount) + ".");
             }
         }
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -107,6 +107,38 @@ struct DispatchOpticalFlowData {
 };
 
 namespace {
+BufferData loadBufferData(const BufferDesc &desc) {
+    BufferData bufferData;
+    if (!desc.src.has_value()) {
+        bufferData.data.resize(desc.size, 0);
+        return bufferData;
+    }
+
+    MemoryMap mapped(desc.src.value());
+    const auto parsedData = vgfutils::numpy::parse(mapped);
+    bufferData.data.resize(parsedData.size());
+    std::memcpy(bufferData.data.data(), parsedData.ptr, parsedData.size());
+    return bufferData;
+}
+
+TensorData loadTensorData(const TensorDesc &desc, uint64_t expectedSize) {
+    TensorData tensorData;
+    tensorData.shape = desc.dims;
+
+    if (!desc.src.has_value()) {
+        tensorData.data.resize(expectedSize, 0);
+        return tensorData;
+    }
+
+    MemoryMap mapped(desc.src.value());
+    const auto parsedData = vgfutils::numpy::parse(mapped);
+
+    tensorData.data.resize(parsedData.size());
+    std::memcpy(tensorData.data.data(), parsedData.ptr, parsedData.size());
+    tensorData.shape = parsedData.shape;
+    return tensorData;
+}
+
 std::vector<GraphConstantInfo> collectGraphConstants(const std::vector<GraphConstantResourceId> &constantIds,
                                                      const ResourceManager &resources) {
     std::vector<GraphConstantInfo> constants;
@@ -541,6 +573,34 @@ void registerMemoryGroup(GroupManager &groupManager, std::unordered_map<Guid, Me
     }
 }
 
+template <typename Id>
+const Guid &resolveRuntimeResource(const std::unordered_map<Id, Guid> &resourceGuids, Id id,
+                                   std::string_view resourceType, std::string_view operation) {
+    const auto resource = resourceGuids.find(id);
+    if (resource == resourceGuids.end()) {
+        throw std::runtime_error("Scenario::" + std::string(operation) + ": " + std::string(resourceType) +
+                                 " resource not found.");
+    }
+    return resource->second;
+}
+
+template <typename Id>
+Id resolveResourceUid(const std::unordered_map<Guid, TypedResourceId> &resourceIds, std::string_view uid,
+                      std::string_view resourceType, std::string_view operation) {
+    const auto resource = resourceIds.find(Guid(std::string(uid)));
+    if (resource == resourceIds.end()) {
+        throw std::runtime_error("Scenario::" + std::string(operation) + ": resource UID '" + std::string(uid) +
+                                 "' not found.");
+    }
+
+    const auto *id = std::get_if<Id>(&resource->second);
+    if (id == nullptr) {
+        throw std::runtime_error("Scenario::" + std::string(operation) + ": resource UID '" + std::string(uid) +
+                                 "' does not identify a " + std::string(resourceType) + " resource.");
+    }
+    return *id;
+}
+
 struct CommandDataFactory {
     const DataManager &_dataManager;
     const std::unordered_map<Guid, TypedResourceId> &_resourceIds;
@@ -758,6 +818,36 @@ Scenario::Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec)
     setupCommands();
 }
 
+Scenario::~Scenario() = default;
+
+BufferId Scenario::getBufferId(std::string_view uid) const {
+    return resolveResourceUid<BufferId>(_resourceIds, uid, "Buffer", "getBufferId");
+}
+
+TensorId Scenario::getTensorId(std::string_view uid) const {
+    return resolveResourceUid<TensorId>(_resourceIds, uid, "Tensor", "getTensorId");
+}
+
+void Scenario::upload(BufferId id, const BufferDataView &data) {
+    const auto &guid = resolveRuntimeResource(_bufferResourceGuids, id, "Buffer", "upload");
+    _dataManager.getBuffer(guid).upload(_ctx, data);
+}
+
+void Scenario::upload(TensorId id, const TensorDataView &data) {
+    const auto &guid = resolveRuntimeResource(_tensorResourceGuids, id, "Tensor", "upload");
+    _dataManager.getTensor(guid).upload(_ctx, data);
+}
+
+BufferData Scenario::download(BufferId id) const {
+    const auto &guid = resolveRuntimeResource(_bufferResourceGuids, id, "Buffer", "download");
+    return _dataManager.getBuffer(guid).download(_ctx);
+}
+
+TensorData Scenario::download(TensorId id) const {
+    const auto &guid = resolveRuntimeResource(_tensorResourceGuids, id, "Tensor", "download");
+    return _dataManager.getTensor(guid).download(_ctx);
+}
+
 const ShaderInfo &Scenario::getShader(ShaderId id) const { return _resources.get(id); }
 
 MemoryResourceId Scenario::getMemoryResourceId(const Guid &guid) const {
@@ -785,48 +875,56 @@ const ShaderInfo &Scenario::getSubstitutionShader(const std::vector<ResolvedShad
 }
 
 void Scenario::run(int repeatCount, bool dryRun) {
-    std::unique_ptr<FrameCapturer> frameCapturer;
-
-    if (_opts.captureFrame) {
-        frameCapturer = std::make_unique<FrameCapturer>();
+    if (repeatCount <= 0) {
+        throw std::invalid_argument("Scenario repeat count must be greater than zero; received " +
+                                    std::to_string(repeatCount) + ".");
     }
 
-    for (int i = 0; i < repeatCount; ++i) {
-        mlsdk::logging::debug("Iteration: " + std::to_string(i));
-        if (i > 0) {
-            _compute.reset();
-        }
-        if (frameCapturer) {
-            frameCapturer->begin();
-        }
-
-        if (!dryRun) {
-            if (hasAliasedOptimalTensors()) {
-                _compute.prepareCommandBuffer();
-                handleAliasedLayoutTransitions();
-            }
-            _compute.submitAndWaitOnFence(_perfCounters, i);
-        }
-        saveProfilingData(i, repeatCount, dryRun);
-
-        // Skip reset after final run
-        if (i + 1 < repeatCount) {
-            for (const auto &resource : _scenarioSpec.resources) {
-                if (resource->resourceType == ResourceType::Image) {
-                    const auto &imageDesc = static_cast<const ImageDesc &>(*resource);
-                    if (imageDesc.tiling.has_value() && imageDesc.tiling.value() == Tiling::Optimal) {
-                        auto &image = _dataManager.getImageMut(imageDesc.guid);
-                        image.resetLayout();
-                    }
-                }
-            }
-        }
-
-        if (frameCapturer) {
-            frameCapturer->end();
-        }
+    for (int iteration = 0; iteration < repeatCount; ++iteration) {
+        mlsdk::logging::debug("Iteration: " + std::to_string(iteration));
+        runIteration(iteration, repeatCount, dryRun);
     }
     saveResults(dryRun);
+}
+
+void Scenario::runIteration(int iteration, int repeatCount, bool dryRun) {
+    if (_opts.captureFrame && !_frameCapturer) {
+        _frameCapturer = std::make_unique<FrameCapturer>();
+    }
+
+    if (_hasRun) {
+        resetForNextRun();
+    }
+    if (_frameCapturer) {
+        _frameCapturer->begin();
+    }
+
+    if (!dryRun) {
+        if (hasAliasedOptimalTensors()) {
+            _compute.prepareCommandBuffer();
+            handleAliasedLayoutTransitions();
+        }
+        _compute.submitAndWaitOnFence(_perfCounters, iteration);
+    }
+    saveProfilingData(iteration, repeatCount, dryRun);
+
+    _hasRun = true;
+
+    if (_frameCapturer) {
+        _frameCapturer->end();
+    }
+}
+
+void Scenario::resetForNextRun() {
+    _compute.reset();
+    for (const auto &resource : _scenarioSpec.resources) {
+        if (resource->resourceType == ResourceType::Image) {
+            const auto &imageDesc = static_cast<const ImageDesc &>(*resource);
+            if (imageDesc.tiling.has_value() && imageDesc.tiling.value() == Tiling::Optimal) {
+                _dataManager.getImageMut(imageDesc.guid).resetLayout();
+            }
+        }
+    }
 }
 
 void Scenario::setupResources() {
@@ -842,6 +940,7 @@ void Scenario::setupResources() {
             const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
             const auto id = _resources.addBuffer(resourceInfoFactory.createInfo(*buffer));
             _resourceIds.emplace(resource->guid, id);
+            _bufferResourceGuids.emplace(id, resource->guid);
             _dataManager.createBuffer(resource->guid, _resources.get(id));
             registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, buffer->memoryGroup);
         } break;
@@ -869,6 +968,7 @@ void Scenario::setupResources() {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
             const auto id = _resources.addTensor(resourceInfoFactory.createInfo(*tensor, _opts.captureFrame));
             _resourceIds.emplace(resource->guid, id);
+            _tensorResourceGuids.emplace(id, resource->guid);
             _dataManager.createTensor(resource->guid, _resources.get(id));
             registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, tensor->memoryGroup);
         } break;
@@ -985,23 +1085,44 @@ void Scenario::setupResources() {
         mlsdk::logging::debug(resourceType(resource) + ": " + resource->guidStr + " loaded");
     }
 
-    // Allocate and fill resource memory
-    for (auto &resource : _scenarioSpec.resources) {
+    // Allocate resource memory before loading runtime input data.
+    for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
         case ResourceType::Tensor: {
-            const auto &tensor = reinterpret_cast<std::unique_ptr<TensorDesc> &>(resource);
-            auto &tensorRec = _dataManager.getTensorMut(tensor->guid);
-            tensorRec.allocateMemory(_ctx);
+            const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
+            _dataManager.getTensorMut(tensor->guid).allocateMemory(_ctx);
+        } break;
+        case ResourceType::Image: {
+            const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
+            _dataManager.getImageMut(image->guid).allocateMemory(_ctx);
+        } break;
+        case ResourceType::Buffer: {
+            const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
+            _dataManager.getBufferMut(buffer->guid).allocateMemory(_ctx);
+        } break;
+        default:
+            // Skip the other types of resources
+            continue;
+        }
+    }
+
+    // Preserve description-based CLI initialization by routing it through the
+    // same typed Scenario upload API used by in-memory clients.
+    for (const auto &resource : _scenarioSpec.resources) {
+        switch (resource->resourceType) {
+        case ResourceType::Tensor: {
+            const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
             PerfCounterGuard guard(_perfCounters, "Load Tensor: " + tensor->guidStr, "Scenario Setup");
             const auto id = resolveResourceId<TensorId>(_resourceIds, tensor->guid, "Tensor");
             if (tensor->src || !_groupManager.isAliased(id)) {
-                tensorRec.fillFromDescription(_ctx, *tensor);
+                const auto &tensorResource = _dataManager.getTensor(tensor->guid);
+                const auto tensorData = loadTensorData(*tensor, tensorResource.dataSize());
+                upload(id, {tensorData.data.data(), tensorData.data.size(), tensorData.shape, tensorData.format});
             }
         } break;
         case ResourceType::Image: {
-            const auto &image = reinterpret_cast<std::unique_ptr<ImageDesc> &>(resource);
+            const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
             auto &imageRec = _dataManager.getImageMut(image->guid);
-            imageRec.allocateMemory(_ctx);
             PerfCounterGuard guard(_perfCounters, "Load Image: " + image->guidStr, "Scenario Setup");
             const auto id = resolveResourceId<ImageId>(_resourceIds, image->guid, "Image");
             if (image->src || !_groupManager.isAliased(id)) {
@@ -1011,13 +1132,12 @@ void Scenario::setupResources() {
             }
         } break;
         case ResourceType::Buffer: {
-            const auto &buffer = reinterpret_cast<std::unique_ptr<BufferDesc> &>(resource);
-            auto &bufferRec = _dataManager.getBufferMut(buffer->guid);
-            bufferRec.allocateMemory(_ctx);
+            const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
             PerfCounterGuard guard(_perfCounters, "Load Buffer: " + buffer->guidStr, "Scenario Setup");
             const auto id = resolveResourceId<BufferId>(_resourceIds, buffer->guid, "Buffer");
             if (buffer->src || !_groupManager.isAliased(id)) {
-                bufferRec.fillFromDescription(_ctx, *buffer);
+                const auto bufferData = loadBufferData(*buffer);
+                upload(id, {bufferData.data.data(), bufferData.data.size()});
             }
         } break;
         default:

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -8,12 +8,15 @@
 #include "compute.hpp"
 #include "context.hpp"
 #include "data_manager.hpp"
+#include "frame_capturer.hpp"
 #include "group_manager.hpp"
+#include "resource_data.hpp"
 #include "resource_manager.hpp"
 #include "scenario_desc.hpp"
 #include "types.hpp"
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -53,10 +56,35 @@ class Scenario {
     /// \brief Constructor
     Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec);
 
-    /// \brief Executes the test case
+    /// \brief Destructor
+    ~Scenario();
+
+    /// \brief Executes the test case one or more times
+    /// \param repeatCount Number of executions; must be greater than zero
+    /// \param dryRun Skip workload execution and output-resource saving
     void run(int repeatCount = 1, bool dryRun = false);
 
+    /// \brief Get a buffer resource ID from its UID
+    BufferId getBufferId(std::string_view uid) const;
+
+    /// \brief Get a tensor resource ID from its UID
+    TensorId getTensorId(std::string_view uid) const;
+
+    /// \brief Upload data to an existing buffer resource
+    void upload(BufferId id, const BufferDataView &data);
+
+    /// \brief Upload data to an existing tensor resource
+    void upload(TensorId id, const TensorDataView &data);
+
+    /// \brief Download data from an existing buffer resource
+    BufferData download(BufferId id) const;
+
+    /// \brief Download data from an existing tensor resource
+    TensorData download(TensorId id) const;
+
   private:
+    void runIteration(int iteration, int repeatCount, bool dryRun);
+
     void createComputePipeline(const DispatchComputeData &dispatchCompute, uint32_t &nQueries);
     void createDataGraphPipeline(const DispatchDataGraphData &dispatchDataGraph, uint32_t &nQueries);
     void createSpirvGraphPipeline(const DispatchSpirvGraphData &dispatchSpirvGraph, uint32_t &nQueries);
@@ -76,6 +104,9 @@ class Scenario {
     /// \brief Save results of output resources to files
     void saveResults(bool dryRun);
 
+    /// \brief Reset transient execution state before another run
+    void resetForNextRun();
+
     bool hasAliasedOptimalTensors() const;
     void handleAliasedLayoutTransitions();
     MemoryResourceId getMemoryResourceId(const Guid &guid) const;
@@ -87,12 +118,16 @@ class Scenario {
     Context _ctx;
     ResourceManager _resources;
     std::unordered_map<Guid, TypedResourceId> _resourceIds;
+    std::unordered_map<BufferId, Guid> _bufferResourceGuids;
+    std::unordered_map<TensorId, Guid> _tensorResourceGuids;
     DataManager _dataManager;
     ScenarioSpec &_scenarioSpec;
     std::shared_ptr<PipelineCache> _pipelineCache;
     Compute _compute;
     std::vector<PerformanceCounter> _perfCounters;
     GroupManager _groupManager;
+    std::unique_ptr<FrameCapturer> _frameCapturer;
+    bool _hasRun{false};
 };
 
 } // namespace mlsdk::scenariorunner

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -147,27 +147,6 @@ void Tensor::allocateMemory(const Context &ctx) {
     trySetVkRaiiObjectDebugName(ctx, _tensorView, _debugName + " view (default)");
 }
 
-void Tensor::fillFromDescription(const Context &ctx, const TensorDesc &desc) const {
-    if (desc.src) {
-        MemoryMap mapped(desc.src.value());
-        auto dataPtr = vgfutils::numpy::parse(mapped);
-
-        for (size_t i = 0; i < desc.dims.size(); ++i) {
-            if (desc.dims[i] != dataPtr.shape[i]) {
-                throw std::runtime_error("Tensor descripton dimension at index " + std::to_string(i) +
-                                         " does not match data shape: " + std::to_string(desc.dims[i]) + " vs " +
-                                         std::to_string(dataPtr.shape[i]));
-            }
-        }
-        TensorDataView view{dataPtr.ptr, dataPtr.size(), {}, std::nullopt};
-        view.shape = std::move(dataPtr.shape);
-        upload(ctx, view);
-    } else {
-        fillZero();
-        _memoryManager->uploadData(ctx, _memoryManager->getSubresourceOffset() + _memoryOffset, _size);
-    }
-}
-
 void Tensor::fill(const void *data, size_t size) const {
     if (size < _size) {
         mlsdk::logging::warning("Tensor data size " + std::to_string(size) +

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -7,7 +7,6 @@
 
 #include "context.hpp"
 #include "resource_data.hpp"
-#include "resource_desc.hpp"
 #include "types.hpp"
 #include "vulkan_memory_manager.hpp"
 
@@ -64,7 +63,6 @@ class Tensor {
 
     void allocateMemory(const Context &ctx);
 
-    void fillFromDescription(const Context &ctx, const TensorDesc &desc) const;
     void fill(const void *data, size_t size) const;
     void fillZero() const;
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(ScenarioRunnerTests
   perf_counter_tests.cpp
   png_reader_tests.cpp
   resource_manager_tests.cpp
+  scenario_tests.cpp
   tensor_tests.cpp
   vgf_view_tests.cpp
   vulkan_startup_tests.cpp

--- a/src/tests/scenario_tests.cpp
+++ b/src/tests/scenario_tests.cpp
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "resource_data.hpp"
+#include "scenario.hpp"
+#include "scenario_desc.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace mlsdk::scenariorunner;
+
+namespace {
+const std::string scenarioJson = R"(
+        {
+            "commands": [],
+            "resources": [
+                {
+                    "buffer": {
+                        "uid": "inBuffer",
+                        "size": 4,
+                        "shader_access": "readwrite"
+                    }
+                },
+                {
+                    "tensor": {
+                        "uid": "inTensor",
+                        "dims": [1, 2, 2, 1],
+                        "format": "VK_FORMAT_R8_SINT",
+                        "shader_access": "readwrite"
+                    }
+                }
+            ]
+        }
+    )";
+} // namespace
+
+TEST(ScenarioInMemoryTransfer, UploadsAndDownloadsByTypedIdAcrossRuns) {
+    ScenarioSpec spec{scenarioJson};
+    spec.useComputeFamilyQueue = true;
+    Scenario scenario{ScenarioOptions{}, spec};
+
+    const auto bufferId = scenario.getBufferId("inBuffer");
+    const auto tensorId = scenario.getTensorId("inTensor");
+
+    std::vector<char> firstBuffer{1, 2, 3, 4};
+    std::vector<char> firstTensor{5, 6, 7, 8};
+    scenario.upload(bufferId, {firstBuffer.data(), firstBuffer.size()});
+    scenario.upload(tensorId, {firstTensor.data(), firstTensor.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
+    scenario.run();
+
+    EXPECT_EQ(scenario.download(bufferId).data, firstBuffer);
+    EXPECT_EQ(scenario.download(tensorId).data, firstTensor);
+
+    std::vector<char> secondBuffer{9, 10, 11, 12};
+    std::vector<char> secondTensor{13, 14, 15, 16};
+    scenario.upload(bufferId, {secondBuffer.data(), secondBuffer.size()});
+    scenario.upload(tensorId, {secondTensor.data(), secondTensor.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
+    scenario.run();
+
+    EXPECT_EQ(scenario.download(bufferId).data, secondBuffer);
+    EXPECT_EQ(scenario.download(tensorId).data, secondTensor);
+}
+
+TEST(ScenarioInMemoryTransfer, InitializesResourcesWithoutSourcesThroughTypedUploadPath) {
+    ScenarioSpec spec{scenarioJson};
+    spec.useComputeFamilyQueue = true;
+    Scenario scenario{ScenarioOptions{}, spec};
+
+    const auto buffer = scenario.download(scenario.getBufferId("inBuffer"));
+    const auto tensor = scenario.download(scenario.getTensorId("inTensor"));
+
+    EXPECT_EQ(buffer.data, std::vector<char>(4, 0));
+    EXPECT_EQ(tensor.data, std::vector<char>(4, 0));
+    EXPECT_EQ(tensor.shape, (std::vector<int64_t>{1, 2, 2, 1}));
+    ASSERT_TRUE(tensor.format.has_value());
+    EXPECT_EQ(tensor.format.value(), vk::Format::eR8Sint);
+}
+
+TEST(ScenarioInMemoryTransfer, RejectsNonPositiveRepeatCount) {
+    ScenarioSpec spec{scenarioJson};
+    spec.useComputeFamilyQueue = true;
+    Scenario scenario{ScenarioOptions{}, spec};
+
+    try {
+        scenario.run(0);
+        FAIL() << "Expected std::invalid_argument";
+    } catch (const std::invalid_argument &error) {
+        EXPECT_STREQ(error.what(), "Scenario repeat count must be greater than zero; received 0.");
+    }
+}
+
+TEST(ScenarioInMemoryTransfer, RejectsUnknownTypedIds) {
+    ScenarioSpec spec{scenarioJson};
+    spec.useComputeFamilyQueue = true;
+    Scenario scenario{ScenarioOptions{}, spec};
+
+    const std::vector<char> data(4);
+    const auto expectError = [](const auto &operation, const char *expectedMessage) {
+        try {
+            operation();
+            FAIL() << "Expected std::runtime_error";
+        } catch (const std::runtime_error &error) {
+            EXPECT_STREQ(error.what(), expectedMessage);
+        }
+    };
+
+    expectError([&] { scenario.upload(BufferId{1}, {data.data(), data.size()}); },
+                "Scenario::upload: Buffer resource not found.");
+    expectError([&] { scenario.upload(TensorId{1}, {data.data(), data.size(), {1, 2, 2, 1}, vk::Format::eR8Sint}); },
+                "Scenario::upload: Tensor resource not found.");
+    expectError([&] { static_cast<void>(scenario.download(BufferId{1})); },
+                "Scenario::download: Buffer resource not found.");
+    expectError([&] { static_cast<void>(scenario.download(TensorId{1})); },
+                "Scenario::download: Tensor resource not found.");
+
+    expectError([&] { static_cast<void>(scenario.getBufferId("missing")); },
+                "Scenario::getBufferId: resource UID 'missing' not found.");
+    expectError([&] { static_cast<void>(scenario.getTensorId("missing")); },
+                "Scenario::getTensorId: resource UID 'missing' not found.");
+    expectError([&] { static_cast<void>(scenario.getBufferId("inTensor")); },
+                "Scenario::getBufferId: resource UID 'inTensor' does not identify a Buffer resource.");
+    expectError([&] { static_cast<void>(scenario.getTensorId("inBuffer")); },
+                "Scenario::getTensorId: resource UID 'inBuffer' does not identify a Tensor resource.");
+}


### PR DESCRIPTION
Resolve buffer and tensor IDs to existing runtime resources, enabling repeated in-memory upload, execution, and download without rebuilding resources or pipelines.

Change-Id: Iaa8262d71c15b20dbff5d5d12c8946657c214f20