### PR TITLE
refactor: add IScenario interface

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -5,7 +5,7 @@
 #include "context.hpp"
 
 #include "logging.hpp"
-#include "scenario.hpp"
+#include "scenario_options.hpp"
 
 #include <iomanip>
 #include <iostream>

--- a/src/iscenario.hpp
+++ b/src/iscenario.hpp
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "resource_data.hpp"
+#include "resource_id.hpp"
+
+#include <string_view>
+
+namespace mlsdk::scenariorunner {
+
+/// @brief Public interface for executing a built scenario and transferring resource data.
+///
+/// Implementations own the built resources and pipelines. A caller can upload new input data,
+/// execute the scenario, and download output data repeatedly without rebuilding those resources.
+class IScenario {
+  public:
+    virtual ~IScenario() = default;
+
+    /// @brief Execute the scenario one or more times.
+    /// @param repeatCount Number of executions; must be greater than zero.
+    /// @param dryRun Skip workload execution and output-resource saving.
+    virtual void run(int repeatCount = 1, bool dryRun = false) = 0;
+
+    virtual BufferId getBufferId(std::string_view uid) const = 0;
+    virtual ImageId getImageId(std::string_view uid) const = 0;
+    virtual TensorId getTensorId(std::string_view uid) const = 0;
+
+    virtual void upload(BufferId id, const BufferDataView &data) = 0;
+    virtual void upload(ImageId id, const ImageDataView &data) = 0;
+    virtual void upload(TensorId id, const TensorDataView &data) = 0;
+
+    virtual BufferData download(BufferId id) const = 0;
+    virtual ImageData download(ImageId id) = 0;
+    virtual TensorData download(TensorId id) const = 0;
+};
+
+} // namespace mlsdk::scenariorunner

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,8 +6,10 @@
 #include <argparse/argparse.hpp>
 #include <vgf/logging.hpp>
 
+#include "iscenario.hpp"
 #include "logging.hpp"
 #include "scenario.hpp"
+#include "scenario_options.hpp"
 #include "version.hpp"
 
 #include <chrono>
@@ -16,6 +18,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -324,12 +327,12 @@ int runScenarioRunner(int argc, const char **argv) {
 
         ScenarioSpec scenarioSpec(scenarioFile, workDir, outputDir);
         mlsdk::logging::info("Scenario file parsed");
-        Scenario scenario(scenarioOptions, scenarioSpec);
+        std::unique_ptr<IScenario> scenario = std::make_unique<Scenario>(scenarioOptions, scenarioSpec);
         if (parser.get<bool>("--wait-for-key-stroke-before-run")) {
             mlsdk::logging::info("Press enter to continue...");
             std::ignore = getchar();
         }
-        scenario.run(repeatCount, dryRun);
+        scenario->run(repeatCount, dryRun);
     } catch (const std::exception &err) {
         mlsdk::logging::error(err.what());
         retval = -1;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -740,10 +740,12 @@ Scenario::Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec)
     setupRuntimeCommands();
 }
 
-Scenario::~Scenario() = default;
-
 BufferId Scenario::getBufferId(std::string_view uid) const {
     return resolveResourceUid<BufferId>(_resourceIds, uid, "Buffer", "getBufferId");
+}
+
+ImageId Scenario::getImageId(std::string_view uid) const {
+    return resolveResourceUid<ImageId>(_resourceIds, uid, "Image", "getImageId");
 }
 
 TensorId Scenario::getTensorId(std::string_view uid) const {
@@ -755,6 +757,13 @@ void Scenario::upload(BufferId id, const BufferDataView &data) {
         throw std::runtime_error("Scenario::upload: Buffer resource not found.");
     }
     _dataManager.getBuffer(id).upload(_ctx, data);
+}
+
+void Scenario::upload(ImageId id, const ImageDataView &data) {
+    if (!_dataManager.hasImage(id)) {
+        throw std::runtime_error("Scenario::upload: Image resource not found.");
+    }
+    _dataManager.getImageMut(id).upload(_ctx, data);
 }
 
 void Scenario::upload(TensorId id, const TensorDataView &data) {
@@ -769,6 +778,13 @@ BufferData Scenario::download(BufferId id) const {
         throw std::runtime_error("Scenario::download: Buffer resource not found.");
     }
     return _dataManager.getBuffer(id).download(_ctx);
+}
+
+ImageData Scenario::download(ImageId id) {
+    if (!_dataManager.hasImage(id)) {
+        throw std::runtime_error("Scenario::download: Image resource not found.");
+    }
+    return _dataManager.getImageMut(id).download(_ctx);
 }
 
 TensorData Scenario::download(TensorId id) const {

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -11,9 +11,11 @@
 #include "data_manager.hpp"
 #include "frame_capturer.hpp"
 #include "group_manager.hpp"
+#include "iscenario.hpp"
 #include "resource_data.hpp"
 #include "resource_manager.hpp"
 #include "scenario_desc.hpp"
+#include "scenario_options.hpp"
 #include "types.hpp"
 
 #include <string>
@@ -24,59 +26,43 @@
 namespace mlsdk::scenariorunner {
 class ScenarioBuilder;
 
-/// \brief Options that are passed for configuring a scenario
-struct ScenarioOptions {
-    bool enablePipelineCaching{false};
-    bool clearPipelineCache{false};
-    bool failOnPipelineCacheMiss{false};
-    bool enableGPUDebugMarkers{false};
-    bool captureFrame{false};
-    bool enableRobustnessFeatures{false};
-    std::filesystem::path pipelineCachePath;
-    std::filesystem::path neuralDebugDatabaseDumpDir;
-    std::filesystem::path neuralStatisticsDumpDir;
-    std::filesystem::path graphProfilingDumpDir;
-    std::filesystem::path sessionRAMsDumpDir;
-    std::filesystem::path perfCountersPath;
-    std::filesystem::path profilingPath;
-    std::vector<std::string> disabledExtensions;
-    vk::NeuralAcceleratorStatisticsModeARM neuralStatisticsMode{};
-
-    bool shouldDumpNeuralDebugDatabase() const { return !neuralDebugDatabaseDumpDir.empty(); }
-    bool shouldDumpNeuralStatistics() const { return !neuralStatisticsDumpDir.empty(); }
-    bool shouldDumpGraphProfiling() const { return !graphProfilingDumpDir.empty(); }
-};
-
-class Scenario {
+class Scenario : public IScenario {
   public:
     /// \brief Constructor
     Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec);
 
     /// \brief Destructor
-    ~Scenario();
+    ~Scenario() override = default;
 
-    /// \brief Executes the test case one or more times
-    /// \param repeatCount Number of executions; must be greater than zero
-    /// \param dryRun Skip workload execution and output-resource saving
-    void run(int repeatCount = 1, bool dryRun = false);
+    /// \brief Execute the scenario one or more times.
+    void run(int repeatCount = 1, bool dryRun = false) override;
 
     /// \brief Get a buffer resource ID from its UID
-    BufferId getBufferId(std::string_view uid) const;
+    BufferId getBufferId(std::string_view uid) const override;
+
+    /// \brief Get an image resource ID from its UID
+    ImageId getImageId(std::string_view uid) const override;
 
     /// \brief Get a tensor resource ID from its UID
-    TensorId getTensorId(std::string_view uid) const;
+    TensorId getTensorId(std::string_view uid) const override;
 
     /// \brief Upload data to an existing buffer resource
-    void upload(BufferId id, const BufferDataView &data);
+    void upload(BufferId id, const BufferDataView &data) override;
+
+    /// \brief Upload data to an existing image resource
+    void upload(ImageId id, const ImageDataView &data) override;
 
     /// \brief Upload data to an existing tensor resource
-    void upload(TensorId id, const TensorDataView &data);
+    void upload(TensorId id, const TensorDataView &data) override;
 
     /// \brief Download data from an existing buffer resource
-    BufferData download(BufferId id) const;
+    BufferData download(BufferId id) const override;
+
+    /// \brief Download data from an existing image resource
+    ImageData download(ImageId id) override;
 
     /// \brief Download data from an existing tensor resource
-    TensorData download(TensorId id) const;
+    TensorData download(TensorId id) const override;
 
   private:
     void runIteration(int iteration, int repeatCount, bool dryRun);

--- a/src/scenario_options.hpp
+++ b/src/scenario_options.hpp
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace mlsdk::scenariorunner {
+
+/// @brief Options that are passed for configuring a scenario.
+struct ScenarioOptions {
+    bool enablePipelineCaching{false};
+    bool clearPipelineCache{false};
+    bool failOnPipelineCacheMiss{false};
+    bool enableGPUDebugMarkers{false};
+    bool captureFrame{false};
+    bool enableRobustnessFeatures{false};
+    std::filesystem::path pipelineCachePath;
+    std::filesystem::path neuralDebugDatabaseDumpDir;
+    std::filesystem::path neuralStatisticsDumpDir;
+    std::filesystem::path graphProfilingDumpDir;
+    std::filesystem::path sessionRAMsDumpDir;
+    std::filesystem::path perfCountersPath;
+    std::filesystem::path profilingPath;
+    std::vector<std::string> disabledExtensions;
+    vk::NeuralAcceleratorStatisticsModeARM neuralStatisticsMode{};
+
+    bool shouldDumpNeuralDebugDatabase() const { return !neuralDebugDatabaseDumpDir.empty(); }
+    bool shouldDumpNeuralStatistics() const { return !neuralStatisticsDumpDir.empty(); }
+    bool shouldDumpGraphProfiling() const { return !graphProfilingDumpDir.empty(); }
+};
+
+} // namespace mlsdk::scenariorunner

--- a/src/tests/buffer_tests.cpp
+++ b/src/tests/buffer_tests.cpp
@@ -4,9 +4,10 @@
  */
 
 #include "buffer.hpp"
+#include "context.hpp"
 #include "data_manager.hpp"
 #include "resource_data.hpp"
-#include "scenario.hpp"
+#include "scenario_options.hpp"
 #include <gtest/gtest.h>
 
 #include <numeric>

--- a/src/tests/image_tests.cpp
+++ b/src/tests/image_tests.cpp
@@ -7,6 +7,7 @@
 #include "image.hpp"
 #include "resource_data.hpp"
 #include "scenario.hpp"
+#include "scenario_options.hpp"
 #include "utils.hpp"
 
 #include <numeric>
@@ -50,6 +51,36 @@ Image &prepareImage(Context &ctx, DataManager &dataManager, ImageId id, const st
     return image;
 }
 } // namespace
+
+TEST(IScenario, ScenarioSupportsImageTransfers) {
+    const std::string scenarioJson = R"(
+        {
+            "commands": [],
+            "resources": [
+                {
+                    "image": {
+                        "uid": "inImage",
+                        "dims": [1, 2, 2, 1],
+                        "format": "VK_FORMAT_R8_UINT",
+                        "shader_access": "readwrite",
+                        "mips": 1
+                    }
+                }
+            ]
+        }
+    )";
+    ScenarioSpec spec{scenarioJson};
+    spec.useComputeFamilyQueue = true;
+    Scenario scenario{ScenarioOptions{}, spec};
+    IScenario &api = scenario;
+    const auto imageId = api.getImageId("inImage");
+    const std::vector<char> payload{1, 2, 3, 4};
+
+    api.upload(imageId, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Uint});
+    api.run();
+
+    EXPECT_EQ(api.download(imageId).data, payload);
+}
 
 TEST(ImageInMemoryTransfer, UploadValidatesMetadataAndSize) {
     ScenarioOptions opts{};

--- a/src/tests/scenario_tests.cpp
+++ b/src/tests/scenario_tests.cpp
@@ -3,13 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "glsl_compiler.hpp"
 #include "resource_data.hpp"
 #include "scenario.hpp"
 #include "scenario_desc.hpp"
+#include "scenario_options.hpp"
+#include "shader_stage.hpp"
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <cstring>
+#include <string_view>
 #include <vector>
+
+#include "vgf-utils/temp_folder.hpp"
 
 using namespace mlsdk::scenariorunner;
 
@@ -36,7 +44,28 @@ const std::string scenarioJson = R"(
             ]
         }
     )";
+
+template <typename T> std::vector<char> asBytes(const std::vector<T> &values) {
+    std::vector<char> bytes(values.size() * sizeof(T));
+    std::memcpy(bytes.data(), values.data(), bytes.size());
+    return bytes;
+}
 } // namespace
+
+TEST(IScenario, ScenarioSupportsVirtualDispatch) {
+    ScenarioSpec spec{scenarioJson};
+    spec.useComputeFamilyQueue = true;
+    Scenario scenario{ScenarioOptions{}, spec};
+    IScenario &api = scenario;
+
+    const auto bufferId = api.getBufferId("inBuffer");
+    const std::vector<char> payload{1, 2, 3, 4};
+    api.upload(bufferId, {payload.data(), payload.size()});
+    api.run();
+
+    EXPECT_EQ(api.download(bufferId).data, payload);
+    EXPECT_EQ(api.getTensorId("inTensor"), scenario.getTensorId("inTensor"));
+}
 
 TEST(ScenarioInMemoryTransfer, UploadsAndDownloadsByTypedIdAcrossRuns) {
     ScenarioSpec spec{scenarioJson};
@@ -125,4 +154,110 @@ TEST(ScenarioInMemoryTransfer, RejectsUnknownTypedIds) {
                 "Scenario::getBufferId: resource UID 'inTensor' does not identify a Buffer resource.");
     expectError([&] { static_cast<void>(scenario.getTensorId("inBuffer")); },
                 "Scenario::getTensorId: resource UID 'inBuffer' does not identify a Tensor resource.");
+}
+
+TEST(IScenario, SupportsTensorUploadAndDownload) {
+    ScenarioSpec spec{scenarioJson};
+    spec.useComputeFamilyQueue = true;
+    Scenario scenario{ScenarioOptions{}, spec};
+    IScenario &api = scenario;
+
+    const auto tensorId = api.getTensorId("inTensor");
+    const std::vector<char> payload{1, 2, 3, 4};
+    api.upload(tensorId, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
+
+    const auto result = api.download(tensorId);
+    EXPECT_EQ(result.data, payload);
+    EXPECT_EQ(result.shape, (std::vector<int64_t>{1, 2, 2, 1}));
+    ASSERT_TRUE(result.format.has_value());
+    EXPECT_EQ(result.format.value(), vk::Format::eR8Sint);
+}
+
+TEST(IScenario, SupportsRepeatedUploadRunDownload) {
+    ScenarioSpec spec{scenarioJson};
+    spec.useComputeFamilyQueue = true;
+    Scenario scenario{ScenarioOptions{}, spec};
+    IScenario &api = scenario;
+    const auto bufferId = api.getBufferId("inBuffer");
+
+    const std::vector<char> firstPayload{1, 2, 3, 4};
+    api.upload(bufferId, {firstPayload.data(), firstPayload.size()});
+    api.run();
+    EXPECT_EQ(api.download(bufferId).data, firstPayload);
+
+    const std::vector<char> secondPayload{5, 6, 7, 8};
+    api.upload(bufferId, {secondPayload.data(), secondPayload.size()});
+    api.run();
+    EXPECT_EQ(api.download(bufferId).data, secondPayload);
+}
+
+TEST(IScenario, ExecutesCommandWithDifferentInputsAcrossRuns) {
+    constexpr std::string_view shaderSource = R"(
+        #version 450
+        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+        layout(set = 0, binding = 0) readonly buffer Input { uint values[]; } inputBuffer;
+        layout(set = 0, binding = 1) writeonly buffer Output { uint values[]; } outputBuffer;
+        void main() {
+            outputBuffer.values[gl_GlobalInvocationID.x] = inputBuffer.values[gl_GlobalInvocationID.x] + 1;
+        }
+    )";
+    constexpr std::string_view computeScenarioJson = R"(
+        {
+            "commands": [
+                {
+                    "dispatch_compute": {
+                        "bindings": [
+                            {"id": 0, "set": 0, "resource_ref": "input"},
+                            {"id": 1, "set": 0, "resource_ref": "output"}
+                        ],
+                        "rangeND": [4],
+                        "shader_ref": "increment"
+                    }
+                }
+            ],
+            "resources": [
+                {"shader": {"src": "increment.spv", "type": "SPIR-V", "uid": "increment"}},
+                {"buffer": {"uid": "input", "size": 16, "shader_access": "readonly"}},
+                {"buffer": {"uid": "output", "size": 16, "shader_access": "readwrite"}}
+            ]
+        }
+    )";
+
+    TempFolder tempFolder("iscenario_compute_test");
+    const auto shaderPath = tempFolder.relative("increment.spv");
+    const auto spirv = GlslCompiler::get().compile(std::string{shaderSource}, ShaderStage::Compute);
+    ASSERT_TRUE(spirv.first.empty()) << spirv.first;
+    ASSERT_TRUE(GlslCompiler::get().save(spirv.second, shaderPath.string()));
+
+    ScenarioSpec spec{std::string{computeScenarioJson}, shaderPath.parent_path()};
+    Scenario scenario{ScenarioOptions{}, spec};
+    IScenario &api = scenario;
+    const auto inputId = api.getBufferId("input");
+    const auto outputId = api.getBufferId("output");
+
+    const auto firstInput = asBytes(std::vector<uint32_t>{1, 2, 3, 4});
+    api.upload(inputId, {firstInput.data(), firstInput.size()});
+    api.run();
+    EXPECT_EQ(api.download(outputId).data, asBytes(std::vector<uint32_t>{2, 3, 4, 5}));
+
+    const auto secondInput = asBytes(std::vector<uint32_t>{10, 20, 30, 40});
+    api.upload(inputId, {secondInput.data(), secondInput.size()});
+    api.run();
+    EXPECT_EQ(api.download(outputId).data, asBytes(std::vector<uint32_t>{11, 21, 31, 41}));
+}
+
+TEST(IScenario, RejectsUnknownTypedIds) {
+    ScenarioSpec spec{scenarioJson};
+    spec.useComputeFamilyQueue = true;
+    Scenario scenario{ScenarioOptions{}, spec};
+    IScenario &api = scenario;
+    const std::vector<char> payload(4);
+
+    EXPECT_THROW(api.upload(BufferId{1}, {payload.data(), payload.size()}), std::runtime_error);
+    EXPECT_THROW(api.upload(TensorId{1}, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Sint}),
+                 std::runtime_error);
+    EXPECT_THROW(api.upload(ImageId{0}, {}), std::runtime_error);
+    EXPECT_THROW(static_cast<void>(api.download(BufferId{1})), std::runtime_error);
+    EXPECT_THROW(static_cast<void>(api.download(TensorId{1})), std::runtime_error);
+    EXPECT_THROW(static_cast<void>(api.download(ImageId{0})), std::runtime_error);
 }

--- a/src/tests/tensor_tests.cpp
+++ b/src/tests/tensor_tests.cpp
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "context.hpp"
 #include "data_manager.hpp"
 #include "resource_data.hpp"
-#include "scenario.hpp"
+#include "scenario_options.hpp"
 #include "tensor.hpp"
 #include "utils.hpp"
 

--- a/src/tests/vulkan_startup_tests.cpp
+++ b/src/tests/vulkan_startup_tests.cpp
@@ -6,8 +6,9 @@
 
 #include "commands.hpp"
 #include "compute.hpp"
+#include "context.hpp"
 #include "glsl_compiler.hpp"
-#include "scenario.hpp"
+#include "scenario_options.hpp"
 
 #include <vector>
 


### PR DESCRIPTION
Add a public interface for running a built scenario and transferring buffer, tensor, and image data using typed resource IDs.

Implement the interface in Scenario and use IScenario from the main runner path. Move ScenarioOptions into a standalone header to remove its dependency on the concrete Scenario class.

Change-Id: If9df01377bbf5d3409bece450300f03efcd1f4b3