### PR TITLE
refactor: use typed IDs for runtime resources

### DIFF
--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -261,7 +261,7 @@ void Compute::_registerPipelineFencedCommon(const DataManager &dataManager, cons
         _addDescriptorSets(baseDescriptorSetIdxGlobal, binding.set, poolSizes, pipeline);
 
         const auto &descSet = *_descriptorSets[baseDescriptorSetIdxGlobal + binding.set];
-        const DataManagerResourceViewer resourceViewer(dataManager, binding.resourceRef);
+        const DataManagerResourceViewer resourceViewer(dataManager, binding.resource);
         _updateDescriptorSets(descSet, binding, resourceViewer);
     }
 

--- a/src/compute.hpp
+++ b/src/compute.hpp
@@ -28,9 +28,9 @@ struct DispatchBarrierData {
 
 /// \brief Typed resources
 struct MarkBoundaryData {
-    std::vector<Guid> buffers;
-    std::vector<Guid> images;
-    std::vector<Guid> tensors;
+    std::vector<BufferId> buffers;
+    std::vector<ImageId> images;
+    std::vector<TensorId> tensors;
 };
 
 /// \brief Image attachment used by a graphics dispatch

--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -9,18 +9,28 @@
 #include <utility>
 
 namespace mlsdk::scenariorunner {
+namespace {
+template <typename Resources, typename Id>
+decltype(auto) getResource(Resources &resources, Id id, const char *errorMessage) {
+    const auto resource = resources.find(id);
+    if (resource == resources.end()) {
+        throw std::runtime_error(errorMessage);
+    }
+    return (resource->second);
+}
+} // namespace
 
-void DataManager::createBuffer(Guid guid, const BufferInfo &info) { _buffers.emplace(guid, Buffer(info)); }
+void DataManager::createBuffer(BufferId id, const BufferInfo &info) { _buffers.emplace(id, Buffer(info)); }
 
-void DataManager::createBuffer(Guid guid, BufferInfo &&info) { _buffers.emplace(guid, Buffer(std::move(info))); }
+void DataManager::createBuffer(BufferId id, BufferInfo &&info) { _buffers.emplace(id, Buffer(std::move(info))); }
 
-void DataManager::createTensor(Guid guid, const TensorInfo &info) { _tensors.emplace(guid, Tensor(info)); }
+void DataManager::createTensor(TensorId id, const TensorInfo &info) { _tensors.emplace(id, Tensor(info)); }
 
-void DataManager::createTensor(Guid guid, TensorInfo &&info) { _tensors.emplace(guid, Tensor(std::move(info))); }
+void DataManager::createTensor(TensorId id, TensorInfo &&info) { _tensors.emplace(id, Tensor(std::move(info))); }
 
-void DataManager::createImage(Guid guid, const ImageInfo &info) { _images.emplace(guid, Image(info)); }
+void DataManager::createImage(ImageId id, const ImageInfo &info) { _images.emplace(id, Image(info)); }
 
-void DataManager::createImage(Guid guid, ImageInfo &&info) { _images.emplace(guid, Image(std::move(info))); }
+void DataManager::createImage(ImageId id, ImageInfo &&info) { _images.emplace(id, Image(std::move(info))); }
 
 void DataManager::createVgfView(DataGraphId id, const DataGraphInfo &info) {
     _vgfViews.insert({id, VgfView::createVgfView(info.src)});
@@ -46,11 +56,11 @@ void DataManager::createRawData(RawDataId id, const RawDataInfo &info) {
     _rawData.insert({id, RawData(info.debugName, info.src)});
 }
 
-bool DataManager::hasBuffer(Guid guid) const { return _buffers.find(guid) != _buffers.end(); }
+bool DataManager::hasBuffer(BufferId id) const { return _buffers.find(id) != _buffers.end(); }
 
-bool DataManager::hasTensor(Guid guid) const { return _tensors.find(guid) != _tensors.end(); }
+bool DataManager::hasTensor(TensorId id) const { return _tensors.find(id) != _tensors.end(); }
 
-bool DataManager::hasImage(Guid guid) const { return _images.find(guid) != _images.end(); }
+bool DataManager::hasImage(ImageId id) const { return _images.find(id) != _images.end(); }
 
 bool DataManager::hasRawData(RawDataId id) const { return _rawData.find(id) != _rawData.end(); }
 
@@ -68,47 +78,17 @@ uint32_t DataManager::numTensors() const { return static_cast<uint32_t>(_tensors
 
 uint32_t DataManager::numImages() const { return static_cast<uint32_t>(_images.size()); }
 
-Buffer &DataManager::getBufferMut(const Guid &guid) {
-    if (_buffers.find(guid) == _buffers.end()) {
-        throw std::runtime_error("Buffer not found");
-    }
-    return _buffers[guid];
-}
+Buffer &DataManager::getBufferMut(BufferId id) { return getResource(_buffers, id, "Buffer not found"); }
 
-Tensor &DataManager::getTensorMut(const Guid &guid) {
-    if (_tensors.find(guid) == _tensors.end()) {
-        throw std::runtime_error("Tensor not found");
-    }
-    return _tensors[guid];
-}
+Tensor &DataManager::getTensorMut(TensorId id) { return getResource(_tensors, id, "Tensor not found"); }
 
-Image &DataManager::getImageMut(const Guid &guid) {
-    if (_images.find(guid) == _images.end()) {
-        throw std::runtime_error("Image not found");
-    }
-    return _images[guid];
-}
+Image &DataManager::getImageMut(ImageId id) { return getResource(_images, id, "Image not found"); }
 
-const Buffer &DataManager::getBuffer(const Guid &guid) const {
-    if (_buffers.find(guid) == _buffers.end()) {
-        throw std::runtime_error("Buffer not found");
-    }
-    return _buffers.at(guid);
-}
+const Buffer &DataManager::getBuffer(BufferId id) const { return getResource(_buffers, id, "Buffer not found"); }
 
-const Tensor &DataManager::getTensor(const Guid &guid) const {
-    if (_tensors.find(guid) == _tensors.end()) {
-        throw std::runtime_error("Tensor not found");
-    }
-    return _tensors.at(guid);
-}
+const Tensor &DataManager::getTensor(TensorId id) const { return getResource(_tensors, id, "Tensor not found"); }
 
-const Image &DataManager::getImage(const Guid &guid) const {
-    if (_images.find(guid) == _images.end()) {
-        throw std::runtime_error("Image not found");
-    }
-    return _images.at(guid);
-}
+const Image &DataManager::getImage(ImageId id) const { return getResource(_images, id, "Image not found"); }
 
 const RawData &DataManager::getRawData(RawDataId id) const {
     if (_rawData.find(id) == _rawData.end()) {

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -18,12 +18,12 @@ namespace mlsdk::scenariorunner {
 
 class DataManager {
   public:
-    void createBuffer(Guid guid, const BufferInfo &info);
-    void createBuffer(Guid guid, BufferInfo &&info);
-    void createTensor(Guid guid, const TensorInfo &info);
-    void createTensor(Guid guid, TensorInfo &&info);
-    void createImage(Guid guid, const ImageInfo &info);
-    void createImage(Guid guid, ImageInfo &&info);
+    void createBuffer(BufferId id, const BufferInfo &info);
+    void createBuffer(BufferId id, BufferInfo &&info);
+    void createTensor(TensorId id, const TensorInfo &info);
+    void createTensor(TensorId id, TensorInfo &&info);
+    void createImage(ImageId id, const ImageInfo &info);
+    void createImage(ImageId id, ImageInfo &&info);
     void createRawData(RawDataId id, const RawDataInfo &info);
     void createVgfView(DataGraphId id, const DataGraphInfo &info);
     void createImageBarrier(Guid guid, const ImageBarrierData &data);
@@ -31,22 +31,22 @@ class DataManager {
     void createMemoryBarrier(Guid guid, const MemoryBarrierData &data);
     void createBufferBarrier(Guid guid, const BufferBarrierData &data);
 
-    bool hasBuffer(Guid guid) const;
-    bool hasTensor(Guid guid) const;
-    bool hasImage(Guid guid) const;
+    bool hasBuffer(BufferId id) const;
+    bool hasTensor(TensorId id) const;
+    bool hasImage(ImageId id) const;
     bool hasRawData(RawDataId id) const;
     bool hasImageBarrier(Guid guid) const;
     bool hasTensorBarrier(Guid guid) const;
     bool hasMemoryBarrier(Guid guid) const;
     bool hasBufferBarrier(Guid guid) const;
 
-    Buffer &getBufferMut(const Guid &guid);
-    Tensor &getTensorMut(const Guid &guid);
-    Image &getImageMut(const Guid &guid);
+    Buffer &getBufferMut(BufferId id);
+    Tensor &getTensorMut(TensorId id);
+    Image &getImageMut(ImageId id);
 
-    const Buffer &getBuffer(const Guid &guid) const;
-    const Tensor &getTensor(const Guid &guid) const;
-    const Image &getImage(const Guid &guid) const;
+    const Buffer &getBuffer(BufferId id) const;
+    const Tensor &getTensor(TensorId id) const;
+    const Image &getImage(ImageId id) const;
     const RawData &getRawData(RawDataId id) const;
     const VgfView &getVgfView(DataGraphId id) const;
     const VulkanImageBarrier &getImageBarrier(const Guid &guid) const;
@@ -59,9 +59,9 @@ class DataManager {
     uint32_t numImages() const;
 
   private:
-    std::unordered_map<Guid, Buffer> _buffers;
-    std::unordered_map<Guid, Tensor> _tensors;
-    std::unordered_map<Guid, Image> _images;
+    std::unordered_map<BufferId, Buffer> _buffers;
+    std::unordered_map<TensorId, Tensor> _tensors;
+    std::unordered_map<ImageId, Image> _images;
     std::unordered_map<RawDataId, RawData> _rawData;
     std::unordered_map<DataGraphId, VgfView> _vgfViews;
     std::unordered_map<Guid, VulkanImageBarrier> _imageBarriers;

--- a/src/iresource.cpp
+++ b/src/iresource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "iresource.hpp"
@@ -8,34 +8,43 @@
 
 namespace mlsdk::scenariorunner {
 
-DataManagerResourceViewer::DataManagerResourceViewer(const DataManager &dataManager, Guid resourceRef)
-    : _dataManager(dataManager), _resourceRef(resourceRef) {}
+DataManagerResourceViewer::DataManagerResourceViewer(const DataManager &dataManager, MemoryResourceId resource)
+    : _dataManager(dataManager), _resource(resource) {}
 
-bool DataManagerResourceViewer::hasBuffer() const { return _dataManager.hasBuffer(_resourceRef); }
+bool DataManagerResourceViewer::hasBuffer() const {
+    const auto *id = std::get_if<BufferId>(&_resource);
+    return id != nullptr && _dataManager.hasBuffer(*id);
+}
 
-bool DataManagerResourceViewer::hasImage() const { return _dataManager.hasImage(_resourceRef); }
+bool DataManagerResourceViewer::hasImage() const {
+    const auto *id = std::get_if<ImageId>(&_resource);
+    return id != nullptr && _dataManager.hasImage(*id);
+}
 
-bool DataManagerResourceViewer::hasTensor() const { return _dataManager.hasTensor(_resourceRef); }
+bool DataManagerResourceViewer::hasTensor() const {
+    const auto *id = std::get_if<TensorId>(&_resource);
+    return id != nullptr && _dataManager.hasTensor(*id);
+}
 
 const Buffer &DataManagerResourceViewer::getBuffer() const {
     if (!hasBuffer()) {
         throw std::runtime_error("Identifier does not reference a buffer");
     }
-    return _dataManager.getBuffer(_resourceRef);
+    return _dataManager.getBuffer(std::get<BufferId>(_resource));
 }
 
 const Image &DataManagerResourceViewer::getImage() const {
     if (!hasImage()) {
         throw std::runtime_error("Identifier does not reference an image");
     }
-    return _dataManager.getImage(_resourceRef);
+    return _dataManager.getImage(std::get<ImageId>(_resource));
 }
 
 const Tensor &DataManagerResourceViewer::getTensor() const {
     if (!hasTensor()) {
         throw std::runtime_error("Identifier does not reference a tensor");
     }
-    return _dataManager.getTensor(_resourceRef);
+    return _dataManager.getTensor(std::get<TensorId>(_resource));
 }
 
 } // namespace mlsdk::scenariorunner

--- a/src/iresource.hpp
+++ b/src/iresource.hpp
@@ -40,7 +40,7 @@ class IResourceViewer {
 /// @brief Base implementation for DataManager
 class DataManagerResourceViewer final : public IResourceViewer {
   public:
-    DataManagerResourceViewer(const DataManager &dataManager, Guid resourceRef);
+    DataManagerResourceViewer(const DataManager &dataManager, MemoryResourceId resource);
 
     bool hasBuffer() const override;
     bool hasImage() const override;
@@ -52,7 +52,7 @@ class DataManagerResourceViewer final : public IResourceViewer {
 
   protected:
     const DataManager &_dataManager;
-    Guid _resourceRef;
+    MemoryResourceId _resource;
 };
 
 } // namespace mlsdk::scenariorunner

--- a/src/optical_flow_utils.cpp
+++ b/src/optical_flow_utils.cpp
@@ -25,11 +25,12 @@ struct OpticalFlowSelectedExtent {
 
 OpticalFlowSelectedExtent getOpticalFlowSelectedExtent(const DataManager &dataManager, const TypedBinding &binding,
                                                        const char *bindingRole) {
-    if (!dataManager.hasImage(binding.resourceRef)) {
+    const auto *imageId = std::get_if<ImageId>(&binding.resource);
+    if (imageId == nullptr || !dataManager.hasImage(*imageId)) {
         throw std::runtime_error("Optical flow " + std::string(bindingRole) + " binding must reference an image");
     }
 
-    const auto &image = dataManager.getImage(binding.resourceRef);
+    const auto &image = dataManager.getImage(*imageId);
     const auto &shape = image.shape();
     if (shape.size() < 3) {
         throw std::runtime_error("Optical flow " + std::string(bindingRole) + " image must have at least 3 dimensions");
@@ -52,8 +53,8 @@ void verifyOpticalFlowConfig(const DataManager &dataManager, const TypedBinding 
                              const std::optional<TypedBinding> &hintMotionVectorsBinding,
                              const std::optional<TypedBinding> &outputCostBinding, uint32_t width, uint32_t height,
                              OpticalFlowGridSize gridSize) {
-    const auto &searchImage = dataManager.getImage(searchImageBinding.resourceRef);
-    const auto &templateImage = dataManager.getImage(templateImageBinding.resourceRef);
+    const auto &searchImage = dataManager.getImage(std::get<ImageId>(searchImageBinding.resource));
+    const auto &templateImage = dataManager.getImage(std::get<ImageId>(templateImageBinding.resource));
 
     const auto searchExtent = getOpticalFlowSelectedExtent(dataManager, searchImageBinding, "search");
     const auto templateExtent = getOpticalFlowSelectedExtent(dataManager, templateImageBinding, "template");

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -102,7 +102,7 @@ std::vector<std::vector<TypedBinding>> splitOutSets(const std::vector<TypedBindi
 
     for (const auto &bindingDesc : allBindings) {
         while (setBindings.size() <= static_cast<size_t>(bindingDesc.set)) {
-            setBindings.emplace_back(0);
+            setBindings.emplace_back();
         }
 
         setBindings[bindingDesc.set].push_back(bindingDesc);
@@ -135,8 +135,8 @@ void makeResourceInfos(const std::vector<TypedBinding> &bindings, const DataMana
     imageLayouts.reserve(imageLayouts.size() + bindings.size());
 
     for (const auto &binding : bindings) {
-        if (dataManager.hasTensor(binding.resourceRef)) {
-            const auto &tensor = dataManager.getTensor(binding.resourceRef);
+        if (const auto *tensorId = std::get_if<TensorId>(&binding.resource)) {
+            const auto &tensor = dataManager.getTensor(*tensorId);
             const auto &shape = tensor.shape();
             const auto &stridesVec = tensor.dimStrides();
             const auto *strides = stridesVec.empty() ? nullptr : stridesVec.data();
@@ -148,8 +148,8 @@ void makeResourceInfos(const std::vector<TypedBinding> &bindings, const DataMana
             continue;
         }
 
-        if (dataManager.hasImage(binding.resourceRef)) {
-            const auto &image = dataManager.getImage(binding.resourceRef);
+        if (const auto *imageId = std::get_if<ImageId>(&binding.resource)) {
+            const auto &image = dataManager.getImage(*imageId);
             const auto &shape = image.shape();
 
             tensorDescriptions.emplace_back(convertImageTiling(image.tiling()), image.dataType(),
@@ -431,8 +431,8 @@ Pipeline::Pipeline(const CommonArguments &args, const DataManager &dataManager, 
     createDescriptorSetLayouts(args.ctx, bindings);
     _pipelineLayout = createPipelineLayout(args.ctx, _descriptorSetLayouts);
 
-    const auto inputFormat = dataManager.getImage(inputSearch.resourceRef).dataType();
-    const auto flowFormat = dataManager.getImage(outputFlow.resourceRef).dataType();
+    const auto inputFormat = dataManager.getImage(std::get<ImageId>(inputSearch.resource)).dataType();
+    const auto flowFormat = dataManager.getImage(std::get<ImageId>(outputFlow.resource)).dataType();
     vk::Format costFormat{};
 
     // We expect all bindings to be images (sampled or storage)
@@ -447,10 +447,11 @@ Pipeline::Pipeline(const CommonArguments &args, const DataManager &dataManager, 
     connections.reserve(bindings.size());
 
     auto addConnection = [&](const TypedBinding &binding, vk::DataGraphPipelineNodeConnectionTypeARM connection) {
-        if (!dataManager.hasImage(binding.resourceRef)) {
+        const auto *imageId = std::get_if<ImageId>(&binding.resource);
+        if (imageId == nullptr || !dataManager.hasImage(*imageId)) {
             throw std::runtime_error("Optical flow pipeline expects image resources for all bindings");
         }
-        const auto layout = dataManager.getImage(binding.resourceRef).getImageLayout();
+        const auto layout = dataManager.getImage(*imageId).getImageLayout();
 
         vk::DataGraphPipelineSingleNodeConnectionARM conn{};
         conn.setSet(static_cast<uint32_t>(binding.set));
@@ -480,7 +481,7 @@ Pipeline::Pipeline(const CommonArguments &args, const DataManager &dataManager, 
     if (outputCost.has_value()) {
         addConnection(outputCost.value(), vk::DataGraphPipelineNodeConnectionTypeARM::eOpticalFlowCost);
         flags |= vk::DataGraphOpticalFlowCreateFlagBitsARM::eEnableCost;
-        costFormat = dataManager.getImage(outputCost.value().resourceRef).dataType();
+        costFormat = dataManager.getImage(std::get<ImageId>(outputCost.value().resource)).dataType();
     }
 
     vk::DataGraphPipelineSingleNodeCreateInfoARM singleNodeInfo{};

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -45,7 +45,7 @@ struct DispatchFragmentData {
     ShaderId vertexShader;
     ShaderId fragmentShader;
     struct Attachment {
-        Guid resourceRef;
+        ImageId resource;
         std::optional<uint32_t> lod;
     };
     std::vector<Attachment> colorAttachments;
@@ -89,6 +89,9 @@ struct DispatchSpirvGraphData {
 
 /// \brief Optical flow data graph with typed bindings
 struct DispatchOpticalFlowData {
+    DispatchOpticalFlowData(TypedBinding search, TypedBinding reference, TypedBinding output)
+        : searchImage(search), templateImage(reference), outputImage(output) {}
+
     std::string debugName;
     TypedBinding searchImage;
     TypedBinding templateImage;
@@ -367,6 +370,13 @@ struct ResourceInfoFactory {
     }
 };
 
+template <typename Id>
+Id resolveResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceIds, const Guid &guid,
+                     std::string_view expectedType);
+
+MemoryResourceId resolveMemoryResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceIds,
+                                         const Guid &guid);
+
 void fill(const BaseBarrierDesc &barrier, BaseBarrierData &data) {
     data.debugName = barrier.guidStr;
     data.srcAccess = barrier.srcAccess;
@@ -377,18 +387,15 @@ void fill(const BaseBarrierDesc &barrier, BaseBarrierData &data) {
 
 struct BarrierDataFactory {
     const DataManager &_dataManager;
+    const std::unordered_map<Guid, TypedResourceId> &_resourceIds;
 
     ImageBarrierData createInfo(const ImageBarrierDesc &imageBarrier) const {
-        // check the image affected by this barrier exists
-        if (!_dataManager.hasImage(imageBarrier.imageResource)) {
-            throw std::runtime_error("Unknown image ID for image barrier");
-        }
-
+        const auto image = resolveResourceId<ImageId>(_resourceIds, imageBarrier.imageResource, "Image");
         ImageBarrierData data{};
         fill(imageBarrier, data);
         data.oldLayout = imageBarrier.oldLayout;
         data.newLayout = imageBarrier.newLayout;
-        data.image = _dataManager.getImage(imageBarrier.imageResource).image();
+        data.image = _dataManager.getImage(image).image();
         data.imageRange = imageBarrier.imageRange;
         return data;
     }
@@ -400,18 +407,20 @@ struct BarrierDataFactory {
     }
 
     TensorBarrierData createInfo(const TensorBarrierDesc &tensorBarrier) const {
+        const auto tensor = resolveResourceId<TensorId>(_resourceIds, tensorBarrier.tensorResource, "Tensor");
         TensorBarrierData data{};
         fill(tensorBarrier, data);
-        data.tensor = _dataManager.getTensor(tensorBarrier.tensorResource).tensor();
+        data.tensor = _dataManager.getTensor(tensor).tensor();
         return data;
     }
 
     BufferBarrierData createInfo(const BufferBarrierDesc &bufferBarrier) const {
+        const auto buffer = resolveResourceId<BufferId>(_resourceIds, bufferBarrier.bufferResource, "Buffer");
         BufferBarrierData data{};
         fill(bufferBarrier, data);
         data.offset = bufferBarrier.offset;
         data.size = bufferBarrier.size;
-        data.buffer = _dataManager.getBuffer(bufferBarrier.bufferResource).buffer();
+        data.buffer = _dataManager.getBuffer(buffer).buffer();
         return data;
     }
 };
@@ -427,15 +436,24 @@ constexpr vk::DescriptorType convertDescriptorType(const DescriptorType descript
     }
 }
 
-vk::DescriptorType getResourceDescriptorType(const DataManager &dataManager, const Guid &guid) {
-    if (dataManager.hasBuffer(guid)) {
+vk::DescriptorType getResourceDescriptorType(const DataManager &dataManager, const MemoryResourceId &resource) {
+    if (const auto *buffer = std::get_if<BufferId>(&resource)) {
+        if (!dataManager.hasBuffer(*buffer)) {
+            throw std::runtime_error("Buffer resource not found");
+        }
         return vk::DescriptorType::eStorageBuffer;
     }
-    if (dataManager.hasTensor(guid)) {
+    if (const auto *tensor = std::get_if<TensorId>(&resource)) {
+        if (!dataManager.hasTensor(*tensor)) {
+            throw std::runtime_error("Tensor resource not found");
+        }
         return vk::DescriptorType::eTensorARM;
     }
-    if (dataManager.hasImage(guid)) {
-        if (dataManager.getImage(guid).isSampled()) {
+    if (const auto *image = std::get_if<ImageId>(&resource)) {
+        if (!dataManager.hasImage(*image)) {
+            throw std::runtime_error("Image resource not found");
+        }
+        if (dataManager.getImage(*image).isSampled()) {
             return vk::DescriptorType::eCombinedImageSampler;
         }
         return vk::DescriptorType::eStorageImage;
@@ -443,19 +461,22 @@ vk::DescriptorType getResourceDescriptorType(const DataManager &dataManager, con
     throw std::runtime_error("Invalid resource descriptor type");
 }
 
-TypedBinding convertBinding(const DataManager &dataManager, const BindingDesc &binding) {
+TypedBinding convertBinding(const DataManager &dataManager,
+                            const std::unordered_map<Guid, TypedResourceId> &resourceIds, const BindingDesc &binding) {
+    const auto resource = resolveMemoryResourceId(resourceIds, binding.resourceRef);
     const auto vkType = binding.descriptorType == DescriptorType::Auto
-                            ? getResourceDescriptorType(dataManager, binding.resourceRef)
+                            ? getResourceDescriptorType(dataManager, resource)
                             : convertDescriptorType(binding.descriptorType);
-    return {binding.set, binding.id, binding.resourceRef, binding.lod, vkType};
+    return {binding.set, binding.id, resource, binding.lod, vkType};
 }
 
 std::vector<TypedBinding> convertBindings(const DataManager &dataManager,
+                                          const std::unordered_map<Guid, TypedResourceId> &resourceIds,
                                           const std::vector<BindingDesc> &bindingDescs) {
     std::vector<TypedBinding> bindings;
     bindings.reserve(bindingDescs.size());
     for (const auto &binding : bindingDescs) {
-        bindings.push_back(convertBinding(dataManager, binding));
+        bindings.push_back(convertBinding(dataManager, resourceIds, binding));
     }
     return bindings;
 }
@@ -466,71 +487,62 @@ class Creator final : public IResourceCreator {
         : _ctx{ctx}, _resources{resources}, _dataManager{dataManager}, _groupManager{groupManager} {}
 
     BufferId createBuffer(BufferInfo &&info) override {
-        // Use the generated resource name as the DataManager key until it accepts typed IDs.
-        const Guid guid(info.debugName);
         const auto id = _resources.addBuffer(std::move(info));
-        _dataManager.createBuffer(guid, _resources.get(id));
-        _createdResources.push_back({guid, id});
+        _dataManager.createBuffer(id, _resources.get(id));
+        _createdResources.push_back(id);
         return id;
     }
 
     TensorId createTensor(TensorInfo &&info) override {
-        const Guid guid(info.debugName);
         const auto id = _resources.addTensor(std::move(info));
-        _dataManager.createTensor(guid, _resources.get(id));
-        _createdResources.push_back({guid, id});
+        _dataManager.createTensor(id, _resources.get(id));
+        _createdResources.push_back(id);
         return id;
     }
 
     ImageId createImage(ImageInfo &&info) override {
-        const Guid guid(info.debugName);
         const auto id = _resources.addImage(std::move(info));
-        _dataManager.createImage(guid, _resources.get(id));
-        _createdResources.push_back({guid, id});
+        _dataManager.createImage(id, _resources.get(id));
+        _createdResources.push_back(id);
         return id;
     }
 
     void setupCreatedNonTensorResources() {
-        for (const auto &[guid, id] : _createdResources) {
-            if (std::holds_alternative<BufferId>(id)) {
-                _dataManager.getBufferMut(guid).setup(_ctx, _groupManager.getMemoryManager(id));
-            } else if (std::holds_alternative<ImageId>(id)) {
-                _dataManager.getImageMut(guid).setup(_ctx, _groupManager.getMemoryManager(id));
+        for (const auto &id : _createdResources) {
+            if (const auto *buffer = std::get_if<BufferId>(&id)) {
+                _dataManager.getBufferMut(*buffer).setup(_ctx, _groupManager.getMemoryManager(id));
+            } else if (const auto *image = std::get_if<ImageId>(&id)) {
+                _dataManager.getImageMut(*image).setup(_ctx, _groupManager.getMemoryManager(id));
             }
         }
     }
 
     void setupCreatedTensorResources() {
-        for (const auto &[guid, id] : _createdResources) {
-            if (std::holds_alternative<TensorId>(id)) {
-                _dataManager.getTensorMut(guid).setup(_ctx, _groupManager.getMemoryManager(id));
+        for (const auto &id : _createdResources) {
+            if (const auto *tensor = std::get_if<TensorId>(&id)) {
+                _dataManager.getTensorMut(*tensor).setup(_ctx, _groupManager.getMemoryManager(id));
             }
         }
     }
 
     void allocateCreatedResources() {
-        for (const auto &[guid, id] : _createdResources) {
-            if (std::holds_alternative<BufferId>(id)) {
-                _dataManager.getBufferMut(guid).allocateMemory(_ctx);
-            } else if (std::holds_alternative<ImageId>(id)) {
-                _dataManager.getImageMut(guid).allocateMemory(_ctx);
-            } else if (std::holds_alternative<TensorId>(id)) {
-                _dataManager.getTensorMut(guid).allocateMemory(_ctx);
+        for (const auto &id : _createdResources) {
+            if (const auto *buffer = std::get_if<BufferId>(&id)) {
+                _dataManager.getBufferMut(*buffer).allocateMemory(_ctx);
+            } else if (const auto *image = std::get_if<ImageId>(&id)) {
+                _dataManager.getImageMut(*image).allocateMemory(_ctx);
+            } else if (const auto *tensor = std::get_if<TensorId>(&id)) {
+                _dataManager.getTensorMut(*tensor).allocateMemory(_ctx);
             }
         }
     }
 
   private:
-    struct CreatedResource {
-        Guid guid;
-        MemoryResourceId id;
-    };
-
     const Context &_ctx;
     ResourceManager &_resources;
     DataManager &_dataManager;
     GroupManager &_groupManager;
-    std::vector<CreatedResource> _createdResources;
+    std::vector<MemoryResourceId> _createdResources;
 };
 
 const TypedResourceId &resolveTypedResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceIds,
@@ -553,6 +565,21 @@ Id resolveResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceId
     return *id;
 }
 
+MemoryResourceId resolveMemoryResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceIds,
+                                         const Guid &guid) {
+    const auto &resourceId = resolveTypedResourceId(resourceIds, guid, "Memory");
+    if (const auto *id = std::get_if<BufferId>(&resourceId)) {
+        return *id;
+    }
+    if (const auto *id = std::get_if<ImageId>(&resourceId)) {
+        return *id;
+    }
+    if (const auto *id = std::get_if<TensorId>(&resourceId)) {
+        return *id;
+    }
+    throw std::runtime_error("Resource UID has the wrong type; expected a memory resource.");
+}
+
 template <typename Key>
 MemoryGroupId getOrCreateMemoryGroup(GroupManager &groupManager, std::unordered_map<Key, MemoryGroupId> &memoryGroupIds,
                                      const Key &key) {
@@ -571,17 +598,6 @@ void registerMemoryGroup(GroupManager &groupManager, std::unordered_map<Guid, Me
         const auto group = getOrCreateMemoryGroup(groupManager, memoryGroupIds, memoryGroup->memoryUid);
         groupManager.addResourceToGroup(group, resource);
     }
-}
-
-template <typename Id>
-const Guid &resolveRuntimeResource(const std::unordered_map<Id, Guid> &resourceGuids, Id id,
-                                   std::string_view resourceType, std::string_view operation) {
-    const auto resource = resourceGuids.find(id);
-    if (resource == resourceGuids.end()) {
-        throw std::runtime_error("Scenario::" + std::string(operation) + ": " + std::string(resourceType) +
-                                 " resource not found.");
-    }
-    return resource->second;
 }
 
 template <typename Id>
@@ -625,7 +641,7 @@ struct CommandDataFactory {
     DispatchComputeData createData(const DispatchComputeDesc &dispatchCompute) {
         DispatchComputeData data{getShaderId(dispatchCompute.shaderRef)};
         data.debugName = dispatchCompute.debugName;
-        data.bindings = convertBindings(_dataManager, dispatchCompute.bindings);
+        data.bindings = convertBindings(_dataManager, _resourceIds, dispatchCompute.bindings);
         data.computeDispatch.gwcx = dispatchCompute.rangeND[0];
         data.computeDispatch.gwcy = dispatchCompute.rangeND[1];
         data.computeDispatch.gwcz = dispatchCompute.rangeND[2];
@@ -639,11 +655,11 @@ struct CommandDataFactory {
         DispatchFragmentData data{getShaderId(dispatchFragment.vertexShaderRef),
                                   getShaderId(dispatchFragment.fragmentShaderRef)};
         data.debugName = dispatchFragment.debugName;
-        data.bindings = convertBindings(_dataManager, dispatchFragment.bindings);
+        data.bindings = convertBindings(_dataManager, _resourceIds, dispatchFragment.bindings);
         data.colorAttachments.reserve(dispatchFragment.colorAttachments.size());
         for (const auto &attachmentDesc : dispatchFragment.colorAttachments) {
             data.colorAttachments.push_back(
-                DispatchFragmentData::Attachment{attachmentDesc.resourceRef, attachmentDesc.lod});
+                {resolveResourceId<ImageId>(_resourceIds, attachmentDesc.resourceRef, "Image"), attachmentDesc.lod});
         }
         if (dispatchFragment.renderExtent) {
             const auto &extent = dispatchFragment.renderExtent.value();
@@ -690,7 +706,7 @@ struct CommandDataFactory {
     DispatchDataGraphData createData(const DispatchDataGraphDesc &dispatchDataGraph) {
         DispatchDataGraphData data{getDataGraphId(dispatchDataGraph.dataGraphRef)};
         data.debugName = dispatchDataGraph.debugName;
-        data.bindings = convertBindings(_dataManager, dispatchDataGraph.bindings);
+        data.bindings = convertBindings(_dataManager, _resourceIds, dispatchDataGraph.bindings);
         data.pushConstants.reserve(dispatchDataGraph.pushConstants.size());
         for (const auto &pushConstant : dispatchDataGraph.pushConstants) {
             data.pushConstants.push_back(
@@ -708,7 +724,7 @@ struct CommandDataFactory {
     DispatchSpirvGraphData createData(const DispatchSpirvGraphDesc &dispatchSpirvGraph) {
         DispatchSpirvGraphData data{getShaderId(dispatchSpirvGraph.dataGraphRef)};
         data.debugName = dispatchSpirvGraph.debugName;
-        data.bindings = convertBindings(_dataManager, dispatchSpirvGraph.bindings);
+        data.bindings = convertBindings(_dataManager, _resourceIds, dispatchSpirvGraph.bindings);
         data.graphConstants.reserve(dispatchSpirvGraph.graphConstants.size());
         for (const auto &graphConstant : dispatchSpirvGraph.graphConstants) {
             data.graphConstants.push_back(getGraphConstantResourceId(graphConstant));
@@ -718,17 +734,16 @@ struct CommandDataFactory {
     }
 
     DispatchOpticalFlowData createData(const DispatchOpticalFlowDesc &dispatchOpticalFlow) {
-        DispatchOpticalFlowData data;
+        DispatchOpticalFlowData data{convertBinding(_dataManager, _resourceIds, dispatchOpticalFlow.searchImage),
+                                     convertBinding(_dataManager, _resourceIds, dispatchOpticalFlow.templateImage),
+                                     convertBinding(_dataManager, _resourceIds, dispatchOpticalFlow.outputImage)};
         data.debugName = dispatchOpticalFlow.debugName;
-
-        data.searchImage = convertBinding(_dataManager, dispatchOpticalFlow.searchImage);
-        data.templateImage = convertBinding(_dataManager, dispatchOpticalFlow.templateImage);
-        data.outputImage = convertBinding(_dataManager, dispatchOpticalFlow.outputImage);
         if (dispatchOpticalFlow.hintMotionVectors.has_value()) {
-            data.hintMotionVectors = convertBinding(_dataManager, dispatchOpticalFlow.hintMotionVectors.value());
+            data.hintMotionVectors =
+                convertBinding(_dataManager, _resourceIds, dispatchOpticalFlow.hintMotionVectors.value());
         }
         if (dispatchOpticalFlow.outputCost.has_value()) {
-            data.outputCost = convertBinding(_dataManager, dispatchOpticalFlow.outputCost.value());
+            data.outputCost = convertBinding(_dataManager, _resourceIds, dispatchOpticalFlow.outputCost.value());
         }
 
         data.width = dispatchOpticalFlow.width;
@@ -747,12 +762,13 @@ struct CommandDataFactory {
 
         for (const auto &resourceRef : markBoundary.resources) {
             const Guid guid(resourceRef);
-            if (_dataManager.hasBuffer(guid)) {
-                data.buffers.emplace_back(guid);
-            } else if (_dataManager.hasImage(guid)) {
-                data.images.emplace_back(guid);
-            } else if (_dataManager.hasTensor(guid)) {
-                data.tensors.emplace_back(guid);
+            const auto &resource = resolveTypedResourceId(_resourceIds, guid, "Memory");
+            if (const auto *buffer = std::get_if<BufferId>(&resource)) {
+                data.buffers.push_back(*buffer);
+            } else if (const auto *image = std::get_if<ImageId>(&resource)) {
+                data.images.push_back(*image);
+            } else if (const auto *tensor = std::get_if<TensorId>(&resource)) {
+                data.tensors.push_back(*tensor);
             } else {
                 throw std::runtime_error("Unsupported resource");
             }
@@ -829,39 +845,37 @@ TensorId Scenario::getTensorId(std::string_view uid) const {
 }
 
 void Scenario::upload(BufferId id, const BufferDataView &data) {
-    const auto &guid = resolveRuntimeResource(_bufferResourceGuids, id, "Buffer", "upload");
-    _dataManager.getBuffer(guid).upload(_ctx, data);
+    if (!_dataManager.hasBuffer(id)) {
+        throw std::runtime_error("Scenario::upload: Buffer resource not found.");
+    }
+    _dataManager.getBuffer(id).upload(_ctx, data);
 }
 
 void Scenario::upload(TensorId id, const TensorDataView &data) {
-    const auto &guid = resolveRuntimeResource(_tensorResourceGuids, id, "Tensor", "upload");
-    _dataManager.getTensor(guid).upload(_ctx, data);
+    if (!_dataManager.hasTensor(id)) {
+        throw std::runtime_error("Scenario::upload: Tensor resource not found.");
+    }
+    _dataManager.getTensor(id).upload(_ctx, data);
 }
 
 BufferData Scenario::download(BufferId id) const {
-    const auto &guid = resolveRuntimeResource(_bufferResourceGuids, id, "Buffer", "download");
-    return _dataManager.getBuffer(guid).download(_ctx);
+    if (!_dataManager.hasBuffer(id)) {
+        throw std::runtime_error("Scenario::download: Buffer resource not found.");
+    }
+    return _dataManager.getBuffer(id).download(_ctx);
 }
 
 TensorData Scenario::download(TensorId id) const {
-    const auto &guid = resolveRuntimeResource(_tensorResourceGuids, id, "Tensor", "download");
-    return _dataManager.getTensor(guid).download(_ctx);
+    if (!_dataManager.hasTensor(id)) {
+        throw std::runtime_error("Scenario::download: Tensor resource not found.");
+    }
+    return _dataManager.getTensor(id).download(_ctx);
 }
 
 const ShaderInfo &Scenario::getShader(ShaderId id) const { return _resources.get(id); }
 
 MemoryResourceId Scenario::getMemoryResourceId(const Guid &guid) const {
-    const auto &resourceId = resolveTypedResourceId(_resourceIds, guid, "Memory");
-    if (const auto *id = std::get_if<BufferId>(&resourceId)) {
-        return *id;
-    }
-    if (const auto *id = std::get_if<ImageId>(&resourceId)) {
-        return *id;
-    }
-    if (const auto *id = std::get_if<TensorId>(&resourceId)) {
-        return *id;
-    }
-    throw std::runtime_error("Resource UID has the wrong type; expected a memory resource.");
+    return resolveMemoryResourceId(_resourceIds, guid);
 }
 
 const ShaderInfo &Scenario::getSubstitutionShader(const std::vector<ResolvedShaderSubstitution> &shaderSubstitutions,
@@ -921,7 +935,8 @@ void Scenario::resetForNextRun() {
         if (resource->resourceType == ResourceType::Image) {
             const auto &imageDesc = static_cast<const ImageDesc &>(*resource);
             if (imageDesc.tiling.has_value() && imageDesc.tiling.value() == Tiling::Optimal) {
-                _dataManager.getImageMut(imageDesc.guid).resetLayout();
+                const auto imageId = resolveResourceId<ImageId>(_resourceIds, imageDesc.guid, "Image");
+                _dataManager.getImageMut(imageId).resetLayout();
             }
         }
     }
@@ -940,8 +955,7 @@ void Scenario::setupResources() {
             const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
             const auto id = _resources.addBuffer(resourceInfoFactory.createInfo(*buffer));
             _resourceIds.emplace(resource->guid, id);
-            _bufferResourceGuids.emplace(id, resource->guid);
-            _dataManager.createBuffer(resource->guid, _resources.get(id));
+            _dataManager.createBuffer(id, _resources.get(id));
             registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, buffer->memoryGroup);
         } break;
         case ResourceType::RawData: {
@@ -954,7 +968,7 @@ void Scenario::setupResources() {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
             const auto id = _resources.addImage(resourceInfoFactory.createInfo(*image));
             _resourceIds.emplace(resource->guid, id);
-            _dataManager.createImage(resource->guid, _resources.get(id));
+            _dataManager.createImage(id, _resources.get(id));
             registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, image->memoryGroup);
         } break;
         case ResourceType::DataGraph: {
@@ -968,8 +982,7 @@ void Scenario::setupResources() {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
             const auto id = _resources.addTensor(resourceInfoFactory.createInfo(*tensor, _opts.captureFrame));
             _resourceIds.emplace(resource->guid, id);
-            _tensorResourceGuids.emplace(id, resource->guid);
-            _dataManager.createTensor(resource->guid, _resources.get(id));
+            _dataManager.createTensor(id, _resources.get(id));
             registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, tensor->memoryGroup);
         } break;
         case ResourceType::Shader: {
@@ -990,6 +1003,7 @@ void Scenario::setupResources() {
     }
 
     Creator vgfResourceCreator{_ctx, _resources, _dataManager, _groupManager};
+    // Per data graph, map VGF alias group IDs to runtime memory group IDs.
     std::unordered_map<DataGraphId, std::unordered_map<uint32_t, MemoryGroupId>> vgfMemoryGroupIds;
 
     for (const auto &command : _scenarioSpec.commands) {
@@ -1001,8 +1015,12 @@ void Scenario::setupResources() {
         const auto dataGraph =
             resolveResourceId<DataGraphId>(_resourceIds, dispatchDataGraph.dataGraphRef, "Data graph");
         const auto &vgfView = _dataManager.getVgfView(dataGraph);
-        const auto externalBindings = convertBindings(_dataManager, dispatchDataGraph.bindings);
-        const auto creationResult = vgfView.createIntermediateResources(vgfResourceCreator);
+        const auto externalBindings = convertBindings(_dataManager, _resourceIds, dispatchDataGraph.bindings);
+        if (_vgfResourceCreationResults.count(dataGraph) == 0) {
+            // cppcheck-suppress stlFindInsert
+            _vgfResourceCreationResults.emplace(dataGraph, vgfView.createIntermediateResources(vgfResourceCreator));
+        }
+        const auto &creationResult = _vgfResourceCreationResults.at(dataGraph);
         for (const auto &[aliasGroupId, resourceIds] : creationResult.memoryGroups) {
             auto &aliasGroupIds = vgfMemoryGroupIds[dataGraph];
             const auto group = getOrCreateMemoryGroup(_groupManager, aliasGroupIds, aliasGroupId);
@@ -1017,7 +1035,7 @@ void Scenario::setupResources() {
             if (!aliasGroupId.has_value()) {
                 continue;
             }
-            const auto resourceId = getMemoryResourceId(binding.resourceRef);
+            const auto resourceId = binding.resource;
             auto &aliasGroupIds = vgfMemoryGroupIds[dataGraph];
             const auto group = getOrCreateMemoryGroup(_groupManager, aliasGroupIds, *aliasGroupId);
             _groupManager.addResourceToGroup(group, resourceId);
@@ -1029,13 +1047,13 @@ void Scenario::setupResources() {
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
         case ResourceType::Buffer: {
-            auto &bufferRef = _dataManager.getBufferMut(resource->guid);
             const auto id = resolveResourceId<BufferId>(_resourceIds, resource->guid, "Buffer");
+            auto &bufferRef = _dataManager.getBufferMut(id);
             bufferRef.setup(_ctx, _groupManager.getMemoryManager(id));
         } break;
         case ResourceType::Image: {
-            auto &imageRef = _dataManager.getImageMut(resource->guid);
             const auto id = resolveResourceId<ImageId>(_resourceIds, resource->guid, "Image");
+            auto &imageRef = _dataManager.getImageMut(id);
             imageRef.setup(_ctx, _groupManager.getMemoryManager(id));
         } break;
         default:
@@ -1047,15 +1065,15 @@ void Scenario::setupResources() {
     // Setup tensors, aliasing tensors are dependent on other resources having been constructed
     for (const auto &resource : _scenarioSpec.resources) {
         if (resource->resourceType == ResourceType::Tensor) {
-            auto &tensorRef = _dataManager.getTensorMut(resource->guid);
             const auto id = resolveResourceId<TensorId>(_resourceIds, resource->guid, "Tensor");
+            auto &tensorRef = _dataManager.getTensorMut(id);
             tensorRef.setup(_ctx, _groupManager.getMemoryManager(id));
         }
     }
     vgfResourceCreator.setupCreatedTensorResources();
 
     // Setup barrier resource info, these depend on other resources
-    BarrierDataFactory barrierDataFactory{_dataManager};
+    BarrierDataFactory barrierDataFactory{_dataManager, _resourceIds};
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
         case ResourceType::ImageBarrier: {
@@ -1090,15 +1108,18 @@ void Scenario::setupResources() {
         switch (resource->resourceType) {
         case ResourceType::Tensor: {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
-            _dataManager.getTensorMut(tensor->guid).allocateMemory(_ctx);
+            const auto id = resolveResourceId<TensorId>(_resourceIds, tensor->guid, "Tensor");
+            _dataManager.getTensorMut(id).allocateMemory(_ctx);
         } break;
         case ResourceType::Image: {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
-            _dataManager.getImageMut(image->guid).allocateMemory(_ctx);
+            const auto id = resolveResourceId<ImageId>(_resourceIds, image->guid, "Image");
+            _dataManager.getImageMut(id).allocateMemory(_ctx);
         } break;
         case ResourceType::Buffer: {
             const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
-            _dataManager.getBufferMut(buffer->guid).allocateMemory(_ctx);
+            const auto id = resolveResourceId<BufferId>(_resourceIds, buffer->guid, "Buffer");
+            _dataManager.getBufferMut(id).allocateMemory(_ctx);
         } break;
         default:
             // Skip the other types of resources
@@ -1115,16 +1136,16 @@ void Scenario::setupResources() {
             PerfCounterGuard guard(_perfCounters, "Load Tensor: " + tensor->guidStr, "Scenario Setup");
             const auto id = resolveResourceId<TensorId>(_resourceIds, tensor->guid, "Tensor");
             if (tensor->src || !_groupManager.isAliased(id)) {
-                const auto &tensorResource = _dataManager.getTensor(tensor->guid);
+                const auto &tensorResource = _dataManager.getTensor(id);
                 const auto tensorData = loadTensorData(*tensor, tensorResource.dataSize());
                 upload(id, {tensorData.data.data(), tensorData.data.size(), tensorData.shape, tensorData.format});
             }
         } break;
         case ResourceType::Image: {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
-            auto &imageRec = _dataManager.getImageMut(image->guid);
             PerfCounterGuard guard(_perfCounters, "Load Image: " + image->guidStr, "Scenario Setup");
             const auto id = resolveResourceId<ImageId>(_resourceIds, image->guid, "Image");
+            auto &imageRec = _dataManager.getImageMut(id);
             if (image->src || !_groupManager.isAliased(id)) {
                 imageRec.fillFromDescription(_ctx, *image);
             } else {
@@ -1311,7 +1332,7 @@ void Scenario::handleAliasedLayoutTransitions() {
                     continue;
                 }
 
-                auto &image = _dataManager.getImageMut(imageDesc.guid);
+                auto &image = _dataManager.getImageMut(imageId);
                 if (image.getImageLayout() != vk::ImageLayout::eTensorAliasingARM) {
                     image.addTransitionLayoutCommand(_compute.getCommandBuffer(), vk::ImageLayout::eTensorAliasingARM);
                 }
@@ -1320,6 +1341,7 @@ void Scenario::handleAliasedLayoutTransitions() {
             //  Image → transition back from alias layout
         } else if (resource->resourceType == ResourceType::Image) {
             const auto &imageDesc = static_cast<const ImageDesc &>(*resource);
+            const auto imageId = resolveResourceId<ImageId>(_resourceIds, imageDesc.guid, "Image");
             if (!imageDesc.tiling.has_value() || imageDesc.tiling.value() != Tiling::Optimal) {
                 continue;
             }
@@ -1341,7 +1363,7 @@ void Scenario::handleAliasedLayoutTransitions() {
                     continue;
                 }
 
-                auto &image = _dataManager.getImageMut(imageDesc.guid);
+                auto &image = _dataManager.getImageMut(imageId);
                 vk::ImageLayout targetLayout = vk::ImageLayout::eGeneral;
                 if (imageDesc.shaderAccess == ShaderAccessType::ReadOnly) {
                     targetLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
@@ -1404,7 +1426,7 @@ void Scenario::createFragmentPipeline(const DispatchFragmentData &dispatchFragme
 
     std::optional<vk::Extent2D> targetExtent = dispatchFragment.renderExtent;
     for (const auto &attachmentSpec : dispatchFragment.colorAttachments) {
-        const auto &colorImage = _dataManager.getImage(attachmentSpec.resourceRef);
+        const auto &colorImage = _dataManager.getImage(attachmentSpec.resource);
         const auto &imageInfo = colorImage.getInfo();
         const auto &shape = colorImage.shape();
         if (shape.size() < 3) {
@@ -1458,7 +1480,9 @@ void Scenario::createFragmentPipeline(const DispatchFragmentData &dispatchFragme
 void Scenario::createDataGraphPipeline(const DispatchDataGraphData &dispatchDataGraph, uint32_t &nQueries) {
     const VgfView &vgfView = _dataManager.getVgfView(dispatchDataGraph.dataGraph);
     for (uint32_t segmentIndex = 0; segmentIndex < vgfView.getNumSegments(); ++segmentIndex) {
-        const auto &sequenceBindings = vgfView.resolveBindings(segmentIndex, _dataManager, dispatchDataGraph.bindings);
+        const auto &intermediates = _vgfResourceCreationResults.at(dispatchDataGraph.dataGraph).intermediateResources;
+        const auto &sequenceBindings =
+            vgfView.resolveBindings(segmentIndex, _dataManager, dispatchDataGraph.bindings, intermediates);
         auto moduleName = vgfView.getModuleName(segmentIndex);
         PerfCounterGuard guard(_perfCounters, "Create Pipeline: " + moduleName, "Pipeline Setup");
         createPipeline(segmentIndex, sequenceBindings, vgfView, dispatchDataGraph, nQueries);
@@ -1478,13 +1502,13 @@ void Scenario::createSpirvGraphPipeline(const DispatchSpirvGraphData &dispatchSp
     // Validate the bindings
     const auto &sequenceBindings = dispatchSpirvGraph.bindings;
     for (const auto &binding : sequenceBindings) {
-        if (_dataManager.hasTensor(binding.resourceRef)) {
+        if (std::holds_alternative<TensorId>(binding.resource)) {
             if (binding.vkDescriptorType != vk::DescriptorType::eTensorARM) {
                 throw std::runtime_error("DataGraph tensor binding must use a tensor descriptor");
             }
             continue;
         }
-        if (_dataManager.hasImage(binding.resourceRef)) {
+        if (std::holds_alternative<ImageId>(binding.resource)) {
             if ((binding.vkDescriptorType != vk::DescriptorType::eStorageImage) &&
                 (binding.vkDescriptorType != vk::DescriptorType::eCombinedImageSampler)) {
                 throw std::runtime_error("DataGraph image binding must use an image descriptor");
@@ -1663,19 +1687,22 @@ void Scenario::saveResults(bool dryRun) {
         for (const auto &resourceDesc : _scenarioSpec.resources) {
             const auto &dst = resourceDesc->getDestination();
             if (dst.has_value()) {
-                const auto &guid = resourceDesc->guid;
                 switch (resourceDesc->resourceType) {
                 case ResourceType::Buffer:
-                    _dataManager.getBuffer(guid).store(_ctx, dst.value());
+                    _dataManager.getBuffer(resolveResourceId<BufferId>(_resourceIds, resourceDesc->guid, "Buffer"))
+                        .store(_ctx, dst.value());
                     break;
                 case ResourceType::Tensor:
-                    _dataManager.getTensor(guid).store(_ctx, dst.value());
+                    _dataManager.getTensor(resolveResourceId<TensorId>(_resourceIds, resourceDesc->guid, "Tensor"))
+                        .store(_ctx, dst.value());
                     break;
                 case ResourceType::Image:
-                    _dataManager.getImageMut(guid).store(_ctx, dst.value());
+                    _dataManager.getImageMut(resolveResourceId<ImageId>(_resourceIds, resourceDesc->guid, "Image"))
+                        .store(_ctx, dst.value());
                     break;
                 default:
-                    throw std::runtime_error("Resource not found");
+                    throw std::runtime_error("Output destination is not supported for " + resourceType(resourceDesc) +
+                                             " resource " + resourceDesc->guidStr);
                 }
                 mlsdk::logging::debug(resourceType(resourceDesc) + " " + resourceDesc->guidStr + " output stored");
             }

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -118,8 +118,7 @@ class Scenario {
     Context _ctx;
     ResourceManager _resources;
     std::unordered_map<Guid, TypedResourceId> _resourceIds;
-    std::unordered_map<BufferId, Guid> _bufferResourceGuids;
-    std::unordered_map<TensorId, Guid> _tensorResourceGuids;
+    std::unordered_map<DataGraphId, VgfResourceCreationResult> _vgfResourceCreationResults;
     DataManager _dataManager;
     ScenarioSpec &_scenarioSpec;
     std::shared_ptr<PipelineCache> _pipelineCache;

--- a/src/tests/buffer_tests.cpp
+++ b/src/tests/buffer_tests.cpp
@@ -14,11 +14,11 @@
 
 using namespace mlsdk::scenariorunner;
 
-Buffer &prepareBuffer(Context &ctx, DataManager &dm, const Guid &guid, uint32_t sizeBytes) {
+Buffer &prepareBuffer(Context &ctx, DataManager &dm, BufferId id, uint32_t sizeBytes) {
     BufferInfo info;
     info.size = sizeBytes;
-    dm.createBuffer(guid, info);
-    auto &buf = dm.getBufferMut(guid);
+    dm.createBuffer(id, info);
+    auto &buf = dm.getBufferMut(id);
     buf.setup(ctx);
     buf.allocateMemory(ctx);
     return buf;
@@ -29,8 +29,7 @@ TEST(BufferInMemoryTransfer, UploadThrowsOnSizeMismatch) {
     Context ctx{opts};
     DataManager dm;
 
-    const Guid guid("buf_mismatch");
-    auto &buf = prepareBuffer(ctx, dm, guid, /*sizeBytes*/ 16);
+    auto &buf = prepareBuffer(ctx, dm, BufferId{0}, /*sizeBytes*/ 16);
 
     std::vector<char> small(8, static_cast<char>(0x7B));
     BufferDataView view{small.data(), small.size()};
@@ -42,8 +41,7 @@ TEST(BufferInMemoryTransfer, UploadSucceedsAndPersistsCopy) {
     Context ctx{opts};
     DataManager dm;
 
-    const Guid guid("buf_upload_ok");
-    auto &buf = prepareBuffer(ctx, dm, guid, /*sizeBytes*/ 16);
+    auto &buf = prepareBuffer(ctx, dm, BufferId{0}, /*sizeBytes*/ 16);
 
     std::vector<char> payload(16);
     std::iota(payload.begin(), payload.end(), static_cast<char>(0));
@@ -67,8 +65,7 @@ TEST(BufferInMemoryTransfer, DownloadReturnsUploadedData) {
     Context ctx{opts};
     DataManager dm;
 
-    const Guid guid("buf_download_ok");
-    auto &buf = prepareBuffer(ctx, dm, guid, /*sizeBytes*/ 12);
+    auto &buf = prepareBuffer(ctx, dm, BufferId{0}, /*sizeBytes*/ 12);
 
     std::vector<char> payload(12);
     std::iota(payload.begin(), payload.end(), static_cast<char>(0));

--- a/src/tests/iresource_tests.cpp
+++ b/src/tests/iresource_tests.cpp
@@ -10,11 +10,23 @@
 
 using namespace mlsdk::scenariorunner;
 
+TEST(DataManager, MissingTypedResourceThrowsRuntimeError) {
+    DataManager dataManager;
+    const auto &constDataManager = dataManager;
+
+    EXPECT_THROW(dataManager.getBufferMut(BufferId{0}), std::runtime_error);
+    EXPECT_THROW(dataManager.getImageMut(ImageId{0}), std::runtime_error);
+    EXPECT_THROW(dataManager.getTensorMut(TensorId{0}), std::runtime_error);
+    EXPECT_THROW(constDataManager.getBuffer(BufferId{0}), std::runtime_error);
+    EXPECT_THROW(constDataManager.getImage(ImageId{0}), std::runtime_error);
+    EXPECT_THROW(constDataManager.getTensor(TensorId{0}), std::runtime_error);
+}
+
 TEST(DataManagerResourceViewer, HasResources) {
     DataManager dm;
 
     {
-        const Guid tensor("tensor");
+        const TensorId tensor{0};
         DataManagerResourceViewer viewer(dm, tensor);
         ASSERT_FALSE(viewer.hasBuffer());
         ASSERT_FALSE(viewer.hasImage());
@@ -25,7 +37,7 @@ TEST(DataManagerResourceViewer, HasResources) {
     }
 
     {
-        const Guid buffer("buffer");
+        const BufferId buffer{0};
         dm.createBuffer(buffer, BufferInfo{});
         DataManagerResourceViewer viewer(dm, buffer);
         ASSERT_TRUE(viewer.hasBuffer());
@@ -37,7 +49,7 @@ TEST(DataManagerResourceViewer, HasResources) {
     }
 
     {
-        const Guid image("image");
+        const ImageId image{0};
         dm.createImage(image, ImageInfo{});
         DataManagerResourceViewer viewer(dm, image);
         ASSERT_FALSE(viewer.hasBuffer());

--- a/src/tests/tensor_tests.cpp
+++ b/src/tests/tensor_tests.cpp
@@ -16,16 +16,16 @@
 #include <gtest/gtest.h>
 using namespace mlsdk::scenariorunner;
 
-Tensor &prepareTensor(Context &ctx, DataManager &dm, const Guid &guid, const std::vector<int64_t> &shape,
-                      vk::Format format, uint64_t memoryOffset = 0) {
+Tensor &prepareTensor(Context &ctx, DataManager &dm, TensorId id, const std::vector<int64_t> &shape, vk::Format format,
+                      uint64_t memoryOffset = 0) {
     TensorInfo info;
     info.debugName = "test_tensor";
     info.shape = shape;
     info.format = format;
     info.tiling = Tiling::Linear;
     info.memoryOffset = memoryOffset;
-    dm.createTensor(guid, info);
-    auto &tensor = dm.getTensorMut(guid);
+    dm.createTensor(id, info);
+    auto &tensor = dm.getTensorMut(id);
     tensor.setup(ctx);
     tensor.allocateMemory(ctx);
     return tensor;
@@ -39,11 +39,10 @@ TEST(TensorInMemoryTransfer, UploadThrowsOnShapeMismatch) {
     ScenarioOptions opts{};
     Context ctx{opts};
     DataManager dm;
-    const Guid guid("tensor_shape_mismatch");
     const std::vector<int64_t> shape{2, 2};
     const vk::Format fmt = vk::Format::eR8Uint;
 
-    auto &tensor = prepareTensor(ctx, dm, guid, shape, fmt);
+    auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
     std::vector<char> payload(bytesFor(fmt, shape), 0x3C);
 
     const std::vector<int64_t> wrongShape{2, 3};
@@ -57,11 +56,10 @@ TEST(TensorInMemoryTransfer, UploadThrowsOnIncompatibleFormatWhenProvided) {
     ScenarioOptions opts{};
     Context ctx{opts};
     DataManager dm;
-    const Guid guid("tensor_format_mismatch");
     const std::vector<int64_t> shape{2, 2};
     const vk::Format fmt = vk::Format::eR8Uint;
 
-    auto &tensor = prepareTensor(ctx, dm, guid, shape, fmt);
+    auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
     std::vector<char> payload(bytesFor(fmt, shape), 0x7F);
 
     TensorDataView view{payload.data(), payload.size(), {}, std::nullopt};
@@ -74,11 +72,10 @@ TEST(TensorInMemoryTransfer, UploadThrowsOnSizeMismatch) {
     ScenarioOptions opts{};
     Context ctx{opts};
     DataManager dm;
-    const Guid guid("tensor_size_mismatch");
     const std::vector<int64_t> shape{2, 2};
     const vk::Format fmt = vk::Format::eR8Uint;
 
-    auto &tensor = prepareTensor(ctx, dm, guid, shape, fmt);
+    auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
     std::vector<char> small(3, 0x11); // too small by 1 byte
 
     TensorDataView view{small.data(), small.size(), {}, std::nullopt};
@@ -90,11 +87,10 @@ TEST(TensorInMemoryTransfer, UploadSucceedsAndPersistsCopy_FormatOptional) {
     ScenarioOptions opts{};
     Context ctx{opts};
     DataManager dm;
-    const Guid guid("tensor_upload_ok");
     const std::vector<int64_t> shape{3, 2};
     const vk::Format fmt = vk::Format::eR8Uint; // 6 bytes
 
-    auto &tensor = prepareTensor(ctx, dm, guid, shape, fmt);
+    auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
     std::vector<char> payload(bytesFor(fmt, shape));
     std::iota(payload.begin(), payload.end(), static_cast<char>(1));
     TensorDataView view{payload.data(), payload.size(), {}, std::nullopt};
@@ -119,11 +115,10 @@ TEST(TensorInMemoryTransfer, UploadAcceptsRankConvertedEmptyShape) {
     ScenarioOptions opts{};
     Context ctx{opts};
     DataManager dm;
-    const Guid guid("tensor_rank_converted");
     const std::vector<int64_t> emptyShape{};    // will be converted to [1]
     const vk::Format fmt = vk::Format::eR8Uint; // 1 byte
 
-    auto &tensor = prepareTensor(ctx, dm, guid, emptyShape, fmt);
+    auto &tensor = prepareTensor(ctx, dm, TensorId{0}, emptyShape, fmt);
 
     std::vector<char> payload(1, static_cast<char>(0x5A));
     TensorDataView view{payload.data(), payload.size(), {}, std::nullopt};
@@ -143,11 +138,10 @@ TEST(TensorInMemoryTransfer, DownloadReturnsUploadedData) {
     ScenarioOptions opts{};
     Context ctx{opts};
     DataManager dm;
-    const Guid guid("tensor_download_ok");
     const std::vector<int64_t> shape{2, 3, 1};
     const vk::Format fmt = vk::Format::eR8Uint; // 6 bytes
 
-    auto &tensor = prepareTensor(ctx, dm, guid, shape, fmt);
+    auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
     std::vector<char> payload(bytesFor(fmt, shape));
     std::iota(payload.begin(), payload.end(), static_cast<char>(0));
     TensorDataView view{payload.data(), payload.size(), {}, std::nullopt};
@@ -167,12 +161,11 @@ TEST(TensorInMemoryTransfer, UploadAndDownloadRespectMemoryOffset) {
     ScenarioOptions opts{};
     Context ctx{opts};
     DataManager dm;
-    const Guid guid("tensor_memory_offset");
     const std::vector<int64_t> shape{2, 3, 1};
     const vk::Format format = vk::Format::eR8Uint;
     constexpr uint64_t memoryOffset = 4096;
 
-    auto &tensor = prepareTensor(ctx, dm, guid, shape, format, memoryOffset);
+    auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, format, memoryOffset);
     std::vector<char> payload(bytesFor(format, shape));
     std::iota(payload.begin(), payload.end(), static_cast<char>(1));
 
@@ -187,7 +180,7 @@ TEST(TensorInMemoryTransfer, UploadAndDownloadRespectImageSubresourceOffset) {
     ScenarioOptions opts{};
     Context ctx{opts};
     DataManager dm;
-    const Guid guid("tensor_image_subresource_offset");
+    const TensorId id{0};
     const std::vector<int64_t> shape{2, 3, 1};
     const vk::Format format = vk::Format::eR8Uint;
     constexpr vk::DeviceSize subresourceOffset = 4096;
@@ -201,9 +194,9 @@ TEST(TensorInMemoryTransfer, UploadAndDownloadRespectImageSubresourceOffset) {
     info.shape = shape;
     info.format = format;
     info.tiling = Tiling::Linear;
-    dm.createTensor(guid, info);
+    dm.createTensor(id, info);
 
-    auto &tensor = dm.getTensorMut(guid);
+    auto &tensor = dm.getTensorMut(id);
     tensor.setup(ctx, memoryManager);
     tensor.allocateMemory(ctx);
 

--- a/src/tests/vgf_view_tests.cpp
+++ b/src/tests/vgf_view_tests.cpp
@@ -87,13 +87,13 @@ DataManager makeDataManagerWithTensor(const std::string &uid, std::vector<int64_
     info.debugName = uid;
     info.shape = std::move(shape);
     info.format = format;
-    dataManager.createTensor(Guid(uid), info);
+    dataManager.createTensor(TensorId{0}, info);
     return dataManager;
 }
 
 std::string mismatchMessageFor(const VgfView &view, const DataManager &dataManager, const TypedBinding &binding) {
     try {
-        view.resolveBindings(0, dataManager, std::vector<TypedBinding>{binding});
+        view.resolveBindings(0, dataManager, std::vector<TypedBinding>{binding}, {});
         return {};
     } catch (const std::runtime_error &error) {
         return error.what();
@@ -288,7 +288,7 @@ TEST(VgfView, ResolveBindingsReportsTensorShapeMismatchWithJsonLine) {
 
     auto view = VgfView::createVgfView(vgfPath.string());
     const auto dataManager = makeDataManagerWithTensor("inputTensor", {1, 16, 16, 3}, vk::Format::eR8Sint);
-    const TypedBinding binding{0, 0, Guid("inputTensor"), std::nullopt, vk::DescriptorType::eTensorARM};
+    const TypedBinding binding{0, 0, TensorId{0}, std::nullopt, vk::DescriptorType::eTensorARM};
 
     const auto message = mismatchMessageFor(view, dataManager, binding);
     ASSERT_FALSE(message.empty());
@@ -305,7 +305,7 @@ TEST(VgfView, ResolveBindingsReportsTensorFormatMismatchWithJsonLine) {
 
     auto view = VgfView::createVgfView(vgfPath.string());
     const auto dataManager = makeDataManagerWithTensor("outputTensor", {1, 8, 8, 4}, vk::Format::eR16Uint);
-    const TypedBinding binding{0, 1, Guid("outputTensor"), std::nullopt, vk::DescriptorType::eTensorARM};
+    const TypedBinding binding{0, 1, TensorId{0}, std::nullopt, vk::DescriptorType::eTensorARM};
 
     const auto message = mismatchMessageFor(view, dataManager, binding);
     ASSERT_FALSE(message.empty());

--- a/src/tests/vulkan_startup_tests.cpp
+++ b/src/tests/vulkan_startup_tests.cpp
@@ -66,12 +66,12 @@ void runShader(const ScenarioOptions &scenarioOptions) {
 
     BufferInfo info;
     std::vector<char> data;
-    auto guidA = Guid("inBufferA");
-    auto guidB = Guid("inBufferB");
-    auto guidOut = Guid("outBufferAdd");
+    const BufferId bufferA{0};
+    const BufferId bufferB{1};
+    const BufferId bufferOut{2};
 
-    const auto prepareBuffer = [&ctx, &dataManager](Guid guid, const std::vector<char> &values) {
-        auto &buffer = dataManager.getBufferMut(guid);
+    const auto prepareBuffer = [&ctx, &dataManager](BufferId id, const std::vector<char> &values) {
+        auto &buffer = dataManager.getBufferMut(id);
         buffer.setup(ctx);
         buffer.allocateMemory(ctx);
         buffer.fill(ctx, values.data(), values.size());
@@ -79,28 +79,20 @@ void runShader(const ScenarioOptions &scenarioOptions) {
     info.size = numElements * sizeof(float);
     data.resize(info.size);
     std::memcpy(data.data(), inDataA.data(), info.size);
-    dataManager.createBuffer(guidA, info);
-    prepareBuffer(guidA, data);
+    dataManager.createBuffer(bufferA, info);
+    prepareBuffer(bufferA, data);
     std::memcpy(data.data(), inDataB.data(), info.size);
-    dataManager.createBuffer(guidB, info);
-    prepareBuffer(guidB, data);
+    dataManager.createBuffer(bufferB, info);
+    prepareBuffer(bufferB, data);
     std::memset(data.data(), 0, info.size);
-    dataManager.createBuffer(guidOut, info);
-    prepareBuffer(guidOut, data);
+    dataManager.createBuffer(bufferOut, info);
+    prepareBuffer(bufferOut, data);
 
-    std::vector<TypedBinding> bindings;
-    TypedBinding binding;
-    binding.set = 0;
-    binding.id = 0;
-    binding.resourceRef = guidA;
-    binding.vkDescriptorType = vk::DescriptorType::eStorageBuffer;
-    bindings.push_back(binding);
-    binding.id = 1;
-    binding.resourceRef = guidB;
-    bindings.push_back(binding);
-    binding.id = 2;
-    binding.resourceRef = guidOut;
-    bindings.push_back(binding);
+    const std::vector<TypedBinding> bindings{
+        {0, 0, bufferA, std::nullopt, vk::DescriptorType::eStorageBuffer},
+        {0, 1, bufferB, std::nullopt, vk::DescriptorType::eStorageBuffer},
+        {0, 2, bufferOut, std::nullopt, vk::DescriptorType::eStorageBuffer},
+    };
 
     // Create compute orchestrator to run commands
     Compute compute(ctx);
@@ -121,7 +113,7 @@ void runShader(const ScenarioOptions &scenarioOptions) {
     compute.submitAndWaitOnFence();
 
     // Retrieve results
-    auto &outputBuf = dataManager.getBufferMut(guidOut);
+    auto &outputBuf = dataManager.getBufferMut(bufferOut);
     outputBuf.memoryManager()->downloadData(ctx, 0, info.size);
     float *outputPtr = static_cast<float *>(outputBuf.memoryManager()->mapStagingBufferMemory(0, info.size));
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -4,7 +4,7 @@
  */
 #pragma once
 
-#include "guid.hpp"
+#include "resource_id.hpp"
 #include "shader_stage.hpp"
 
 #include "vulkan/vulkan_raii.hpp"
@@ -142,7 +142,7 @@ struct GraphConstantInfo {
 struct TypedBinding {
     uint32_t set{};
     uint32_t id{};
-    Guid resourceRef;
+    MemoryResourceId resource;
     std::optional<uint32_t> lod;
     vk::DescriptorType vkDescriptorType{};
 };

--- a/src/vgf_view.cpp
+++ b/src/vgf_view.cpp
@@ -392,11 +392,10 @@ vgflib::DataView<uint8_t> VgfView::getConstantData(uint32_t constantIndex) const
     return constantTableDecoder->getConstant(constantIndex);
 }
 
-std::pair<std::vector<TypedBinding>, VgfView::MrtIndexes> VgfView::getBindings(uint32_t segmentIndex) const {
+std::vector<VgfView::VgfBinding> VgfView::getBindings(uint32_t segmentIndex) const {
     // Get segment binding infos
-    std::vector<TypedBinding> bindings;
+    std::vector<VgfBinding> bindings;
     auto descSetSize = sequenceTableDecoder->getSegmentDescriptorSetInfosSize(segmentIndex);
-    MrtIndexes mrtIndexes;
     // For each segment descriptor set entry:
     for (uint32_t descIdx = 0; descIdx < descSetSize; ++descIdx) {
         const uint32_t set = sequenceTableDecoder->getSegmentDescriptorSetIndex(segmentIndex, descIdx);
@@ -407,51 +406,41 @@ std::pair<std::vector<TypedBinding>, VgfView::MrtIndexes> VgfView::getBindings(u
             const auto expectedType = resourceTableDecoder->getDescriptorType(mrtIndex);
             const auto vkDescriptorType = getVkDescriptorType(expectedType.value_or(DESCRIPTOR_TYPE_UNKNOWN));
             auto bindingId = sequenceTableDecoder->getBindingSlotBinding(handle, slot);
-            auto guidStr = createResourceName(mrtIndex, resourceTableDecoder->getCategory(mrtIndex));
-            TypedBinding binding;
-            binding.set = set;
-            binding.id = bindingId;
-            binding.resourceRef = guidStr;
-            binding.vkDescriptorType = vkDescriptorType;
-            bindings.emplace_back(binding);
-            mrtIndexes.insert({{set, bindingId}, mrtIndex});
+            bindings.push_back({set, bindingId, mrtIndex, vkDescriptorType});
         }
     }
 
-    return {std::move(bindings), std::move(mrtIndexes)};
+    return bindings;
 }
 
-std::vector<TypedBinding> VgfView::resolveBindings(uint32_t segmentIndex, const DataManager &dataManager,
-                                                   const std::vector<TypedBinding> &externalBindings) const {
-
-    auto [bindings, mrtIndexes] = getBindings(segmentIndex);
-
+std::vector<TypedBinding>
+VgfView::resolveBindings(uint32_t segmentIndex, const DataManager &dataManager,
+                         const std::vector<TypedBinding> &externalBindings,
+                         const std::unordered_map<uint32_t, MemoryResourceId> &intermediates) const {
+    // Add model inputs and outputs to the MRT-index mapping created for intermediate resources.
+    auto resolvedResources = intermediates;
     for (const auto &externalBinding : externalBindings) {
-        if (!(dataManager.hasTensor(externalBinding.resourceRef) ||
-              dataManager.hasBuffer(externalBinding.resourceRef) ||
-              dataManager.hasImage(externalBinding.resourceRef))) {
-            throw std::runtime_error("No resource with this guid found");
-        }
-
-        const DataManagerResourceViewer resourceViewer(dataManager, externalBinding.resourceRef);
         const auto interfaceLookup = findModelInterfaceResource(*sequenceTableDecoder, externalBinding.id);
         if (!interfaceLookup.has_value()) {
             continue;
         }
 
-        for (auto &binding : bindings) {
-            auto mrtIndexSearch = mrtIndexes.find({binding.set, binding.id});
-            if (mrtIndexSearch == mrtIndexes.end()) {
-                throw std::runtime_error("No resource found in MRT Table");
-            }
-            const auto segmentMrtIndex = mrtIndexSearch->second;
+        const DataManagerResourceViewer resourceViewer(dataManager, externalBinding.resource);
+        const std::string_view direction = interfaceLookup->isOutput ? "output" : "input";
+        validateResource(resourceViewer, interfaceLookup->mrtIndex, direction, interfaceLookup->slotIndex);
+        resolvedResources.insert_or_assign(interfaceLookup->mrtIndex, externalBinding.resource);
+    }
 
-            if (segmentMrtIndex == interfaceLookup->mrtIndex) {
-                binding.resourceRef = externalBinding.resourceRef;
-                const std::string_view direction = interfaceLookup->isOutput ? "output" : "input";
-                validateResource(resourceViewer, segmentMrtIndex, direction, interfaceLookup->slotIndex);
-            }
+    // Resolve each segment descriptor binding's MRT index to its typed runtime resource ID.
+    const auto vgfBindings = getBindings(segmentIndex);
+    std::vector<TypedBinding> bindings;
+    bindings.reserve(vgfBindings.size());
+    for (const auto &vgfBinding : vgfBindings) {
+        const auto resource = resolvedResources.find(vgfBinding.resourceIndex);
+        if (resource == resolvedResources.end()) {
+            throw std::runtime_error("No resource found for VGF binding");
         }
+        bindings.push_back({vgfBinding.set, vgfBinding.id, resource->second, std::nullopt, vgfBinding.descriptorType});
     }
     return bindings;
 }
@@ -547,6 +536,7 @@ VgfResourceCreationResult VgfView::createIntermediateResources(IResourceCreator 
         auto resourceCategory = resourceTableDecoder->getCategory(resourceIndex);
         if (resourceCategory == vgflib::ResourceCategory::INTERMEDIATE) {
             const auto addResource = [&](MemoryResourceId id) {
+                result.intermediateResources.emplace(resourceIndex, id);
                 if (const auto aliasGroupId = resourceTableDecoder->getAliasGroupId(resourceIndex)) {
                     result.memoryGroups[*aliasGroupId].push_back(id);
                 }

--- a/src/vgf_view.hpp
+++ b/src/vgf_view.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace mlsdk::scenariorunner {
@@ -22,6 +23,9 @@ namespace mlsdk::scenariorunner {
 class DataManager;
 
 struct VgfResourceCreationResult {
+    // VGF model resource table index to the created runtime resource ID.
+    std::unordered_map<uint32_t, MemoryResourceId> intermediateResources;
+    // VGF alias group ID to its created runtime resource IDs. Ordered for deterministic group creation.
     std::map<uint32_t, std::vector<MemoryResourceId>> memoryGroups;
 };
 
@@ -49,16 +53,23 @@ class VgfView {
     vgflib::DataView<int64_t> getConstantShape(uint32_t constantIndex) const;
     vgflib::DataView<uint8_t> getConstantData(uint32_t constantIndex) const;
 
-    std::vector<TypedBinding> resolveBindings(uint32_t segmentIndex, const DataManager &dataManager,
-                                              const std::vector<TypedBinding> &externalBindings) const;
+    std::vector<TypedBinding>
+    resolveBindings(uint32_t segmentIndex, const DataManager &dataManager,
+                    const std::vector<TypedBinding> &externalBindings,
+                    const std::unordered_map<uint32_t, MemoryResourceId> &intermediates) const;
     std::optional<uint32_t> getModelResourceAliasGroup(uint32_t bindingId) const;
     VgfResourceCreationResult createIntermediateResources(IResourceCreator &creator) const;
 
   private:
-    // Map of (set, binding) to vgfMrtIndex
-    using MrtIndexes = std::map<std::tuple<uint32_t, uint32_t>, uint32_t>;
+    struct VgfBinding {
+        uint32_t set;
+        uint32_t id;
+        // Index into the VGF model resource table.
+        uint32_t resourceIndex;
+        vk::DescriptorType descriptorType;
+    };
 
-    std::pair<std::vector<TypedBinding>, MrtIndexes> getBindings(uint32_t segmentIndex) const;
+    std::vector<VgfBinding> getBindings(uint32_t segmentIndex) const;
     void validateResource(const IResourceViewer &resourceViewer, uint32_t vgfMrtIndex, std::string_view vgfDirection,
                           uint32_t vgfSlotIndex) const;
 


### PR DESCRIPTION
Store buffers, images, and tensors in DataManager by typed resource ID and resolve JSON UIDs at the Scenario boundary. Carry typed IDs through commands, barriers, pipelines, resource transfers, and result storage.

Track VGF intermediate resources by model resource table index and use that mapping to resolve segment bindings without generated resource UIDs. Keep VGF-created resources addressable by typed ID throughout setup, allocation, and dispatch.

This removes UID lookup and its temporary compatibility accessors from DataManager.

Change-Id: I756e263bf0a2bd051b8e447ff96f7b783c6d60bb