### PR TITLE
refactor: hide internal resource sizing helpers

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -319,8 +319,6 @@ vk::ImageView Image::imageView(uint32_t lod) const {
 
 vk::Sampler Image::sampler() const { return *_sampler; }
 
-uint64_t Image::memSize() const { return _memoryManager->getMemSize(); }
-
 uint64_t Image::baseDataSize() const {
     uint64_t size = elementSizeFromVkFormat(_dataType) * totalElementsFromShape(_imageInfo.shape);
     return size;

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -42,18 +42,6 @@ class Image {
     /// \return The underlying Vulkan® image sampler
     vk::Sampler sampler() const;
 
-    /// \brief Get base mip image packed data size in bytes
-    /// \return Size of base mip image packed data in bytes
-    uint64_t baseDataSize() const;
-
-    /// \brief Get image mip-chain packed data size in bytes
-    /// \return Size of image packed data for the requested number of mip levels in bytes
-    uint64_t mipChainDataSize(uint32_t mipLevels) const;
-
-    /// \brief Get total size of memory object associated with this tensor
-    /// \return Size of memory in bytes
-    uint64_t memSize() const;
-
     /// \brief Get image data type
     /// \return Data type of image
     vk::Format dataType() const;
@@ -88,6 +76,8 @@ class Image {
     const ImageInfo &getInfo() const { return _imageInfo; }
 
   private:
+    uint64_t baseDataSize() const;
+    uint64_t mipChainDataSize(uint32_t mipLevels) const;
     void uploadData(const Context &ctx, const void *data, size_t size, uint32_t mipLevels);
     std::vector<char> getImageData(const Context &ctx);
     uint32_t getFormatMaxMipLevels(const Context &ctx, vk::ImageTiling tiling, vk::ImageUsageFlags usageFlags);

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -124,11 +124,13 @@ BufferData loadBufferData(const BufferDesc &desc) {
     return bufferData;
 }
 
-TensorData loadTensorData(const TensorDesc &desc, uint64_t expectedSize) {
+TensorData loadTensorData(const TensorDesc &desc) {
     TensorData tensorData;
     tensorData.shape = desc.dims;
 
     if (!desc.src.has_value()) {
+        const auto format = getVkFormatFromString(desc.format);
+        const auto expectedSize = elementSizeFromVkFormat(format) * totalElementsFromShape(desc.dims);
         tensorData.data.resize(expectedSize, 0);
         return tensorData;
     }
@@ -1123,8 +1125,7 @@ void Scenario::setupResources() {
             PerfCounterGuard guard(_perfCounters, "Load Tensor: " + tensor->guidStr, "Scenario Setup");
             const auto id = resolveResourceId<TensorId>(_resourceIds, tensor->guid, "Tensor");
             if (tensor->src || !_groupManager.isAliased(id)) {
-                const auto &tensorResource = _dataManager.getTensor(id);
-                const auto tensorData = loadTensorData(*tensor, tensorResource.dataSize());
+                const auto tensorData = loadTensorData(*tensor);
                 upload(id, {tensorData.data.data(), tensorData.data.size(), tensorData.shape, tensorData.format});
             }
         } break;

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -120,8 +120,6 @@ const vk::TensorViewARM &Tensor::tensorView() const { return *_tensorView; }
 
 uint64_t Tensor::dataSize() const { return elementSizeFromVkFormat(_dataType) * totalElementsFromShape(_shape); }
 
-uint64_t Tensor::memSize() const { return _memoryManager->getMemSize(); }
-
 vk::Format Tensor::dataType() const { return _dataType; }
 
 const std::vector<int64_t> &Tensor::dimStrides() const { return _strides; }

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -34,14 +34,6 @@ class Tensor {
     /// \return The underlying Vulkan tensor view
     const vk::TensorViewARM &tensorView() const;
 
-    /// \brief Get total size of memory object associated with this tensor
-    /// \return Size of memory in bytes
-    uint64_t memSize() const;
-
-    /// \brief Get tensor packed data size in bytes
-    /// \return Size of tensor data in bytes
-    uint64_t dataSize() const;
-
     /// \brief Get tensor dimensions strides
     /// \return dimensions strides
     const std::vector<int64_t> &dimStrides() const;
@@ -82,6 +74,8 @@ class Tensor {
     const std::string &debugName() const;
 
   private:
+    uint64_t dataSize() const;
+
     std::string _debugName;
     vk::raii::TensorARM _tensor{nullptr};
     vk::raii::TensorViewARM _tensorView{nullptr};

--- a/src/tests/image_tests.cpp
+++ b/src/tests/image_tests.cpp
@@ -7,6 +7,7 @@
 #include "image.hpp"
 #include "resource_data.hpp"
 #include "scenario.hpp"
+#include "utils.hpp"
 
 #include <numeric>
 #include <vector>
@@ -16,6 +17,20 @@
 using namespace mlsdk::scenariorunner;
 
 namespace {
+size_t packedImageDataSize(const std::vector<int64_t> &shape, vk::Format format, uint32_t mipLevels = 1) {
+    auto width = static_cast<size_t>(shape[1]);
+    auto height = static_cast<size_t>(shape[2]);
+    const auto depth = static_cast<size_t>(shape[3]);
+    const auto elementSize = static_cast<size_t>(elementSizeFromVkFormat(format));
+    size_t size = 0;
+    for (uint32_t mip = 0; mip < mipLevels; ++mip) {
+        size += width * height * depth * elementSize;
+        width = std::max(width / 2, size_t{1});
+        height = std::max(height / 2, size_t{1});
+    }
+    return size;
+}
+
 Image &prepareImage(Context &ctx, DataManager &dataManager, ImageId id, const std::vector<int64_t> &shape,
                     vk::Format format, uint32_t mipLevels = 1) {
     ImageInfo info{};
@@ -45,7 +60,7 @@ TEST(ImageInMemoryTransfer, UploadValidatesMetadataAndSize) {
     const vk::Format format = vk::Format::eR8Uint;
 
     auto &image = prepareImage(ctx, dataManager, imageId, shape, format);
-    std::vector<char> payload(image.baseDataSize(), 0x3c);
+    std::vector<char> payload(packedImageDataSize(shape, format), 0x3c);
 
     EXPECT_THROW(image.upload(ctx, {payload.data(), payload.size(), {1, 2, 2, 1}, format}), std::runtime_error);
     EXPECT_THROW(image.upload(ctx, {payload.data(), payload.size(), shape, vk::Format::eR16Uint}), std::runtime_error);
@@ -63,7 +78,7 @@ TEST(ImageInMemoryTransfer, CanUploadAndDownloadRepeatedly) {
     const vk::Format format = vk::Format::eR8Uint;
 
     auto &image = prepareImage(ctx, dataManager, imageId, shape, format);
-    std::vector<char> firstPayload(image.baseDataSize());
+    std::vector<char> firstPayload(packedImageDataSize(shape, format));
     std::iota(firstPayload.begin(), firstPayload.end(), static_cast<char>(1));
 
     image.transitionLayout(ctx, vk::ImageLayout::eShaderReadOnlyOptimal);
@@ -79,7 +94,7 @@ TEST(ImageInMemoryTransfer, CanUploadAndDownloadRepeatedly) {
     ASSERT_TRUE(firstDownload.format.has_value());
     EXPECT_EQ(firstDownload.format.value(), format);
 
-    std::vector<char> secondPayload(image.baseDataSize());
+    std::vector<char> secondPayload(packedImageDataSize(shape, format));
     std::iota(secondPayload.rbegin(), secondPayload.rend(), static_cast<char>(10));
 
     ASSERT_NO_THROW(image.upload(ctx, {secondPayload.data(), secondPayload.size(), shape, std::nullopt}));
@@ -101,13 +116,13 @@ TEST(ImageInMemoryTransfer, CanUploadCompleteMipChainAndDownloadBaseMip) {
     constexpr uint32_t mipLevels = 3;
 
     auto &image = prepareImage(ctx, dataManager, imageId, shape, format, mipLevels);
-    std::vector<char> payload(image.mipChainDataSize(mipLevels));
+    std::vector<char> payload(packedImageDataSize(shape, format, mipLevels));
     std::iota(payload.begin(), payload.end(), static_cast<char>(1));
 
     ASSERT_NO_THROW(image.upload(ctx, {payload.data(), payload.size(), shape, format, mipLevels}));
     const auto download = image.download(ctx);
 
-    payload.resize(image.baseDataSize());
+    payload.resize(packedImageDataSize(shape, format));
     EXPECT_EQ(download.data, payload);
     EXPECT_EQ(download.shape, shape);
     EXPECT_EQ(download.mipLevels, 1);


### PR DESCRIPTION
Remove the unused Tensor::memSize() and Image::memSize() APIs. Make Tensor::dataSize(), Image::baseDataSize(), and Image::mipChainDataSize() private because they are implementation details.

Change-Id: If55287a1c33ed4e1af4699d06178080116ecdec3