### PR TITLE
refactor: use typed IDs for barrier resources

### DIFF
--- a/src/compute.hpp
+++ b/src/compute.hpp
@@ -20,10 +20,10 @@ namespace mlsdk::scenariorunner {
 
 /// \brief Typed barriers
 struct DispatchBarrierData {
-    std::vector<Guid> memoryBarriers;
-    std::vector<Guid> imageBarriers;
-    std::vector<Guid> tensorBarriers;
-    std::vector<Guid> bufferBarriers;
+    std::vector<MemoryBarrierId> memoryBarriers;
+    std::vector<ImageBarrierId> imageBarriers;
+    std::vector<TensorBarrierId> tensorBarriers;
+    std::vector<BufferBarrierId> bufferBarriers;
 };
 
 /// \brief Typed resources

--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -10,6 +10,14 @@
 
 namespace mlsdk::scenariorunner {
 namespace {
+void fill(const BaseBarrierInfo &info, BaseBarrierData &data) {
+    data.debugName = info.debugName;
+    data.srcAccess = info.srcAccess;
+    data.dstAccess = info.dstAccess;
+    data.srcStages = info.srcStages;
+    data.dstStages = info.dstStages;
+}
+
 template <typename Resources, typename Id>
 decltype(auto) getResource(Resources &resources, Id id, const char *errorMessage) {
     const auto resource = resources.find(id);
@@ -36,20 +44,36 @@ void DataManager::createVgfView(DataGraphId id, const DataGraphInfo &info) {
     _vgfViews.insert({id, VgfView::createVgfView(info.src)});
 }
 
-void DataManager::createImageBarrier(Guid guid, const ImageBarrierData &data) {
-    _imageBarriers.insert({guid, VulkanImageBarrier(data)});
+void DataManager::createImageBarrier(ImageBarrierId id, const ImageBarrierInfo &info) {
+    ImageBarrierData data;
+    fill(info, data);
+    data.oldLayout = info.oldLayout;
+    data.newLayout = info.newLayout;
+    data.image = getImage(info.image).image();
+    data.imageRange = info.range;
+    _imageBarriers.insert({id, VulkanImageBarrier(data)});
 }
 
-void DataManager::createTensorBarrier(Guid guid, const TensorBarrierData &data) {
-    _tensorBarriers.insert({guid, VulkanTensorBarrier(data)});
+void DataManager::createTensorBarrier(TensorBarrierId id, const TensorBarrierInfo &info) {
+    TensorBarrierData data;
+    fill(info, data);
+    data.tensor = getTensor(info.tensor).tensor();
+    _tensorBarriers.insert({id, VulkanTensorBarrier(data)});
 }
 
-void DataManager::createMemoryBarrier(Guid guid, const MemoryBarrierData &data) {
-    _memoryBarriers.insert({guid, VulkanMemoryBarrier(data)});
+void DataManager::createMemoryBarrier(MemoryBarrierId id, const MemoryBarrierInfo &info) {
+    MemoryBarrierData data;
+    fill(info, data);
+    _memoryBarriers.insert({id, VulkanMemoryBarrier(data)});
 }
 
-void DataManager::createBufferBarrier(Guid guid, const BufferBarrierData &data) {
-    _bufferBarriers.insert({guid, VulkanBufferBarrier(data)});
+void DataManager::createBufferBarrier(BufferBarrierId id, const BufferBarrierInfo &info) {
+    BufferBarrierData data;
+    fill(info, data);
+    data.buffer = getBuffer(info.buffer).buffer();
+    data.offset = info.offset;
+    data.size = info.size;
+    _bufferBarriers.insert({id, VulkanBufferBarrier(data)});
 }
 
 void DataManager::createRawData(RawDataId id, const RawDataInfo &info) {
@@ -64,13 +88,19 @@ bool DataManager::hasImage(ImageId id) const { return _images.find(id) != _image
 
 bool DataManager::hasRawData(RawDataId id) const { return _rawData.find(id) != _rawData.end(); }
 
-bool DataManager::hasImageBarrier(Guid guid) const { return _imageBarriers.find(guid) != _imageBarriers.end(); }
+bool DataManager::hasImageBarrier(ImageBarrierId id) const { return _imageBarriers.find(id) != _imageBarriers.end(); }
 
-bool DataManager::hasMemoryBarrier(Guid guid) const { return _memoryBarriers.find(guid) != _memoryBarriers.end(); }
+bool DataManager::hasMemoryBarrier(MemoryBarrierId id) const {
+    return _memoryBarriers.find(id) != _memoryBarriers.end();
+}
 
-bool DataManager::hasTensorBarrier(Guid guid) const { return _tensorBarriers.find(guid) != _tensorBarriers.end(); }
+bool DataManager::hasTensorBarrier(TensorBarrierId id) const {
+    return _tensorBarriers.find(id) != _tensorBarriers.end();
+}
 
-bool DataManager::hasBufferBarrier(Guid guid) const { return _bufferBarriers.find(guid) != _bufferBarriers.end(); }
+bool DataManager::hasBufferBarrier(BufferBarrierId id) const {
+    return _bufferBarriers.find(id) != _bufferBarriers.end();
+}
 
 uint32_t DataManager::numBuffers() const { return static_cast<uint32_t>(_buffers.size()); }
 
@@ -104,32 +134,32 @@ const VgfView &DataManager::getVgfView(DataGraphId id) const {
     return _vgfViews.at(id);
 }
 
-const VulkanImageBarrier &DataManager::getImageBarrier(const Guid &guid) const {
-    if (_imageBarriers.find(guid) == _imageBarriers.end()) {
+const VulkanImageBarrier &DataManager::getImageBarrier(ImageBarrierId id) const {
+    if (_imageBarriers.find(id) == _imageBarriers.end()) {
         throw std::runtime_error("Image Barrier not found");
     }
-    return _imageBarriers.at(guid);
+    return _imageBarriers.at(id);
 }
 
-const VulkanTensorBarrier &DataManager::getTensorBarrier(const Guid &guid) const {
-    if (_tensorBarriers.find(guid) == _tensorBarriers.end()) {
+const VulkanTensorBarrier &DataManager::getTensorBarrier(TensorBarrierId id) const {
+    if (_tensorBarriers.find(id) == _tensorBarriers.end()) {
         throw std::runtime_error("Tensor Barrier not found");
     }
-    return _tensorBarriers.at(guid);
+    return _tensorBarriers.at(id);
 }
 
-const VulkanMemoryBarrier &DataManager::getMemoryBarrier(const Guid &guid) const {
-    if (_memoryBarriers.find(guid) == _memoryBarriers.end()) {
+const VulkanMemoryBarrier &DataManager::getMemoryBarrier(MemoryBarrierId id) const {
+    if (_memoryBarriers.find(id) == _memoryBarriers.end()) {
         throw std::runtime_error("Memory Barrier not found");
     }
-    return _memoryBarriers.at(guid);
+    return _memoryBarriers.at(id);
 }
 
-const VulkanBufferBarrier &DataManager::getBufferBarrier(const Guid &guid) const {
-    if (_bufferBarriers.find(guid) == _bufferBarriers.end()) {
+const VulkanBufferBarrier &DataManager::getBufferBarrier(BufferBarrierId id) const {
+    if (_bufferBarriers.find(id) == _bufferBarriers.end()) {
         throw std::runtime_error("Buffer Barrier not found");
     }
-    return _bufferBarriers.at(guid);
+    return _bufferBarriers.at(id);
 }
 
 } // namespace mlsdk::scenariorunner

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -26,19 +26,19 @@ class DataManager {
     void createImage(ImageId id, ImageInfo &&info);
     void createRawData(RawDataId id, const RawDataInfo &info);
     void createVgfView(DataGraphId id, const DataGraphInfo &info);
-    void createImageBarrier(Guid guid, const ImageBarrierData &data);
-    void createTensorBarrier(Guid guid, const TensorBarrierData &data);
-    void createMemoryBarrier(Guid guid, const MemoryBarrierData &data);
-    void createBufferBarrier(Guid guid, const BufferBarrierData &data);
+    void createImageBarrier(ImageBarrierId id, const ImageBarrierInfo &info);
+    void createTensorBarrier(TensorBarrierId id, const TensorBarrierInfo &info);
+    void createMemoryBarrier(MemoryBarrierId id, const MemoryBarrierInfo &info);
+    void createBufferBarrier(BufferBarrierId id, const BufferBarrierInfo &info);
 
     bool hasBuffer(BufferId id) const;
     bool hasTensor(TensorId id) const;
     bool hasImage(ImageId id) const;
     bool hasRawData(RawDataId id) const;
-    bool hasImageBarrier(Guid guid) const;
-    bool hasTensorBarrier(Guid guid) const;
-    bool hasMemoryBarrier(Guid guid) const;
-    bool hasBufferBarrier(Guid guid) const;
+    bool hasImageBarrier(ImageBarrierId id) const;
+    bool hasTensorBarrier(TensorBarrierId id) const;
+    bool hasMemoryBarrier(MemoryBarrierId id) const;
+    bool hasBufferBarrier(BufferBarrierId id) const;
 
     Buffer &getBufferMut(BufferId id);
     Tensor &getTensorMut(TensorId id);
@@ -49,10 +49,10 @@ class DataManager {
     const Image &getImage(ImageId id) const;
     const RawData &getRawData(RawDataId id) const;
     const VgfView &getVgfView(DataGraphId id) const;
-    const VulkanImageBarrier &getImageBarrier(const Guid &guid) const;
-    const VulkanMemoryBarrier &getMemoryBarrier(const Guid &guid) const;
-    const VulkanBufferBarrier &getBufferBarrier(const Guid &guid) const;
-    const VulkanTensorBarrier &getTensorBarrier(const Guid &guid) const;
+    const VulkanImageBarrier &getImageBarrier(ImageBarrierId id) const;
+    const VulkanMemoryBarrier &getMemoryBarrier(MemoryBarrierId id) const;
+    const VulkanBufferBarrier &getBufferBarrier(BufferBarrierId id) const;
+    const VulkanTensorBarrier &getTensorBarrier(TensorBarrierId id) const;
 
     uint32_t numBuffers() const;
     uint32_t numTensors() const;
@@ -64,9 +64,9 @@ class DataManager {
     std::unordered_map<ImageId, Image> _images;
     std::unordered_map<RawDataId, RawData> _rawData;
     std::unordered_map<DataGraphId, VgfView> _vgfViews;
-    std::unordered_map<Guid, VulkanImageBarrier> _imageBarriers;
-    std::unordered_map<Guid, VulkanMemoryBarrier> _memoryBarriers;
-    std::unordered_map<Guid, VulkanBufferBarrier> _bufferBarriers;
-    std::unordered_map<Guid, VulkanTensorBarrier> _tensorBarriers;
+    std::unordered_map<ImageBarrierId, VulkanImageBarrier> _imageBarriers;
+    std::unordered_map<MemoryBarrierId, VulkanMemoryBarrier> _memoryBarriers;
+    std::unordered_map<BufferBarrierId, VulkanBufferBarrier> _bufferBarriers;
+    std::unordered_map<TensorBarrierId, VulkanTensorBarrier> _tensorBarriers;
 };
 } // namespace mlsdk::scenariorunner

--- a/src/resource_id.hpp
+++ b/src/resource_id.hpp
@@ -34,6 +34,10 @@ struct RawDataIdTag;
 struct DataGraphIdTag;
 struct GraphConstantResourceIdTag;
 struct MemoryGroupIdTag;
+struct ImageBarrierIdTag;
+struct BufferBarrierIdTag;
+struct TensorBarrierIdTag;
+struct MemoryBarrierIdTag;
 
 using BufferId = ResourceId<BufferIdTag>;
 using ImageId = ResourceId<ImageIdTag>;
@@ -43,11 +47,16 @@ using RawDataId = ResourceId<RawDataIdTag>;
 using DataGraphId = ResourceId<DataGraphIdTag>;
 using GraphConstantResourceId = ResourceId<GraphConstantResourceIdTag>;
 using MemoryGroupId = ResourceId<MemoryGroupIdTag>;
+using ImageBarrierId = ResourceId<ImageBarrierIdTag>;
+using BufferBarrierId = ResourceId<BufferBarrierIdTag>;
+using TensorBarrierId = ResourceId<TensorBarrierIdTag>;
+using MemoryBarrierId = ResourceId<MemoryBarrierIdTag>;
 
 using MemoryResourceId = std::variant<BufferId, ImageId, TensorId>;
 
 using TypedResourceId =
-    std::variant<BufferId, ImageId, TensorId, ShaderId, RawDataId, DataGraphId, GraphConstantResourceId>;
+    std::variant<BufferId, ImageId, TensorId, ShaderId, RawDataId, DataGraphId, GraphConstantResourceId, ImageBarrierId,
+                 BufferBarrierId, TensorBarrierId, MemoryBarrierId>;
 
 } // namespace mlsdk::scenariorunner
 

--- a/src/resource_manager.cpp
+++ b/src/resource_manager.cpp
@@ -57,6 +57,31 @@ GraphConstantResourceId ResourceManager::addGraphConstant(GraphConstantInfo &&in
     return addResource<GraphConstantResourceId>(_graphConstants, std::move(info));
 }
 
+ImageBarrierId ResourceManager::addImageBarrier(const ImageBarrierInfo &info) {
+    return addResource<ImageBarrierId>(_imageBarriers, info);
+}
+ImageBarrierId ResourceManager::addImageBarrier(ImageBarrierInfo &&info) {
+    return addResource<ImageBarrierId>(_imageBarriers, std::move(info));
+}
+BufferBarrierId ResourceManager::addBufferBarrier(const BufferBarrierInfo &info) {
+    return addResource<BufferBarrierId>(_bufferBarriers, info);
+}
+BufferBarrierId ResourceManager::addBufferBarrier(BufferBarrierInfo &&info) {
+    return addResource<BufferBarrierId>(_bufferBarriers, std::move(info));
+}
+TensorBarrierId ResourceManager::addTensorBarrier(const TensorBarrierInfo &info) {
+    return addResource<TensorBarrierId>(_tensorBarriers, info);
+}
+TensorBarrierId ResourceManager::addTensorBarrier(TensorBarrierInfo &&info) {
+    return addResource<TensorBarrierId>(_tensorBarriers, std::move(info));
+}
+MemoryBarrierId ResourceManager::addMemoryBarrier(const MemoryBarrierInfo &info) {
+    return addResource<MemoryBarrierId>(_memoryBarriers, info);
+}
+MemoryBarrierId ResourceManager::addMemoryBarrier(MemoryBarrierInfo &&info) {
+    return addResource<MemoryBarrierId>(_memoryBarriers, std::move(info));
+}
+
 const BufferInfo &ResourceManager::get(BufferId id) const { return getResource(_buffers, id); }
 
 const ImageInfo &ResourceManager::get(ImageId id) const { return getResource(_images, id); }
@@ -72,5 +97,10 @@ const DataGraphInfo &ResourceManager::get(DataGraphId id) const { return getReso
 const GraphConstantInfo &ResourceManager::get(GraphConstantResourceId id) const {
     return getResource(_graphConstants, id);
 }
+
+const ImageBarrierInfo &ResourceManager::get(ImageBarrierId id) const { return getResource(_imageBarriers, id); }
+const BufferBarrierInfo &ResourceManager::get(BufferBarrierId id) const { return getResource(_bufferBarriers, id); }
+const TensorBarrierInfo &ResourceManager::get(TensorBarrierId id) const { return getResource(_tensorBarriers, id); }
+const MemoryBarrierInfo &ResourceManager::get(MemoryBarrierId id) const { return getResource(_memoryBarriers, id); }
 
 } // namespace mlsdk::scenariorunner

--- a/src/resource_manager.hpp
+++ b/src/resource_manager.hpp
@@ -28,6 +28,14 @@ class ResourceManager {
     DataGraphId addDataGraph(DataGraphInfo &&info);
     GraphConstantResourceId addGraphConstant(const GraphConstantInfo &info);
     GraphConstantResourceId addGraphConstant(GraphConstantInfo &&info);
+    ImageBarrierId addImageBarrier(const ImageBarrierInfo &info);
+    ImageBarrierId addImageBarrier(ImageBarrierInfo &&info);
+    BufferBarrierId addBufferBarrier(const BufferBarrierInfo &info);
+    BufferBarrierId addBufferBarrier(BufferBarrierInfo &&info);
+    TensorBarrierId addTensorBarrier(const TensorBarrierInfo &info);
+    TensorBarrierId addTensorBarrier(TensorBarrierInfo &&info);
+    MemoryBarrierId addMemoryBarrier(const MemoryBarrierInfo &info);
+    MemoryBarrierId addMemoryBarrier(MemoryBarrierInfo &&info);
 
     const BufferInfo &get(BufferId id) const;
     const ImageInfo &get(ImageId id) const;
@@ -36,6 +44,10 @@ class ResourceManager {
     const RawDataInfo &get(RawDataId id) const;
     const DataGraphInfo &get(DataGraphId id) const;
     const GraphConstantInfo &get(GraphConstantResourceId id) const;
+    const ImageBarrierInfo &get(ImageBarrierId id) const;
+    const BufferBarrierInfo &get(BufferBarrierId id) const;
+    const TensorBarrierInfo &get(TensorBarrierId id) const;
+    const MemoryBarrierInfo &get(MemoryBarrierId id) const;
 
   private:
     std::vector<BufferInfo> _buffers;
@@ -45,6 +57,10 @@ class ResourceManager {
     std::vector<RawDataInfo> _rawData;
     std::vector<DataGraphInfo> _dataGraphs;
     std::vector<GraphConstantInfo> _graphConstants;
+    std::vector<ImageBarrierInfo> _imageBarriers;
+    std::vector<BufferBarrierInfo> _bufferBarriers;
+    std::vector<TensorBarrierInfo> _tensorBarriers;
+    std::vector<MemoryBarrierInfo> _memoryBarriers;
 };
 
 } // namespace mlsdk::scenariorunner

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -377,51 +377,47 @@ Id resolveResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceId
 MemoryResourceId resolveMemoryResourceId(const std::unordered_map<Guid, TypedResourceId> &resourceIds,
                                          const Guid &guid);
 
-void fill(const BaseBarrierDesc &barrier, BaseBarrierData &data) {
-    data.debugName = barrier.guidStr;
-    data.srcAccess = barrier.srcAccess;
-    data.dstAccess = barrier.dstAccess;
-    data.srcStages = barrier.srcStages;
-    data.dstStages = barrier.dstStages;
+void fill(const BaseBarrierDesc &barrier, BaseBarrierInfo &info) {
+    info.debugName = barrier.guidStr;
+    info.srcAccess = barrier.srcAccess;
+    info.dstAccess = barrier.dstAccess;
+    info.srcStages = barrier.srcStages;
+    info.dstStages = barrier.dstStages;
 }
 
-struct BarrierDataFactory {
-    const DataManager &_dataManager;
+struct BarrierInfoFactory {
     const std::unordered_map<Guid, TypedResourceId> &_resourceIds;
 
-    ImageBarrierData createInfo(const ImageBarrierDesc &imageBarrier) const {
-        const auto image = resolveResourceId<ImageId>(_resourceIds, imageBarrier.imageResource, "Image");
-        ImageBarrierData data{};
-        fill(imageBarrier, data);
-        data.oldLayout = imageBarrier.oldLayout;
-        data.newLayout = imageBarrier.newLayout;
-        data.image = _dataManager.getImage(image).image();
-        data.imageRange = imageBarrier.imageRange;
-        return data;
+    ImageBarrierInfo createInfo(const ImageBarrierDesc &imageBarrier) const {
+        ImageBarrierInfo info{};
+        fill(imageBarrier, info);
+        info.image = resolveResourceId<ImageId>(_resourceIds, imageBarrier.imageResource, "Image");
+        info.oldLayout = imageBarrier.oldLayout;
+        info.newLayout = imageBarrier.newLayout;
+        info.range = imageBarrier.imageRange;
+        return info;
     }
 
-    MemoryBarrierData createInfo(const MemoryBarrierDesc &memoryBarrier) const {
-        MemoryBarrierData data{};
-        fill(memoryBarrier, data);
-        return data;
+    MemoryBarrierInfo createInfo(const MemoryBarrierDesc &memoryBarrier) const {
+        MemoryBarrierInfo info{};
+        fill(memoryBarrier, info);
+        return info;
     }
 
-    TensorBarrierData createInfo(const TensorBarrierDesc &tensorBarrier) const {
-        const auto tensor = resolveResourceId<TensorId>(_resourceIds, tensorBarrier.tensorResource, "Tensor");
-        TensorBarrierData data{};
-        fill(tensorBarrier, data);
-        data.tensor = _dataManager.getTensor(tensor).tensor();
-        return data;
+    TensorBarrierInfo createInfo(const TensorBarrierDesc &tensorBarrier) const {
+        TensorBarrierInfo info{};
+        fill(tensorBarrier, info);
+        info.tensor = resolveResourceId<TensorId>(_resourceIds, tensorBarrier.tensorResource, "Tensor");
+        return info;
     }
 
-    BufferBarrierData createInfo(const BufferBarrierDesc &bufferBarrier) const {
-        const auto buffer = resolveResourceId<BufferId>(_resourceIds, bufferBarrier.bufferResource, "Buffer");
-        BufferBarrierData data{};
-        fill(bufferBarrier, data);
-        data.offset = bufferBarrier.offset;
-        data.size = bufferBarrier.size;
-        data.buffer = _dataManager.getBuffer(buffer).buffer();
-        return data;
+    BufferBarrierInfo createInfo(const BufferBarrierDesc &bufferBarrier) const {
+        BufferBarrierInfo info{};
+        fill(bufferBarrier, info);
+        info.buffer = resolveResourceId<BufferId>(_resourceIds, bufferBarrier.bufferResource, "Buffer");
+        info.offset = bufferBarrier.offset;
+        info.size = bufferBarrier.size;
+        return info;
     }
 };
 
@@ -673,32 +669,19 @@ struct CommandDataFactory {
     DispatchBarrierData createData(const DispatchBarrierDesc &dispatchBarrier) {
         DispatchBarrierData data;
         for (const auto &ref : dispatchBarrier.bufferBarriersRef) {
-            if (_dataManager.hasBufferBarrier(ref)) {
-                data.bufferBarriers.push_back(ref);
-            } else {
-                throw std::runtime_error("Cannot find Buffer memory barrier");
-            }
+            data.bufferBarriers.push_back(
+                resolveResourceId<BufferBarrierId>(_resourceIds, Guid(ref), "Buffer barrier"));
         }
         for (const auto &ref : dispatchBarrier.imageBarriersRef) {
-            if (_dataManager.hasImageBarrier(ref)) {
-                data.imageBarriers.push_back(ref);
-            } else {
-                throw std::runtime_error("Cannot find Image memory barrier");
-            }
+            data.imageBarriers.push_back(resolveResourceId<ImageBarrierId>(_resourceIds, Guid(ref), "Image barrier"));
         }
         for (const auto &ref : dispatchBarrier.memoryBarriersRef) {
-            if (_dataManager.hasMemoryBarrier(ref)) {
-                data.memoryBarriers.push_back(ref);
-            } else {
-                throw std::runtime_error("Cannot find Memory barrier");
-            }
+            data.memoryBarriers.push_back(
+                resolveResourceId<MemoryBarrierId>(_resourceIds, Guid(ref), "Memory barrier"));
         }
         for (const auto &ref : dispatchBarrier.tensorBarriersRef) {
-            if (_dataManager.hasTensorBarrier(ref)) {
-                data.tensorBarriers.push_back(ref);
-            } else {
-                throw std::runtime_error("Cannot find Tensor memory barrier");
-            }
+            data.tensorBarriers.push_back(
+                resolveResourceId<TensorBarrierId>(_resourceIds, Guid(ref), "Tensor barrier"));
         }
         return data;
     }
@@ -1073,28 +1056,32 @@ void Scenario::setupResources() {
     vgfResourceCreator.setupCreatedTensorResources();
 
     // Setup barrier resource info, these depend on other resources
-    BarrierDataFactory barrierDataFactory{_dataManager, _resourceIds};
+    BarrierInfoFactory barrierInfoFactory{_resourceIds};
     for (const auto &resource : _scenarioSpec.resources) {
         switch (resource->resourceType) {
         case ResourceType::ImageBarrier: {
             const auto &imageBarrier = reinterpret_cast<const std::unique_ptr<ImageBarrierDesc> &>(resource);
-            const auto data = barrierDataFactory.createInfo(*imageBarrier);
-            _dataManager.createImageBarrier(resource->guid, data);
+            const auto id = _resources.addImageBarrier(barrierInfoFactory.createInfo(*imageBarrier));
+            _resourceIds.emplace(resource->guid, id);
+            _dataManager.createImageBarrier(id, _resources.get(id));
         } break;
         case ResourceType::MemoryBarrier: {
             const auto &memoryBarrier = reinterpret_cast<const std::unique_ptr<MemoryBarrierDesc> &>(resource);
-            const auto data = barrierDataFactory.createInfo(*memoryBarrier);
-            _dataManager.createMemoryBarrier(resource->guid, data);
+            const auto id = _resources.addMemoryBarrier(barrierInfoFactory.createInfo(*memoryBarrier));
+            _resourceIds.emplace(resource->guid, id);
+            _dataManager.createMemoryBarrier(id, _resources.get(id));
         } break;
         case ResourceType::TensorBarrier: {
             const auto &tensorBarrier = reinterpret_cast<const std::unique_ptr<TensorBarrierDesc> &>(resource);
-            const auto data = barrierDataFactory.createInfo(*tensorBarrier);
-            _dataManager.createTensorBarrier(resource->guid, data);
+            const auto id = _resources.addTensorBarrier(barrierInfoFactory.createInfo(*tensorBarrier));
+            _resourceIds.emplace(resource->guid, id);
+            _dataManager.createTensorBarrier(id, _resources.get(id));
         } break;
         case ResourceType::BufferBarrier: {
             const auto &bufferBarrier = reinterpret_cast<const std::unique_ptr<BufferBarrierDesc> &>(resource);
-            const auto data = barrierDataFactory.createInfo(*bufferBarrier);
-            _dataManager.createBufferBarrier(resource->guid, data);
+            const auto id = _resources.addBufferBarrier(barrierInfoFactory.createInfo(*bufferBarrier));
+            _resourceIds.emplace(resource->guid, id);
+            _dataManager.createBufferBarrier(id, _resources.get(id));
         } break;
         default:
             // Skip the other types of resources

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -187,4 +187,31 @@ struct ShaderInfo {
     std::vector<std::string> includeDirs;
 };
 
+struct BaseBarrierInfo {
+    std::string debugName;
+    MemoryAccess srcAccess{MemoryAccess::Unknown};
+    MemoryAccess dstAccess{MemoryAccess::Unknown};
+    std::vector<PipelineStage> srcStages{PipelineStage::All};
+    std::vector<PipelineStage> dstStages{PipelineStage::All};
+};
+
+struct ImageBarrierInfo : BaseBarrierInfo {
+    ImageId image{0};
+    ImageLayout oldLayout{ImageLayout::Undefined};
+    ImageLayout newLayout{ImageLayout::Undefined};
+    SubresourceRange range;
+};
+
+struct BufferBarrierInfo : BaseBarrierInfo {
+    BufferId buffer{0};
+    uint64_t offset{};
+    uint64_t size{};
+};
+
+struct TensorBarrierInfo : BaseBarrierInfo {
+    TensorId tensor{0};
+};
+
+struct MemoryBarrierInfo : BaseBarrierInfo {};
+
 } // namespace mlsdk::scenariorunner


### PR DESCRIPTION
Store barrier information in ResourceManager and identify runtime barriers with type-safe IDs. Keep GUID translation within the JSON scenario setup path.


Change-Id: I34b4c9a80f3aa2e1f4d1f37b6994369db34c2449