### PR TITLE
refactor: extract scenario command definitions

### DIFF
--- a/src/command_types.hpp
+++ b/src/command_types.hpp
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "commands.hpp"
+#include "compute.hpp"
+#include "types.hpp"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mlsdk::scenariorunner {
+
+/// \brief Compute data with typed bindings
+struct DispatchComputeData {
+    explicit DispatchComputeData(ShaderId shader) : shader(shader) {}
+
+    std::string debugName;
+    std::vector<TypedBinding> bindings;
+    ComputeDispatch computeDispatch{};
+    ShaderId shader;
+    bool implicitBarrier{true};
+    std::optional<RawDataId> pushData;
+};
+
+/// \brief Fragment (graphics) data with typed bindings
+struct DispatchFragmentData {
+    DispatchFragmentData(ShaderId vertexShader, ShaderId fragmentShader)
+        : vertexShader(vertexShader), fragmentShader(fragmentShader) {}
+
+    std::string debugName;
+    std::vector<TypedBinding> bindings;
+    ShaderId vertexShader;
+    ShaderId fragmentShader;
+    struct Attachment {
+        ImageId resource;
+        std::optional<uint32_t> lod;
+    };
+    std::vector<Attachment> colorAttachments;
+    std::optional<vk::Extent2D> renderExtent;
+    bool implicitBarrier{true};
+    std::optional<RawDataId> pushData;
+};
+
+struct ResolvedPushConstantMap {
+    RawDataId pushData;
+    std::string shaderTarget;
+};
+
+struct ResolvedShaderSubstitution {
+    ShaderId shader;
+    std::string target;
+};
+
+/// \brief Compute data graph with typed bindings
+struct DispatchDataGraphData {
+    explicit DispatchDataGraphData(DataGraphId dataGraph) : dataGraph(dataGraph) {}
+
+    DataGraphId dataGraph;
+    std::string debugName;
+    std::vector<TypedBinding> bindings;
+    std::vector<ResolvedPushConstantMap> pushConstants;
+    std::vector<ResolvedShaderSubstitution> shaderSubstitutions;
+    bool implicitBarrier{true};
+};
+
+/// \brief SPIR-V-only data graph with typed bindings and constants
+struct DispatchSpirvGraphData {
+    explicit DispatchSpirvGraphData(ShaderId graphShader) : graphShader(graphShader) {}
+
+    ShaderId graphShader;
+    std::string debugName;
+    std::vector<TypedBinding> bindings;
+    std::vector<GraphConstantResourceId> graphConstants;
+    bool implicitBarrier{true};
+};
+
+/// \brief Optical flow data graph with typed bindings
+struct DispatchOpticalFlowData {
+    DispatchOpticalFlowData(TypedBinding search, TypedBinding reference, TypedBinding output)
+        : searchImage(search), templateImage(reference), outputImage(output) {}
+
+    std::string debugName;
+    TypedBinding searchImage;
+    TypedBinding templateImage;
+    TypedBinding outputImage;
+    std::optional<TypedBinding> hintMotionVectors;
+    std::optional<TypedBinding> outputCost;
+    uint32_t width{0};
+    uint32_t height{0};
+    OpticalFlowPerformanceLevel performanceLevel{OpticalFlowPerformanceLevel::Medium};
+    uint32_t executionFlags{0};
+    OpticalFlowGridSize gridSize{OpticalFlowGridSize::e1x1};
+    uint32_t meanFlowL1NormHint{0};
+
+    bool implicitBarrier{true};
+};
+
+/// \brief Typed barriers
+struct DispatchBarrierData {
+    std::vector<MemoryBarrierId> memoryBarriers;
+    std::vector<ImageBarrierId> imageBarriers;
+    std::vector<TensorBarrierId> tensorBarriers;
+    std::vector<BufferBarrierId> bufferBarriers;
+};
+
+/// \brief Typed resources
+struct MarkBoundaryData {
+    std::vector<BufferId> buffers;
+    std::vector<ImageId> images;
+    std::vector<TensorId> tensors;
+};
+
+} // namespace mlsdk::scenariorunner

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "compute.hpp"
+#include "command_types.hpp"
 #include "logging.hpp"
 #include "utils.hpp"
 

--- a/src/compute.hpp
+++ b/src/compute.hpp
@@ -18,20 +18,8 @@
 
 namespace mlsdk::scenariorunner {
 
-/// \brief Typed barriers
-struct DispatchBarrierData {
-    std::vector<MemoryBarrierId> memoryBarriers;
-    std::vector<ImageBarrierId> imageBarriers;
-    std::vector<TensorBarrierId> tensorBarriers;
-    std::vector<BufferBarrierId> bufferBarriers;
-};
-
-/// \brief Typed resources
-struct MarkBoundaryData {
-    std::vector<BufferId> buffers;
-    std::vector<ImageId> images;
-    std::vector<TensorId> tensors;
-};
+struct DispatchBarrierData;
+struct MarkBoundaryData;
 
 /// \brief Image attachment used by a graphics dispatch
 struct GraphicsDispatchAttachment {

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "scenario.hpp"
+#include "command_types.hpp"
 #include "frame_capturer.hpp"
 #include "glsl_compiler.hpp"
 #ifdef SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT
@@ -23,92 +24,6 @@
 #include <unordered_set>
 
 namespace mlsdk::scenariorunner {
-/// \brief Compute data with typed bindings
-struct DispatchComputeData {
-    explicit DispatchComputeData(ShaderId shader) : shader(shader) {}
-
-    std::string debugName;
-    std::vector<TypedBinding> bindings;
-    ComputeDispatch computeDispatch{};
-    ShaderId shader;
-    bool implicitBarrier{true};
-    std::optional<RawDataId> pushData;
-};
-
-/// \brief Fragment (graphics) data with typed bindings
-struct DispatchFragmentData {
-    DispatchFragmentData(ShaderId vertexShader, ShaderId fragmentShader)
-        : vertexShader(vertexShader), fragmentShader(fragmentShader) {}
-
-    std::string debugName;
-    std::vector<TypedBinding> bindings;
-    ShaderId vertexShader;
-    ShaderId fragmentShader;
-    struct Attachment {
-        ImageId resource;
-        std::optional<uint32_t> lod;
-    };
-    std::vector<Attachment> colorAttachments;
-    std::optional<vk::Extent2D> renderExtent;
-    bool implicitBarrier{true};
-    std::optional<RawDataId> pushData;
-};
-
-struct ResolvedPushConstantMap {
-    RawDataId pushData;
-    std::string shaderTarget;
-};
-
-struct ResolvedShaderSubstitution {
-    ShaderId shader;
-    std::string target;
-};
-
-/// \brief Compute data graph with typed bindings
-struct DispatchDataGraphData {
-    explicit DispatchDataGraphData(DataGraphId dataGraph) : dataGraph(dataGraph) {}
-
-    DataGraphId dataGraph;
-    std::string debugName;
-    std::vector<TypedBinding> bindings;
-    std::vector<ResolvedPushConstantMap> pushConstants;
-    std::vector<ResolvedShaderSubstitution> shaderSubstitutions;
-    bool implicitBarrier{true};
-};
-
-/// \brief SPIR-V-only data graph with typed bindings and constants
-struct DispatchSpirvGraphData {
-    explicit DispatchSpirvGraphData(ShaderId graphShader) : graphShader(graphShader) {}
-
-    ShaderId graphShader;
-    std::string debugName;
-    std::vector<TypedBinding> bindings;
-    std::vector<GraphConstantResourceId> graphConstants;
-    bool implicitBarrier{true};
-};
-
-/// \brief Optical flow data graph with typed bindings
-struct DispatchOpticalFlowData {
-    DispatchOpticalFlowData(TypedBinding search, TypedBinding reference, TypedBinding output)
-        : searchImage(search), templateImage(reference), outputImage(output) {}
-
-    std::string debugName;
-    TypedBinding searchImage;
-    TypedBinding templateImage;
-    TypedBinding outputImage;
-    std::optional<TypedBinding> hintMotionVectors;
-    std::optional<TypedBinding> outputCost;
-
-    uint32_t width{0};
-    uint32_t height{0};
-    OpticalFlowPerformanceLevel performanceLevel{OpticalFlowPerformanceLevel::Medium};
-    uint32_t executionFlags{0};
-    OpticalFlowGridSize gridSize{OpticalFlowGridSize::e1x1};
-    uint32_t meanFlowL1NormHint{0};
-
-    bool implicitBarrier{true};
-};
-
 namespace {
 BufferData loadBufferData(const BufferDesc &desc) {
     BufferData bufferData;


### PR DESCRIPTION
Move typed command definitions out of scenario.cpp and compute.hpp into command_types.hpp. This separates the resolved scenario command model from its consumers without changing behavior.


Change-Id: I059b3b5e0292da40062358361e802cbdc32129af