### PR TITLE
refactor: add in-memory upload/download for image

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -462,7 +462,6 @@ void Image::fillFromDescription(const Context &ctx, const ImageDesc &desc) {
         data.resize(baseDataSize());
         std::fill_n(data.begin(), baseDataSize(), 0);
     }
-
     // D32S8 stencil discard case
     if ((_dataType == vk::Format::eR32Sfloat || _dataType == vk::Format::eD32Sfloat) &&
         fileFormat == vk::Format::eD32SfloatS8Uint) {
@@ -485,22 +484,25 @@ void Image::fillFromDescription(const Context &ctx, const ImageDesc &desc) {
         }
         data = std::move(bodgeData);
     }
+    uploadData(ctx, data.data(), data.size(), mipmapsFromFile);
+}
 
+void Image::uploadData(const Context &ctx, const void *data, size_t size, uint32_t mipLevels) {
     const auto elementSize = elementSizeFromVkFormat(_dataType);
     const auto baseWidth = static_cast<uint32_t>(_imageInfo.shape[1]);
     const auto baseHeight = static_cast<uint32_t>(_imageInfo.shape[2]);
     const auto depth = static_cast<uint32_t>(_imageInfo.shape[3]);
-    const auto copiedMipLevels = std::min(mipmapsFromFile, _imageInfo.mips);
-    const uint64_t requiredDataSize = mipmapsFromFile > 1 ? mipChainDataSize(copiedMipLevels) : baseDataSize();
-    const bool requireExactSize = mipmapsFromFile <= 1;
-    if (data.size() < requiredDataSize || (requireExactSize && data.size() != requiredDataSize)) {
-        throw std::runtime_error(
-            "Expected image input size " + std::string(requireExactSize ? "to be " : "to be at least ") +
-            std::to_string(requiredDataSize) + ", but got " + std::to_string(data.size()) + " instead");
+    const auto copiedMipLevels = std::min(mipLevels, _imageInfo.mips);
+    const uint64_t requiredDataSize = mipLevels > 1 ? mipChainDataSize(copiedMipLevels) : baseDataSize();
+    const bool requireExactSize = mipLevels <= 1;
+    if (size < requiredDataSize || (requireExactSize && size != requiredDataSize)) {
+        throw std::runtime_error("Expected image input size " +
+                                 std::string(requireExactSize ? "to be " : "to be at least ") +
+                                 std::to_string(requiredDataSize) + ", but got " + std::to_string(size) + " instead");
     }
 
-    void *pBufferDeviceMemory = _memoryManager->mapStagingBufferMemory(0, data.size());
-    std::memcpy(pBufferDeviceMemory, data.data(), data.size());
+    void *pBufferDeviceMemory = _memoryManager->mapStagingBufferMemory(0, size);
+    std::memcpy(pBufferDeviceMemory, data, size);
     _memoryManager->unmapStagingBufferMemory();
 
     // Create Image barrier
@@ -535,7 +537,7 @@ void Image::fillFromDescription(const Context &ctx, const ImageDesc &desc) {
 
     cmdBuffer.pipelineBarrier2(vk::DependencyInfo((vk::DependencyFlags)0, memoryBarrier, {}, imageBarrier));
 
-    if (mipmapsFromFile > 1) {
+    if (mipLevels > 1) {
         // All mip levels are present in the file data — copy each level directly from the buffer.
         uint64_t bufferOffset = 0;
         auto mipWidth = baseWidth;
@@ -697,6 +699,33 @@ void Image::fillFromDescription(const Context &ctx, const ImageDesc &desc) {
     }
 }
 
+void Image::upload(const Context &ctx, const ImageDataView &imageData) {
+    if (imageData.shape != shape()) {
+        throw std::runtime_error("Image::upload: provided shape does not match image shape");
+    }
+    if (imageData.format.has_value() && imageData.format.value() != dataType()) {
+        throw std::runtime_error("Image::upload: provided format does not match image format");
+    }
+    if (imageData.mipLevels == 0 || imageData.mipLevels > _imageInfo.mips) {
+        throw std::runtime_error("Image::upload: mipLevels must be between 1 and " + std::to_string(_imageInfo.mips));
+    }
+    const auto expectedSize = mipChainDataSize(imageData.mipLevels);
+    if (imageData.size != expectedSize) {
+        throw std::runtime_error("Image::upload: expected packed mip data size to be " + std::to_string(expectedSize) +
+                                 ", but got " + std::to_string(imageData.size));
+    }
+    uploadData(ctx, imageData.data, imageData.size, imageData.mipLevels);
+}
+
+ImageData Image::download(const Context &ctx) {
+    ImageData imageData;
+    imageData.data = getImageData(ctx);
+    imageData.shape = shape();
+    imageData.mipLevels = 1;
+    imageData.format = dataType();
+    return imageData;
+}
+
 std::vector<char> Image::getImageData(const Context &ctx) {
     const auto originalLayout = _targetLayout;
     if (_targetLayout != vk::ImageLayout::eGeneral) {
@@ -711,19 +740,19 @@ std::vector<char> Image::getImageData(const Context &ctx) {
     vk::raii::CommandBuffer cmdBuffer = std::move(ctx.device().allocateCommandBuffers(cmdBufferAllocInfo).front());
     const vk::CommandBufferBeginInfo cmdBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
     cmdBuffer.begin(cmdBufferBeginInfo);
+
     vk::BufferImageCopy region{};
-    const vk::Extent3D extent(static_cast<uint32_t>(_imageInfo.shape[1]), static_cast<uint32_t>(_imageInfo.shape[2]),
-                              static_cast<uint32_t>(_imageInfo.shape[3]));
-    const vk::Offset3D offset(0, 0, 0);
     region.bufferOffset = 0;
     region.bufferRowLength = 0;
     region.bufferImageHeight = 0;
-    region.imageSubresource.aspectMask = getImageAspectMaskForVkFormat(_imageInfo.format);
+    region.imageSubresource.aspectMask = getImageAspectMaskForVkFormat(_dataType);
     region.imageSubresource.mipLevel = 0;
     region.imageSubresource.baseArrayLayer = 0;
     region.imageSubresource.layerCount = 1;
-    region.imageOffset = offset;
-    region.imageExtent = extent;
+    region.imageOffset = vk::Offset3D(0, 0, 0);
+    region.imageExtent =
+        vk::Extent3D(static_cast<uint32_t>(_imageInfo.shape[1]), static_cast<uint32_t>(_imageInfo.shape[2]),
+                     static_cast<uint32_t>(_imageInfo.shape[3]));
 
     cmdBuffer.copyImageToBuffer(_image, vk::ImageLayout::eGeneral, _memoryManager->getStagingBuffer(), {region});
     cmdBuffer.end();

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "context.hpp"
+#include "resource_data.hpp"
 #include "resource_desc.hpp"
 #include "types.hpp"
 #include "vulkan_memory_manager.hpp"
@@ -67,6 +68,14 @@ class Image {
 
     void fillFromDescription(const Context &ctx, const ImageDesc &desc);
 
+    /// \brief Upload packed image data (host -> device)
+    /// Validates byte size, shape, mip count, and (when provided) format. Any configured
+    /// mip levels not supplied by the payload are generated from the supplied levels.
+    void upload(const Context &ctx, const ImageDataView &data);
+
+    /// \brief Download packed base-mip image data (device -> host)
+    ImageData download(const Context &ctx);
+
     void store(const Context &ctx, const std::string &filename);
 
     bool isSampled() const;
@@ -79,6 +88,7 @@ class Image {
     const ImageInfo &getInfo() const { return _imageInfo; }
 
   private:
+    void uploadData(const Context &ctx, const void *data, size_t size, uint32_t mipLevels);
     std::vector<char> getImageData(const Context &ctx);
     uint32_t getFormatMaxMipLevels(const Context &ctx, vk::ImageTiling tiling, vk::ImageUsageFlags usageFlags);
 

--- a/src/resource_data.hpp
+++ b/src/resource_data.hpp
@@ -34,4 +34,19 @@ struct TensorData {
     std::optional<vk::Format> format{std::nullopt};
 };
 
+struct ImageDataView {
+    const void *data{nullptr};
+    size_t size{0};
+    std::vector<int64_t> shape;
+    std::optional<vk::Format> format{std::nullopt};
+    uint32_t mipLevels{1};
+};
+
+struct ImageData {
+    std::vector<char> data;
+    std::vector<int64_t> shape;
+    std::optional<vk::Format> format{std::nullopt};
+    uint32_t mipLevels{1};
+};
+
 } // namespace mlsdk::scenariorunner

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(ScenarioRunnerTests
   guid_tests.cpp
   group_manager_tests.cpp
   image_formats_tests.cpp
+  image_tests.cpp
   iresource_tests.cpp
   json_parser_tests.cpp
   json_writer_tests.cpp

--- a/src/tests/image_tests.cpp
+++ b/src/tests/image_tests.cpp
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "data_manager.hpp"
+#include "image.hpp"
+#include "resource_data.hpp"
+#include "scenario.hpp"
+
+#include <numeric>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace mlsdk::scenariorunner;
+
+namespace {
+Image &prepareImage(Context &ctx, DataManager &dataManager, ImageId id, const std::vector<int64_t> &shape,
+                    vk::Format format, uint32_t mipLevels = 1) {
+    ImageInfo info{};
+    info.debugName = "test_image";
+    info.shape = shape;
+    info.format = format;
+    info.targetFormat = format;
+    info.isInput = true;
+    info.isSampled = true;
+    info.mips = mipLevels;
+    info.tiling = mipLevels > 1 ? Tiling::Optimal : Tiling::Linear;
+
+    dataManager.createImage(id, info);
+    auto &image = dataManager.getImageMut(id);
+    image.setup(ctx);
+    image.allocateMemory(ctx);
+    return image;
+}
+} // namespace
+
+TEST(ImageInMemoryTransfer, UploadValidatesMetadataAndSize) {
+    ScenarioOptions opts{};
+    Context ctx{opts};
+    DataManager dataManager;
+    const ImageId imageId{0};
+    const std::vector<int64_t> shape{1, 3, 2, 1};
+    const vk::Format format = vk::Format::eR8Uint;
+
+    auto &image = prepareImage(ctx, dataManager, imageId, shape, format);
+    std::vector<char> payload(image.baseDataSize(), 0x3c);
+
+    EXPECT_THROW(image.upload(ctx, {payload.data(), payload.size(), {1, 2, 2, 1}, format}), std::runtime_error);
+    EXPECT_THROW(image.upload(ctx, {payload.data(), payload.size(), shape, vk::Format::eR16Uint}), std::runtime_error);
+    EXPECT_THROW(image.upload(ctx, {payload.data(), payload.size() - 1, shape, format}), std::runtime_error);
+    EXPECT_THROW(image.upload(ctx, {payload.data(), payload.size(), shape, format, 0}), std::runtime_error);
+    EXPECT_THROW(image.upload(ctx, {payload.data(), payload.size(), shape, format, 2}), std::runtime_error);
+}
+
+TEST(ImageInMemoryTransfer, CanUploadAndDownloadRepeatedly) {
+    ScenarioOptions opts{};
+    Context ctx{opts};
+    DataManager dataManager;
+    const ImageId imageId{0};
+    const std::vector<int64_t> shape{1, 3, 2, 1};
+    const vk::Format format = vk::Format::eR8Uint;
+
+    auto &image = prepareImage(ctx, dataManager, imageId, shape, format);
+    std::vector<char> firstPayload(image.baseDataSize());
+    std::iota(firstPayload.begin(), firstPayload.end(), static_cast<char>(1));
+
+    image.transitionLayout(ctx, vk::ImageLayout::eShaderReadOnlyOptimal);
+    ASSERT_NO_THROW(image.upload(ctx, {firstPayload.data(), firstPayload.size(), shape, format}));
+    EXPECT_EQ(image.getImageLayout(), vk::ImageLayout::eShaderReadOnlyOptimal);
+
+    image.transitionLayout(ctx, vk::ImageLayout::eShaderReadOnlyOptimal);
+    const auto firstDownload = image.download(ctx);
+    EXPECT_EQ(firstDownload.data, firstPayload);
+    EXPECT_EQ(firstDownload.shape, shape);
+    EXPECT_EQ(firstDownload.mipLevels, 1);
+    EXPECT_EQ(image.getImageLayout(), vk::ImageLayout::eShaderReadOnlyOptimal);
+    ASSERT_TRUE(firstDownload.format.has_value());
+    EXPECT_EQ(firstDownload.format.value(), format);
+
+    std::vector<char> secondPayload(image.baseDataSize());
+    std::iota(secondPayload.rbegin(), secondPayload.rend(), static_cast<char>(10));
+
+    ASSERT_NO_THROW(image.upload(ctx, {secondPayload.data(), secondPayload.size(), shape, std::nullopt}));
+    const auto secondDownload = image.download(ctx);
+    EXPECT_EQ(secondDownload.data, secondPayload);
+    EXPECT_EQ(secondDownload.shape, shape);
+    EXPECT_EQ(secondDownload.mipLevels, 1);
+    ASSERT_TRUE(secondDownload.format.has_value());
+    EXPECT_EQ(secondDownload.format.value(), format);
+}
+
+TEST(ImageInMemoryTransfer, CanUploadCompleteMipChainAndDownloadBaseMip) {
+    ScenarioOptions opts{};
+    Context ctx{opts};
+    DataManager dataManager;
+    const ImageId imageId{0};
+    const std::vector<int64_t> shape{1, 4, 4, 1};
+    const vk::Format format = vk::Format::eR8Uint;
+    constexpr uint32_t mipLevels = 3;
+
+    auto &image = prepareImage(ctx, dataManager, imageId, shape, format, mipLevels);
+    std::vector<char> payload(image.mipChainDataSize(mipLevels));
+    std::iota(payload.begin(), payload.end(), static_cast<char>(1));
+
+    ASSERT_NO_THROW(image.upload(ctx, {payload.data(), payload.size(), shape, format, mipLevels}));
+    const auto download = image.download(ctx);
+
+    payload.resize(image.baseDataSize());
+    EXPECT_EQ(download.data, payload);
+    EXPECT_EQ(download.shape, shape);
+    EXPECT_EQ(download.mipLevels, 1);
+    ASSERT_TRUE(download.format.has_value());
+    EXPECT_EQ(download.format.value(), format);
+}


### PR DESCRIPTION
Add image data view/result types and host-memory transfer methods. Reuse the existing description upload path and cover validation, repeated transfers, and mip-chain upload.

Change-Id: I2d415e30d8ec10141d95a4c94c16f390b676b963