### PR TITLE
refactor: build JSON data through ScenarioBuilder

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SCENARIO_RUNNER_LIB_SOURCES
     resource_desc.cpp
     resource_manager.cpp
     scenario.cpp
+    scenario_builder.cpp
     scenario_desc.cpp
     tensor.cpp
     utils.cpp

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -6,15 +6,16 @@
 #include "command_types.hpp"
 #include "frame_capturer.hpp"
 #include "glsl_compiler.hpp"
+#include "guid.hpp"
 #ifdef SCENARIO_RUNNER_ENABLE_HLSL_SUPPORT
 #    include "hlsl_compiler.hpp"
 #endif
-#include "guid.hpp"
 #include "image_formats.hpp"
 #include "iresource.hpp"
 #include "json_writer.hpp"
 #include "logging.hpp"
 #include "optical_flow_utils.hpp"
+#include "scenario_builder.hpp"
 #include "utils.hpp"
 
 #include "vgf-utils/numpy.hpp"
@@ -503,11 +504,17 @@ MemoryGroupId getOrCreateMemoryGroup(GroupManager &groupManager, std::unordered_
     return group;
 }
 
-void registerMemoryGroup(GroupManager &groupManager, std::unordered_map<Guid, MemoryGroupId> &memoryGroupIds,
+void registerMemoryGroup(ScenarioBuilder &builder, std::unordered_map<Guid, MemoryGroupId> &memoryGroupIds,
                          MemoryResourceId resource, const std::optional<MemoryGroup> &memoryGroup) {
     if (memoryGroup.has_value()) {
-        const auto group = getOrCreateMemoryGroup(groupManager, memoryGroupIds, memoryGroup->memoryUid);
-        groupManager.addResourceToGroup(group, resource);
+        const auto existingGroup = memoryGroupIds.find(memoryGroup->memoryUid);
+        if (existingGroup != memoryGroupIds.end()) {
+            builder.addResourceToMemoryGroup(existingGroup->second, resource);
+            return;
+        }
+        const auto group = builder.createMemoryGroup();
+        memoryGroupIds.emplace(memoryGroup->memoryUid, group);
+        builder.addResourceToMemoryGroup(group, resource);
     }
 }
 
@@ -728,9 +735,7 @@ void verifyOpticalFlowData(const DataManager &dataManager, const DispatchOptical
 
 Scenario::Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec)
     : _opts{opts}, _ctx{opts, getFamilyQueue(scenarioSpec)}, _scenarioSpec(scenarioSpec), _compute(_ctx) {
-    registerResourceInfo();
-    registerBarrierInfo();
-    resolveCommands();
+    buildJsonScenarioData(scenarioSpec);
     setupResources();
     setupRuntimeCommands();
 }
@@ -873,52 +878,51 @@ void Scenario::createRuntimeBarriers() {
     }
 }
 
-void Scenario::registerResourceInfo() {
-    mlsdk::logging::info("Setup resources, count: " + std::to_string(_scenarioSpec.resources.size()));
-    // Setup resource info
-    // (Memory for Tensors and Images is allocated in next pass)
-    ResourceInfoFactory resourceInfoFactory;
-    std::unordered_map<Guid, MemoryGroupId> jsonMemoryGroupIds;
+namespace {
+void registerJsonResourceInfo(ScenarioBuilder &builder, const ScenarioSpec &scenarioSpec,
+                              const ResourceInfoFactory &resourceInfoFactory, bool captureFrame,
+                              std::unordered_map<Guid, MemoryGroupId> &jsonMemoryGroupIds,
+                              std::unordered_map<Guid, TypedResourceId> &resourceIds) {
 
-    for (const auto &resource : _scenarioSpec.resources) {
+    for (const auto &resource : scenarioSpec.resources) {
         switch (resource->resourceType) {
         case ResourceType::Buffer: {
             const auto &buffer = reinterpret_cast<const std::unique_ptr<BufferDesc> &>(resource);
-            const auto id = _resources.addBuffer(resourceInfoFactory.createInfo(*buffer));
-            _resourceIds.emplace(resource->guid, id);
-            registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, buffer->memoryGroup);
+            const auto id = builder.addBuffer(resourceInfoFactory.createInfo(*buffer));
+            resourceIds.emplace(resource->guid, id);
+            registerMemoryGroup(builder, jsonMemoryGroupIds, id, buffer->memoryGroup);
         } break;
         case ResourceType::RawData: {
             const auto &rawData = reinterpret_cast<const std::unique_ptr<RawDataDesc> &>(resource);
-            const auto id = _resources.addRawData(resourceInfoFactory.createInfo(*rawData));
-            _resourceIds.emplace(resource->guid, id);
+            const auto id = builder.addRawData(resourceInfoFactory.createInfo(*rawData));
+            resourceIds.emplace(resource->guid, id);
         } break;
         case ResourceType::Image: {
             const auto &image = reinterpret_cast<const std::unique_ptr<ImageDesc> &>(resource);
-            const auto id = _resources.addImage(resourceInfoFactory.createInfo(*image));
-            _resourceIds.emplace(resource->guid, id);
-            registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, image->memoryGroup);
+            const auto id = builder.addImage(resourceInfoFactory.createInfo(*image));
+            resourceIds.emplace(resource->guid, id);
+            registerMemoryGroup(builder, jsonMemoryGroupIds, id, image->memoryGroup);
         } break;
         case ResourceType::DataGraph: {
             const auto &dataGraph = reinterpret_cast<const std::unique_ptr<DataGraphDesc> &>(resource);
-            const auto id = _resources.addDataGraph(resourceInfoFactory.createInfo(*dataGraph));
-            _resourceIds.emplace(resource->guid, id);
+            const auto id = builder.addDataGraph(resourceInfoFactory.createInfo(*dataGraph));
+            resourceIds.emplace(resource->guid, id);
         } break;
         case ResourceType::Tensor: {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
-            const auto id = _resources.addTensor(resourceInfoFactory.createInfo(*tensor, _opts.captureFrame));
-            _resourceIds.emplace(resource->guid, id);
-            registerMemoryGroup(_groupManager, jsonMemoryGroupIds, id, tensor->memoryGroup);
+            const auto id = builder.addTensor(resourceInfoFactory.createInfo(*tensor, captureFrame));
+            resourceIds.emplace(resource->guid, id);
+            registerMemoryGroup(builder, jsonMemoryGroupIds, id, tensor->memoryGroup);
         } break;
         case ResourceType::Shader: {
             const auto &shader = reinterpret_cast<const std::unique_ptr<ShaderDesc> &>(resource);
-            const auto id = _resources.addShader(resourceInfoFactory.createInfo(*shader));
-            _resourceIds.emplace(resource->guid, id);
+            const auto id = builder.addShader(resourceInfoFactory.createInfo(*shader));
+            resourceIds.emplace(resource->guid, id);
         } break;
         case ResourceType::GraphConstant: {
             const auto &graphConstant = reinterpret_cast<const std::unique_ptr<GraphConstantDesc> &>(resource);
-            const auto id = _resources.addGraphConstant(resourceInfoFactory.createInfo(*graphConstant));
-            _resourceIds.emplace(resource->guid, id);
+            const auto id = builder.addGraphConstant(resourceInfoFactory.createInfo(*graphConstant));
+            resourceIds.emplace(resource->guid, id);
         } break;
         default:
             // Barriers can precede the regular resources they reference, so register them in a second pass.
@@ -928,33 +932,58 @@ void Scenario::registerResourceInfo() {
     }
 }
 
-void Scenario::registerBarrierInfo() {
-    // Resolve barrier references after all regular resources have typed IDs.
-    BarrierInfoFactory barrierInfoFactory{_resourceIds};
-    for (const auto &resource : _scenarioSpec.resources) {
+void registerJsonBarrierInfo(ScenarioBuilder &builder, const ScenarioSpec &scenarioSpec,
+                             std::unordered_map<Guid, TypedResourceId> &resourceIds) {
+    // Barrier descriptions can reference resources declared later in the JSON,
+    // so translate them only after all regular resources have typed IDs.
+    BarrierInfoFactory barrierInfoFactory{resourceIds};
+    for (const auto &resource : scenarioSpec.resources) {
         switch (resource->resourceType) {
         case ResourceType::ImageBarrier: {
-            const auto &barrier = reinterpret_cast<const std::unique_ptr<ImageBarrierDesc> &>(resource);
-            _resourceIds.emplace(resource->guid, _resources.addImageBarrier(barrierInfoFactory.createInfo(*barrier)));
+            const auto &imageBarrier = reinterpret_cast<const std::unique_ptr<ImageBarrierDesc> &>(resource);
+            const auto id = builder.addImageBarrier(barrierInfoFactory.createInfo(*imageBarrier));
+            resourceIds.emplace(resource->guid, id);
         } break;
         case ResourceType::MemoryBarrier: {
-            const auto &barrier = reinterpret_cast<const std::unique_ptr<MemoryBarrierDesc> &>(resource);
-            _resourceIds.emplace(resource->guid, _resources.addMemoryBarrier(barrierInfoFactory.createInfo(*barrier)));
+            const auto &memoryBarrier = reinterpret_cast<const std::unique_ptr<MemoryBarrierDesc> &>(resource);
+            const auto id = builder.addMemoryBarrier(barrierInfoFactory.createInfo(*memoryBarrier));
+            resourceIds.emplace(resource->guid, id);
         } break;
         case ResourceType::TensorBarrier: {
-            const auto &barrier = reinterpret_cast<const std::unique_ptr<TensorBarrierDesc> &>(resource);
-            _resourceIds.emplace(resource->guid, _resources.addTensorBarrier(barrierInfoFactory.createInfo(*barrier)));
+            const auto &tensorBarrier = reinterpret_cast<const std::unique_ptr<TensorBarrierDesc> &>(resource);
+            const auto id = builder.addTensorBarrier(barrierInfoFactory.createInfo(*tensorBarrier));
+            resourceIds.emplace(resource->guid, id);
         } break;
         case ResourceType::BufferBarrier: {
-            const auto &barrier = reinterpret_cast<const std::unique_ptr<BufferBarrierDesc> &>(resource);
-            _resourceIds.emplace(resource->guid, _resources.addBufferBarrier(barrierInfoFactory.createInfo(*barrier)));
+            const auto &bufferBarrier = reinterpret_cast<const std::unique_ptr<BufferBarrierDesc> &>(resource);
+            const auto id = builder.addBufferBarrier(barrierInfoFactory.createInfo(*bufferBarrier));
+            resourceIds.emplace(resource->guid, id);
         } break;
         default:
-            // Regular resources were registered in registerResourceInfo().
+            // Regular resources were registered in the first pass.
             continue;
         }
         mlsdk::logging::debug(resourceType(resource) + ": " + resource->guidStr + " loaded");
     }
+}
+} // namespace
+
+void Scenario::buildJsonScenarioData(const ScenarioSpec &scenarioSpec) {
+    mlsdk::logging::info("Setup resources, count: " + std::to_string(scenarioSpec.resources.size()));
+    ScenarioBuilder builder;
+    ResourceInfoFactory resourceInfoFactory;
+    std::unordered_map<Guid, MemoryGroupId> jsonMemoryGroupIds;
+    std::unordered_map<Guid, TypedResourceId> resourceIds;
+
+    registerJsonResourceInfo(builder, scenarioSpec, resourceInfoFactory, _opts.captureFrame, jsonMemoryGroupIds,
+                             resourceIds);
+    registerJsonBarrierInfo(builder, scenarioSpec, resourceIds);
+    resolveCommands(builder, scenarioSpec, resourceIds);
+    auto buildData = builder.takeBuildData();
+    _resources = std::move(buildData.resources);
+    _resourceIds = std::move(resourceIds);
+    _commands = std::move(buildData.commands);
+    _groupManager = std::move(buildData.groupManager);
 }
 
 void Scenario::setupResources() {
@@ -1074,30 +1103,33 @@ void Scenario::loadJsonResourceData() {
     }
 }
 
-void Scenario::resolveCommands() {
-    CommandDataFactory factory{_resources, _resourceIds};
-    for (const auto &command : _scenarioSpec.commands) {
+void Scenario::resolveCommands(ScenarioBuilder &builder, const ScenarioSpec &scenarioSpec,
+                               const std::unordered_map<Guid, TypedResourceId> &resourceIds) {
+    CommandDataFactory factory{builder._data.resources, resourceIds};
+    for (const auto &command : scenarioSpec.commands) {
         switch (command->commandType) {
         case CommandType::DispatchCompute:
-            _commands.emplace_back(factory.createData(reinterpret_cast<DispatchComputeDesc &>(*command)));
+            builder.addDispatchCompute(factory.createData(reinterpret_cast<const DispatchComputeDesc &>(*command)));
             break;
         case CommandType::DispatchBarrier:
-            _commands.emplace_back(factory.createData(reinterpret_cast<DispatchBarrierDesc &>(*command)));
+            builder.addDispatchBarrier(factory.createData(reinterpret_cast<const DispatchBarrierDesc &>(*command)));
             break;
         case CommandType::DispatchDataGraph:
-            _commands.emplace_back(factory.createData(reinterpret_cast<DispatchDataGraphDesc &>(*command)));
+            builder.addDispatchDataGraph(factory.createData(reinterpret_cast<const DispatchDataGraphDesc &>(*command)));
             break;
         case CommandType::DispatchSpirvGraph:
-            _commands.emplace_back(factory.createData(reinterpret_cast<DispatchSpirvGraphDesc &>(*command)));
+            builder.addDispatchSpirvGraph(
+                factory.createData(reinterpret_cast<const DispatchSpirvGraphDesc &>(*command)));
             break;
         case CommandType::DispatchFragment:
-            _commands.emplace_back(factory.createData(reinterpret_cast<DispatchFragmentDesc &>(*command)));
+            builder.addDispatchFragment(factory.createData(reinterpret_cast<const DispatchFragmentDesc &>(*command)));
             break;
         case CommandType::DispatchOpticalFlow:
-            _commands.emplace_back(factory.createData(reinterpret_cast<DispatchOpticalFlowDesc &>(*command)));
+            builder.addDispatchOpticalFlow(
+                factory.createData(reinterpret_cast<const DispatchOpticalFlowDesc &>(*command)));
             break;
         case CommandType::MarkBoundary:
-            _commands.emplace_back(factory.createData(reinterpret_cast<MarkBoundaryDesc &>(*command)));
+            builder.addMarkBoundary(factory.createData(reinterpret_cast<const MarkBoundaryDesc &>(*command)));
             break;
         default:
             throw std::runtime_error("Unknown CommandType in commands");

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -22,6 +22,8 @@
 #include <vector>
 
 namespace mlsdk::scenariorunner {
+class ScenarioBuilder;
+
 /// \brief Options that are passed for configuring a scenario
 struct ScenarioOptions {
     bool enablePipelineCaching{false};
@@ -89,13 +91,13 @@ class Scenario {
                         const VgfView &vgfView, const DispatchDataGraphData &dispatchDataGraph, uint32_t &nQueries);
 
     /// \brief Sets up runtime options
+    void buildJsonScenarioData(const ScenarioSpec &scenarioSpec);
+    void resolveCommands(ScenarioBuilder &builder, const ScenarioSpec &scenarioSpec,
+                         const std::unordered_map<Guid, TypedResourceId> &resourceIds);
     void setupResources();
-    void registerResourceInfo();
-    void registerBarrierInfo();
     void createRuntimeResources();
     void createRuntimeBarriers();
     void loadJsonResourceData();
-    void resolveCommands();
     void setupRuntimeCommands();
 
     /// \brief Save profiling data to file

--- a/src/scenario_builder.cpp
+++ b/src/scenario_builder.cpp
@@ -1,0 +1,245 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "scenario_builder.hpp"
+#include <stdexcept>
+#include <utility>
+
+namespace mlsdk::scenariorunner {
+namespace {
+template <typename Id> void requireResource(const ResourceManager &resources, Id id, const char *type) {
+    try {
+        static_cast<void>(resources.get(id));
+    } catch (const std::out_of_range &) {
+        throw std::runtime_error(std::string(type) + " resource does not exist");
+    }
+}
+
+template <typename Info, typename Add>
+auto addResource(detail::ScenarioBuildData &data, bool built, Info &&info, Add add) {
+    if (built) {
+        throw std::runtime_error("ScenarioBuilder cannot be modified after build");
+    }
+    return (data.resources.*add)(std::forward<Info>(info));
+}
+} // namespace
+
+void ScenarioBuilder::ensureMutable() const {
+    if (_built) {
+        throw std::runtime_error("ScenarioBuilder cannot be modified after build");
+    }
+}
+
+BufferId ScenarioBuilder::addBuffer(const BufferInfo &info) {
+    return addResource(_data, _built, info,
+                       static_cast<BufferId (ResourceManager::*)(const BufferInfo &)>(&ResourceManager::addBuffer));
+}
+BufferId ScenarioBuilder::addBuffer(BufferInfo &&info) {
+    return addResource(_data, _built, std::move(info),
+                       static_cast<BufferId (ResourceManager::*)(BufferInfo &&)>(&ResourceManager::addBuffer));
+}
+ImageId ScenarioBuilder::addImage(const ImageInfo &info) {
+    return addResource(_data, _built, info,
+                       static_cast<ImageId (ResourceManager::*)(const ImageInfo &)>(&ResourceManager::addImage));
+}
+ImageId ScenarioBuilder::addImage(ImageInfo &&info) {
+    return addResource(_data, _built, std::move(info),
+                       static_cast<ImageId (ResourceManager::*)(ImageInfo &&)>(&ResourceManager::addImage));
+}
+TensorId ScenarioBuilder::addTensor(const TensorInfo &info) {
+    return addResource(_data, _built, info,
+                       static_cast<TensorId (ResourceManager::*)(const TensorInfo &)>(&ResourceManager::addTensor));
+}
+TensorId ScenarioBuilder::addTensor(TensorInfo &&info) {
+    return addResource(_data, _built, std::move(info),
+                       static_cast<TensorId (ResourceManager::*)(TensorInfo &&)>(&ResourceManager::addTensor));
+}
+ShaderId ScenarioBuilder::addShader(const ShaderInfo &info) {
+    return addResource(_data, _built, info,
+                       static_cast<ShaderId (ResourceManager::*)(const ShaderInfo &)>(&ResourceManager::addShader));
+}
+ShaderId ScenarioBuilder::addShader(ShaderInfo &&info) {
+    return addResource(_data, _built, std::move(info),
+                       static_cast<ShaderId (ResourceManager::*)(ShaderInfo &&)>(&ResourceManager::addShader));
+}
+RawDataId ScenarioBuilder::addRawData(const RawDataInfo &info) {
+    return addResource(_data, _built, info,
+                       static_cast<RawDataId (ResourceManager::*)(const RawDataInfo &)>(&ResourceManager::addRawData));
+}
+RawDataId ScenarioBuilder::addRawData(RawDataInfo &&info) {
+    return addResource(_data, _built, std::move(info),
+                       static_cast<RawDataId (ResourceManager::*)(RawDataInfo &&)>(&ResourceManager::addRawData));
+}
+DataGraphId ScenarioBuilder::addDataGraph(const DataGraphInfo &info) {
+    return addResource(
+        _data, _built, info,
+        static_cast<DataGraphId (ResourceManager::*)(const DataGraphInfo &)>(&ResourceManager::addDataGraph));
+}
+DataGraphId ScenarioBuilder::addDataGraph(DataGraphInfo &&info) {
+    return addResource(_data, _built, std::move(info),
+                       static_cast<DataGraphId (ResourceManager::*)(DataGraphInfo &&)>(&ResourceManager::addDataGraph));
+}
+GraphConstantResourceId ScenarioBuilder::addGraphConstant(const GraphConstantInfo &info) {
+    return addResource(_data, _built, info,
+                       static_cast<GraphConstantResourceId (ResourceManager::*)(const GraphConstantInfo &)>(
+                           &ResourceManager::addGraphConstant));
+}
+GraphConstantResourceId ScenarioBuilder::addGraphConstant(GraphConstantInfo &&info) {
+    return addResource(_data, _built, std::move(info),
+                       static_cast<GraphConstantResourceId (ResourceManager::*)(GraphConstantInfo &&)>(
+                           &ResourceManager::addGraphConstant));
+}
+
+ImageBarrierId ScenarioBuilder::addImageBarrier(const ImageBarrierInfo &info) {
+    ensureMutable();
+    requireResource(_data.resources, info.image, "Image");
+    return _data.resources.addImageBarrier(info);
+}
+BufferBarrierId ScenarioBuilder::addBufferBarrier(const BufferBarrierInfo &info) {
+    ensureMutable();
+    requireResource(_data.resources, info.buffer, "Buffer");
+    return _data.resources.addBufferBarrier(info);
+}
+TensorBarrierId ScenarioBuilder::addTensorBarrier(const TensorBarrierInfo &info) {
+    ensureMutable();
+    requireResource(_data.resources, info.tensor, "Tensor");
+    return _data.resources.addTensorBarrier(info);
+}
+MemoryBarrierId ScenarioBuilder::addMemoryBarrier(const MemoryBarrierInfo &info) {
+    ensureMutable();
+    return _data.resources.addMemoryBarrier(info);
+}
+
+MemoryGroupId ScenarioBuilder::createMemoryGroup() {
+    ensureMutable();
+    return _data.groupManager.createMemoryGroup();
+}
+
+void ScenarioBuilder::validateGroup(MemoryGroupId group) const {
+    if (_data.groupManager.getGroups().find(group) == _data.groupManager.getGroups().end()) {
+        throw std::runtime_error("Memory group does not exist");
+    }
+}
+
+void ScenarioBuilder::validateMemoryResource(MemoryResourceId resource) const {
+    std::visit([&](auto id) { requireResource(_data.resources, id, "Memory"); }, resource);
+}
+
+void ScenarioBuilder::addResourceToMemoryGroup(MemoryGroupId group, MemoryResourceId resource) {
+    ensureMutable();
+    validateGroup(group);
+    validateMemoryResource(resource);
+    _data.groupManager.addResourceToGroup(group, resource);
+}
+
+void ScenarioBuilder::validateBinding(const TypedBinding &binding) const { validateMemoryResource(binding.resource); }
+
+void ScenarioBuilder::addDispatchCompute(DispatchComputeData command) {
+    ensureMutable();
+    requireResource(_data.resources, command.shader, "Shader");
+    for (const auto &binding : command.bindings) {
+        validateBinding(binding);
+    }
+    if (command.pushData) {
+        requireResource(_data.resources, *command.pushData, "Raw data");
+    }
+    _data.commands.emplace_back(std::move(command));
+}
+
+void ScenarioBuilder::addDispatchFragment(DispatchFragmentData command) {
+    ensureMutable();
+    requireResource(_data.resources, command.vertexShader, "Shader");
+    requireResource(_data.resources, command.fragmentShader, "Shader");
+    for (const auto &binding : command.bindings) {
+        validateBinding(binding);
+    }
+    for (const auto &attachment : command.colorAttachments) {
+        requireResource(_data.resources, attachment.resource, "Image");
+    }
+    if (command.pushData) {
+        requireResource(_data.resources, *command.pushData, "Raw data");
+    }
+    _data.commands.emplace_back(std::move(command));
+}
+
+void ScenarioBuilder::addDispatchDataGraph(DispatchDataGraphData command) {
+    ensureMutable();
+    requireResource(_data.resources, command.dataGraph, "Data graph");
+    for (const auto &binding : command.bindings) {
+        validateBinding(binding);
+    }
+    for (const auto &push : command.pushConstants) {
+        requireResource(_data.resources, push.pushData, "Raw data");
+    }
+    for (const auto &shader : command.shaderSubstitutions) {
+        requireResource(_data.resources, shader.shader, "Shader");
+    }
+    _data.commands.emplace_back(std::move(command));
+}
+
+void ScenarioBuilder::addDispatchSpirvGraph(DispatchSpirvGraphData command) {
+    ensureMutable();
+    requireResource(_data.resources, command.graphShader, "Shader");
+    for (const auto &binding : command.bindings) {
+        validateBinding(binding);
+    }
+    for (const auto constant : command.graphConstants) {
+        requireResource(_data.resources, constant, "Graph constant");
+    }
+    _data.commands.emplace_back(std::move(command));
+}
+
+void ScenarioBuilder::addDispatchOpticalFlow(DispatchOpticalFlowData command) {
+    ensureMutable();
+    validateBinding(command.searchImage);
+    validateBinding(command.templateImage);
+    validateBinding(command.outputImage);
+    if (command.hintMotionVectors) {
+        validateBinding(*command.hintMotionVectors);
+    }
+    if (command.outputCost) {
+        validateBinding(*command.outputCost);
+    }
+    _data.commands.emplace_back(std::move(command));
+}
+
+void ScenarioBuilder::addDispatchBarrier(DispatchBarrierData command) {
+    ensureMutable();
+    for (const auto id : command.memoryBarriers) {
+        requireResource(_data.resources, id, "Memory barrier");
+    }
+    for (const auto id : command.imageBarriers) {
+        requireResource(_data.resources, id, "Image barrier");
+    }
+    for (const auto id : command.tensorBarriers) {
+        requireResource(_data.resources, id, "Tensor barrier");
+    }
+    for (const auto id : command.bufferBarriers) {
+        requireResource(_data.resources, id, "Buffer barrier");
+    }
+    _data.commands.emplace_back(std::move(command));
+}
+
+void ScenarioBuilder::addMarkBoundary(MarkBoundaryData command) {
+    ensureMutable();
+    for (const auto resource : command.buffers) {
+        requireResource(_data.resources, resource, "Buffer");
+    }
+    for (const auto resource : command.images) {
+        requireResource(_data.resources, resource, "Image");
+    }
+    for (const auto resource : command.tensors) {
+        requireResource(_data.resources, resource, "Tensor");
+    }
+    _data.commands.emplace_back(std::move(command));
+}
+
+detail::ScenarioBuildData ScenarioBuilder::takeBuildData() {
+    ensureMutable();
+    _built = true;
+    return std::move(_data);
+}
+
+} // namespace mlsdk::scenariorunner

--- a/src/scenario_builder.hpp
+++ b/src/scenario_builder.hpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "command_types.hpp"
+#include "group_manager.hpp"
+#include "resource_manager.hpp"
+
+namespace mlsdk::scenariorunner {
+
+namespace detail {
+struct ScenarioBuildData {
+    ResourceManager resources;
+    GroupManager groupManager;
+    std::vector<ScenarioCommand> commands;
+};
+} // namespace detail
+
+class ScenarioBuilder {
+  public:
+    BufferId addBuffer(const BufferInfo &info);
+    BufferId addBuffer(BufferInfo &&info);
+    ImageId addImage(const ImageInfo &info);
+    ImageId addImage(ImageInfo &&info);
+    TensorId addTensor(const TensorInfo &info);
+    TensorId addTensor(TensorInfo &&info);
+    ShaderId addShader(const ShaderInfo &info);
+    ShaderId addShader(ShaderInfo &&info);
+    RawDataId addRawData(const RawDataInfo &info);
+    RawDataId addRawData(RawDataInfo &&info);
+    DataGraphId addDataGraph(const DataGraphInfo &info);
+    DataGraphId addDataGraph(DataGraphInfo &&info);
+    GraphConstantResourceId addGraphConstant(const GraphConstantInfo &info);
+    GraphConstantResourceId addGraphConstant(GraphConstantInfo &&info);
+
+    ImageBarrierId addImageBarrier(const ImageBarrierInfo &info);
+    BufferBarrierId addBufferBarrier(const BufferBarrierInfo &info);
+    TensorBarrierId addTensorBarrier(const TensorBarrierInfo &info);
+    MemoryBarrierId addMemoryBarrier(const MemoryBarrierInfo &info);
+
+    MemoryGroupId createMemoryGroup();
+    void addResourceToMemoryGroup(MemoryGroupId group, MemoryResourceId resource);
+
+    void addDispatchCompute(DispatchComputeData command);
+    void addDispatchFragment(DispatchFragmentData command);
+    void addDispatchDataGraph(DispatchDataGraphData command);
+    void addDispatchSpirvGraph(DispatchSpirvGraphData command);
+    void addDispatchOpticalFlow(DispatchOpticalFlowData command);
+    void addDispatchBarrier(DispatchBarrierData command);
+    void addMarkBoundary(MarkBoundaryData command);
+
+  private:
+    friend class Scenario;
+
+    detail::ScenarioBuildData takeBuildData();
+    void ensureMutable() const;
+    void validateMemoryResource(MemoryResourceId resource) const;
+    void validateBinding(const TypedBinding &binding) const;
+    void validateGroup(MemoryGroupId group) const;
+
+    detail::ScenarioBuildData _data;
+    bool _built{};
+};
+
+} // namespace mlsdk::scenariorunner


### PR DESCRIPTION
Build typed resources, memory groups, barriers, and commands through ScenarioBuilder before Scenario creates runtime resources. Keep GUID translation local to the JSON path while runtime setup uses typed IDs.


Change-Id: Idb45731a0635763a068047361a24b929d5b03fd3