### PR TITLE
refactor: add IScenarioBuilder interface

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,13 @@
 
 ## Unreleased
 
+### API Changes
+
+- Added `IScenario` as the public interface for running scenarios and transferring
+  buffer, image, and tensor data in memory using typed resource IDs.
+- Added `IScenarioBuilder` for registering typed resources and commands and
+  constructing an `IScenario`.
+
 ### Build, Packaging & Developer Experience
 
 - Updated Scenario Runner to consume explicit VGF graph constant bindings.

--- a/src/iscenario_builder.hpp
+++ b/src/iscenario_builder.hpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "command_types.hpp"
+#include "iscenario.hpp"
+#include "scenario_options.hpp"
+#include "types.hpp"
+
+#include <memory>
+
+namespace mlsdk::scenariorunner {
+
+struct ScenarioSpec;
+
+/// @brief Public interface for defining and building a scenario.
+///
+/// Resource registration returns stable typed IDs. Callers retain these IDs
+/// and use them to transfer data through the IScenario returned by build().
+class IScenarioBuilder {
+  public:
+    virtual ~IScenarioBuilder() = default;
+
+    virtual BufferId addBuffer(const BufferInfo &info) = 0;
+    virtual ImageId addImage(const ImageInfo &info) = 0;
+    virtual TensorId addTensor(const TensorInfo &info) = 0;
+    virtual ShaderId addShader(const ShaderInfo &info) = 0;
+    virtual RawDataId addRawData(const RawDataInfo &info) = 0;
+    virtual DataGraphId addDataGraph(const DataGraphInfo &info) = 0;
+    virtual GraphConstantResourceId addGraphConstant(const GraphConstantInfo &info) = 0;
+
+    virtual ImageBarrierId addImageBarrier(const ImageBarrierInfo &info) = 0;
+    virtual BufferBarrierId addBufferBarrier(const BufferBarrierInfo &info) = 0;
+    virtual TensorBarrierId addTensorBarrier(const TensorBarrierInfo &info) = 0;
+    virtual MemoryBarrierId addMemoryBarrier(const MemoryBarrierInfo &info) = 0;
+
+    virtual MemoryGroupId createMemoryGroup() = 0;
+    virtual void addResourceToMemoryGroup(MemoryGroupId group, MemoryResourceId resource) = 0;
+
+    virtual void addDispatchCompute(DispatchComputeData command) = 0;
+    virtual void addDispatchFragment(DispatchFragmentData command) = 0;
+    virtual void addDispatchDataGraph(DispatchDataGraphData command) = 0;
+    virtual void addDispatchSpirvGraph(DispatchSpirvGraphData command) = 0;
+    virtual void addDispatchOpticalFlow(DispatchOpticalFlowData command) = 0;
+    virtual void addDispatchBarrier(DispatchBarrierData command) = 0;
+    virtual void addMarkBoundary(MarkBoundaryData command) = 0;
+
+    /// @brief Consume the builder and return a ready-to-run scenario.
+    virtual std::unique_ptr<IScenario> build(const ScenarioOptions &options) = 0;
+
+    /// @brief Build the scenario described by a parsed scenario.json file.
+    virtual std::unique_ptr<IScenario> build(const ScenarioOptions &options, ScenarioSpec &spec) = 0;
+};
+
+} // namespace mlsdk::scenariorunner

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,9 +6,10 @@
 #include <argparse/argparse.hpp>
 #include <vgf/logging.hpp>
 
-#include "iscenario.hpp"
+#include "iscenario_builder.hpp"
 #include "logging.hpp"
-#include "scenario.hpp"
+#include "scenario_builder.hpp"
+#include "scenario_desc.hpp"
 #include "scenario_options.hpp"
 #include "version.hpp"
 
@@ -327,7 +328,8 @@ int runScenarioRunner(int argc, const char **argv) {
 
         ScenarioSpec scenarioSpec(scenarioFile, workDir, outputDir);
         mlsdk::logging::info("Scenario file parsed");
-        std::unique_ptr<IScenario> scenario = std::make_unique<Scenario>(scenarioOptions, scenarioSpec);
+        std::unique_ptr<IScenarioBuilder> builder = std::make_unique<ScenarioBuilder>();
+        std::unique_ptr<IScenario> scenario = builder->build(scenarioOptions, scenarioSpec);
         if (parser.get<bool>("--wait-for-key-stroke-before-run")) {
             mlsdk::logging::info("Press enter to continue...");
             std::ignore = getchar();

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -654,6 +654,15 @@ auto getFamilyQueue(const ScenarioSpec &spec) {
     }
     return FamilyQueue::DataGraph;
 }
+FamilyQueue getFamilyQueue(const detail::ScenarioBuildData &buildData) {
+    if (buildData.requiresGraphicsFamilyQueue) {
+        return FamilyQueue::Graphics;
+    }
+    if (buildData.useComputeFamilyQueue) {
+        return FamilyQueue::Compute;
+    }
+    return FamilyQueue::DataGraph;
+}
 
 // Map performance level to Vulkan enum
 auto getOpticalFlowPerformanceLevel(OpticalFlowPerformanceLevel performanceLevel) {
@@ -696,9 +705,16 @@ void verifyOpticalFlowData(const DataManager &dataManager, const DispatchOptical
 
 } // namespace
 
-Scenario::Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec)
-    : _opts{opts}, _ctx{opts, getFamilyQueue(scenarioSpec)}, _scenarioSpec(scenarioSpec), _compute(_ctx) {
-    buildJsonScenarioData(scenarioSpec);
+Scenario::Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec, ScenarioBuilder &builder)
+    : _opts{opts}, _ctx{opts, getFamilyQueue(scenarioSpec)}, _scenarioSpec{&scenarioSpec}, _compute(_ctx) {
+    buildJsonScenarioData(builder, scenarioSpec);
+    setupResources();
+    setupRuntimeCommands();
+}
+
+Scenario::Scenario(const ScenarioOptions &opts, detail::ScenarioBuildData buildData)
+    : _opts{opts}, _ctx{opts, getFamilyQueue(buildData)}, _resources{std::move(buildData.resources)},
+      _commands{std::move(buildData.commands)}, _compute(_ctx), _groupManager{std::move(buildData.groupManager)} {
     setupResources();
     setupRuntimeCommands();
 }
@@ -947,9 +963,8 @@ void registerJsonBarrierInfo(ScenarioBuilder &builder, const ScenarioSpec &scena
 }
 } // namespace
 
-void Scenario::buildJsonScenarioData(const ScenarioSpec &scenarioSpec) {
+void Scenario::buildJsonScenarioData(ScenarioBuilder &builder, const ScenarioSpec &scenarioSpec) {
     mlsdk::logging::info("Setup resources, count: " + std::to_string(scenarioSpec.resources.size()));
-    ScenarioBuilder builder;
     ResourceInfoFactory resourceInfoFactory;
     std::unordered_map<Guid, MemoryGroupId> jsonMemoryGroupIds;
     std::unordered_map<Guid, TypedResourceId> resourceIds;
@@ -1034,13 +1049,15 @@ void Scenario::setupResources() {
         _dataManager.getBufferMut(entry.id).allocateMemory(_ctx);
     }
 
-    loadJsonResourceData();
+    if (_scenarioSpec != nullptr) {
+        loadJsonResourceData();
+    }
 }
 
 void Scenario::loadJsonResourceData() {
     // Preserve description-based CLI initialization by routing it through the
     // same typed Scenario upload API used by in-memory clients.
-    for (const auto &resource : _scenarioSpec.resources) {
+    for (const auto &resource : _scenarioSpec->resources) {
         switch (resource->resourceType) {
         case ResourceType::Tensor: {
             const auto &tensor = reinterpret_cast<const std::unique_ptr<TensorDesc> &>(resource);
@@ -1577,27 +1594,29 @@ void Scenario::saveResults(bool dryRun) {
     // Save resources that have an output destination
     {
         PerfCounterGuard guard(_perfCounters, "Save Resources", "Save Results", false);
-        for (const auto &resourceDesc : _scenarioSpec.resources) {
-            const auto &dst = resourceDesc->getDestination();
-            if (dst.has_value()) {
-                switch (resourceDesc->resourceType) {
-                case ResourceType::Buffer:
-                    _dataManager.getBuffer(resolveResourceId<BufferId>(_resourceIds, resourceDesc->guid, "Buffer"))
-                        .store(_ctx, dst.value());
-                    break;
-                case ResourceType::Tensor:
-                    _dataManager.getTensor(resolveResourceId<TensorId>(_resourceIds, resourceDesc->guid, "Tensor"))
-                        .store(_ctx, dst.value());
-                    break;
-                case ResourceType::Image:
-                    _dataManager.getImageMut(resolveResourceId<ImageId>(_resourceIds, resourceDesc->guid, "Image"))
-                        .store(_ctx, dst.value());
-                    break;
-                default:
-                    throw std::runtime_error("Output destination is not supported for " + resourceType(resourceDesc) +
-                                             " resource " + resourceDesc->guidStr);
+        if (_scenarioSpec != nullptr) {
+            for (const auto &resourceDesc : _scenarioSpec->resources) {
+                const auto &dst = resourceDesc->getDestination();
+                if (dst.has_value()) {
+                    switch (resourceDesc->resourceType) {
+                    case ResourceType::Buffer:
+                        _dataManager.getBuffer(resolveResourceId<BufferId>(_resourceIds, resourceDesc->guid, "Buffer"))
+                            .store(_ctx, dst.value());
+                        break;
+                    case ResourceType::Tensor:
+                        _dataManager.getTensor(resolveResourceId<TensorId>(_resourceIds, resourceDesc->guid, "Tensor"))
+                            .store(_ctx, dst.value());
+                        break;
+                    case ResourceType::Image:
+                        _dataManager.getImageMut(resolveResourceId<ImageId>(_resourceIds, resourceDesc->guid, "Image"))
+                            .store(_ctx, dst.value());
+                        break;
+                    default:
+                        throw std::runtime_error("Output destination is not supported for " +
+                                                 resourceType(resourceDesc) + " resource " + resourceDesc->guidStr);
+                    }
+                    mlsdk::logging::debug(resourceType(resourceDesc) + " " + resourceDesc->guidStr + " output stored");
                 }
-                mlsdk::logging::debug(resourceType(resourceDesc) + " " + resourceDesc->guidStr + " output stored");
             }
         }
     }

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -25,12 +25,12 @@
 
 namespace mlsdk::scenariorunner {
 class ScenarioBuilder;
+namespace detail {
+struct ScenarioBuildData;
+} // namespace detail
 
 class Scenario : public IScenario {
   public:
-    /// \brief Constructor
-    Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec);
-
     /// \brief Destructor
     ~Scenario() override = default;
 
@@ -65,6 +65,11 @@ class Scenario : public IScenario {
     TensorData download(TensorId id) const override;
 
   private:
+    friend class ScenarioBuilder;
+
+    Scenario(const ScenarioOptions &opts, ScenarioSpec &scenarioSpec, ScenarioBuilder &builder);
+    Scenario(const ScenarioOptions &opts, detail::ScenarioBuildData buildData);
+
     void runIteration(int iteration, int repeatCount, bool dryRun);
 
     void createComputePipeline(const DispatchComputeData &dispatchCompute, uint32_t &nQueries);
@@ -77,7 +82,7 @@ class Scenario : public IScenario {
                         const VgfView &vgfView, const DispatchDataGraphData &dispatchDataGraph, uint32_t &nQueries);
 
     /// \brief Sets up runtime options
-    void buildJsonScenarioData(const ScenarioSpec &scenarioSpec);
+    void buildJsonScenarioData(ScenarioBuilder &builder, const ScenarioSpec &scenarioSpec);
     void resolveCommands(ScenarioBuilder &builder, const ScenarioSpec &scenarioSpec,
                          const std::unordered_map<Guid, TypedResourceId> &resourceIds);
     void setupResources();
@@ -108,7 +113,7 @@ class Scenario : public IScenario {
     std::unordered_map<Guid, TypedResourceId> _resourceIds;
     std::unordered_map<DataGraphId, VgfResourceCreationResult> _vgfResourceCreationResults;
     DataManager _dataManager;
-    ScenarioSpec &_scenarioSpec;
+    const ScenarioSpec *_scenarioSpec{};
     std::vector<detail::ScenarioCommand> _commands;
     std::shared_ptr<PipelineCache> _pipelineCache;
     Compute _compute;

--- a/src/scenario_builder.cpp
+++ b/src/scenario_builder.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "scenario_builder.hpp"
+#include "scenario.hpp"
 #include <stdexcept>
 #include <utility>
 
@@ -145,6 +146,7 @@ void ScenarioBuilder::addDispatchCompute(DispatchComputeData command) {
     if (command.pushData) {
         requireResource(_data.resources, *command.pushData, "Raw data");
     }
+    _data.useComputeFamilyQueue = true;
     _data.commands.emplace_back(std::move(command));
 }
 
@@ -161,6 +163,7 @@ void ScenarioBuilder::addDispatchFragment(DispatchFragmentData command) {
     if (command.pushData) {
         requireResource(_data.resources, *command.pushData, "Raw data");
     }
+    _data.requiresGraphicsFamilyQueue = true;
     _data.commands.emplace_back(std::move(command));
 }
 
@@ -234,6 +237,15 @@ void ScenarioBuilder::addMarkBoundary(MarkBoundaryData command) {
         requireResource(_data.resources, resource, "Tensor");
     }
     _data.commands.emplace_back(std::move(command));
+}
+
+std::unique_ptr<IScenario> ScenarioBuilder::build(const ScenarioOptions &options) {
+    return std::unique_ptr<IScenario>{new Scenario(options, takeBuildData())};
+}
+
+std::unique_ptr<IScenario> ScenarioBuilder::build(const ScenarioOptions &options, ScenarioSpec &spec) {
+    ensureMutable();
+    return std::unique_ptr<IScenario>{new Scenario(options, spec, *this)};
 }
 
 detail::ScenarioBuildData ScenarioBuilder::takeBuildData() {

--- a/src/scenario_builder.hpp
+++ b/src/scenario_builder.hpp
@@ -7,6 +7,7 @@
 
 #include "command_types.hpp"
 #include "group_manager.hpp"
+#include "iscenario_builder.hpp"
 #include "resource_manager.hpp"
 
 namespace mlsdk::scenariorunner {
@@ -16,41 +17,48 @@ struct ScenarioBuildData {
     ResourceManager resources;
     GroupManager groupManager;
     std::vector<ScenarioCommand> commands;
+    bool useComputeFamilyQueue{};
+    bool requiresGraphicsFamilyQueue{};
 };
 } // namespace detail
 
-class ScenarioBuilder {
+class ScenarioBuilder : public IScenarioBuilder {
   public:
-    BufferId addBuffer(const BufferInfo &info);
+    ~ScenarioBuilder() override = default;
+
+    BufferId addBuffer(const BufferInfo &info) override;
     BufferId addBuffer(BufferInfo &&info);
-    ImageId addImage(const ImageInfo &info);
+    ImageId addImage(const ImageInfo &info) override;
     ImageId addImage(ImageInfo &&info);
-    TensorId addTensor(const TensorInfo &info);
+    TensorId addTensor(const TensorInfo &info) override;
     TensorId addTensor(TensorInfo &&info);
-    ShaderId addShader(const ShaderInfo &info);
+    ShaderId addShader(const ShaderInfo &info) override;
     ShaderId addShader(ShaderInfo &&info);
-    RawDataId addRawData(const RawDataInfo &info);
+    RawDataId addRawData(const RawDataInfo &info) override;
     RawDataId addRawData(RawDataInfo &&info);
-    DataGraphId addDataGraph(const DataGraphInfo &info);
+    DataGraphId addDataGraph(const DataGraphInfo &info) override;
     DataGraphId addDataGraph(DataGraphInfo &&info);
-    GraphConstantResourceId addGraphConstant(const GraphConstantInfo &info);
+    GraphConstantResourceId addGraphConstant(const GraphConstantInfo &info) override;
     GraphConstantResourceId addGraphConstant(GraphConstantInfo &&info);
 
-    ImageBarrierId addImageBarrier(const ImageBarrierInfo &info);
-    BufferBarrierId addBufferBarrier(const BufferBarrierInfo &info);
-    TensorBarrierId addTensorBarrier(const TensorBarrierInfo &info);
-    MemoryBarrierId addMemoryBarrier(const MemoryBarrierInfo &info);
+    ImageBarrierId addImageBarrier(const ImageBarrierInfo &info) override;
+    BufferBarrierId addBufferBarrier(const BufferBarrierInfo &info) override;
+    TensorBarrierId addTensorBarrier(const TensorBarrierInfo &info) override;
+    MemoryBarrierId addMemoryBarrier(const MemoryBarrierInfo &info) override;
 
-    MemoryGroupId createMemoryGroup();
-    void addResourceToMemoryGroup(MemoryGroupId group, MemoryResourceId resource);
+    MemoryGroupId createMemoryGroup() override;
+    void addResourceToMemoryGroup(MemoryGroupId group, MemoryResourceId resource) override;
 
-    void addDispatchCompute(DispatchComputeData command);
-    void addDispatchFragment(DispatchFragmentData command);
-    void addDispatchDataGraph(DispatchDataGraphData command);
-    void addDispatchSpirvGraph(DispatchSpirvGraphData command);
-    void addDispatchOpticalFlow(DispatchOpticalFlowData command);
-    void addDispatchBarrier(DispatchBarrierData command);
-    void addMarkBoundary(MarkBoundaryData command);
+    void addDispatchCompute(DispatchComputeData command) override;
+    void addDispatchFragment(DispatchFragmentData command) override;
+    void addDispatchDataGraph(DispatchDataGraphData command) override;
+    void addDispatchSpirvGraph(DispatchSpirvGraphData command) override;
+    void addDispatchOpticalFlow(DispatchOpticalFlowData command) override;
+    void addDispatchBarrier(DispatchBarrierData command) override;
+    void addMarkBoundary(MarkBoundaryData command) override;
+
+    std::unique_ptr<IScenario> build(const ScenarioOptions &options) override;
+    std::unique_ptr<IScenario> build(const ScenarioOptions &options, ScenarioSpec &spec) override;
 
   private:
     friend class Scenario;

--- a/src/tests/image_tests.cpp
+++ b/src/tests/image_tests.cpp
@@ -5,11 +5,14 @@
 
 #include "data_manager.hpp"
 #include "image.hpp"
+#include "iscenario_builder.hpp"
 #include "resource_data.hpp"
-#include "scenario.hpp"
+#include "scenario_builder.hpp"
+#include "scenario_desc.hpp"
 #include "scenario_options.hpp"
 #include "utils.hpp"
 
+#include <memory>
 #include <numeric>
 #include <vector>
 
@@ -71,15 +74,15 @@ TEST(IScenario, ScenarioSupportsImageTransfers) {
     )";
     ScenarioSpec spec{scenarioJson};
     spec.useComputeFamilyQueue = true;
-    Scenario scenario{ScenarioOptions{}, spec};
-    IScenario &api = scenario;
-    const auto imageId = api.getImageId("inImage");
+    std::unique_ptr<IScenarioBuilder> builder = std::make_unique<ScenarioBuilder>();
+    auto api = builder->build(ScenarioOptions{}, spec);
+    const auto imageId = api->getImageId("inImage");
     const std::vector<char> payload{1, 2, 3, 4};
 
-    api.upload(imageId, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Uint});
-    api.run();
+    api->upload(imageId, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Uint});
+    api->run();
 
-    EXPECT_EQ(api.download(imageId).data, payload);
+    EXPECT_EQ(api->download(imageId).data, payload);
 }
 
 TEST(ImageInMemoryTransfer, UploadValidatesMetadataAndSize) {

--- a/src/tests/scenario_tests.cpp
+++ b/src/tests/scenario_tests.cpp
@@ -4,8 +4,10 @@
  */
 
 #include "glsl_compiler.hpp"
+#include "iscenario_builder.hpp"
 #include "resource_data.hpp"
 #include "scenario.hpp"
+#include "scenario_builder.hpp"
 #include "scenario_desc.hpp"
 #include "scenario_options.hpp"
 #include "shader_stage.hpp"
@@ -15,6 +17,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "vgf-utils/temp_folder.hpp"
@@ -50,57 +53,75 @@ template <typename T> std::vector<char> asBytes(const std::vector<T> &values) {
     std::memcpy(bytes.data(), values.data(), bytes.size());
     return bytes;
 }
+
+std::unique_ptr<IScenario> buildScenario(ScenarioSpec &spec) {
+    std::unique_ptr<IScenarioBuilder> builder = std::make_unique<ScenarioBuilder>();
+    return builder->build(ScenarioOptions{}, spec);
+}
 } // namespace
+
+TEST(IScenarioBuilder, BuildsScenarioWithRetainedTypedHandles) {
+    std::unique_ptr<IScenarioBuilder> builder = std::make_unique<ScenarioBuilder>();
+    const auto bufferId = builder->addBuffer(BufferInfo{"in_memory_buffer", 4, 0});
+
+    std::unique_ptr<IScenario> scenario = builder->build(ScenarioOptions{});
+    const std::vector<char> payload{1, 2, 3, 4};
+    scenario->upload(bufferId, {payload.data(), payload.size()});
+    scenario->run();
+
+    EXPECT_EQ(scenario->download(bufferId).data, payload);
+    EXPECT_THROW(builder->build(ScenarioOptions{}), std::runtime_error);
+}
 
 TEST(IScenario, ScenarioSupportsVirtualDispatch) {
     ScenarioSpec spec{scenarioJson};
     spec.useComputeFamilyQueue = true;
-    Scenario scenario{ScenarioOptions{}, spec};
-    IScenario &api = scenario;
+    std::unique_ptr<IScenarioBuilder> builder = std::make_unique<ScenarioBuilder>();
+    std::unique_ptr<IScenario> api = builder->build(ScenarioOptions{}, spec);
 
-    const auto bufferId = api.getBufferId("inBuffer");
+    const auto bufferId = api->getBufferId("inBuffer");
     const std::vector<char> payload{1, 2, 3, 4};
-    api.upload(bufferId, {payload.data(), payload.size()});
-    api.run();
+    api->upload(bufferId, {payload.data(), payload.size()});
+    api->run();
 
-    EXPECT_EQ(api.download(bufferId).data, payload);
-    EXPECT_EQ(api.getTensorId("inTensor"), scenario.getTensorId("inTensor"));
+    EXPECT_EQ(api->download(bufferId).data, payload);
+    EXPECT_EQ(api->getTensorId("inTensor").value(), 0U);
 }
 
 TEST(ScenarioInMemoryTransfer, UploadsAndDownloadsByTypedIdAcrossRuns) {
     ScenarioSpec spec{scenarioJson};
     spec.useComputeFamilyQueue = true;
-    Scenario scenario{ScenarioOptions{}, spec};
+    auto scenario = buildScenario(spec);
 
-    const auto bufferId = scenario.getBufferId("inBuffer");
-    const auto tensorId = scenario.getTensorId("inTensor");
+    const auto bufferId = scenario->getBufferId("inBuffer");
+    const auto tensorId = scenario->getTensorId("inTensor");
 
     std::vector<char> firstBuffer{1, 2, 3, 4};
     std::vector<char> firstTensor{5, 6, 7, 8};
-    scenario.upload(bufferId, {firstBuffer.data(), firstBuffer.size()});
-    scenario.upload(tensorId, {firstTensor.data(), firstTensor.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
-    scenario.run();
+    scenario->upload(bufferId, {firstBuffer.data(), firstBuffer.size()});
+    scenario->upload(tensorId, {firstTensor.data(), firstTensor.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
+    scenario->run();
 
-    EXPECT_EQ(scenario.download(bufferId).data, firstBuffer);
-    EXPECT_EQ(scenario.download(tensorId).data, firstTensor);
+    EXPECT_EQ(scenario->download(bufferId).data, firstBuffer);
+    EXPECT_EQ(scenario->download(tensorId).data, firstTensor);
 
     std::vector<char> secondBuffer{9, 10, 11, 12};
     std::vector<char> secondTensor{13, 14, 15, 16};
-    scenario.upload(bufferId, {secondBuffer.data(), secondBuffer.size()});
-    scenario.upload(tensorId, {secondTensor.data(), secondTensor.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
-    scenario.run();
+    scenario->upload(bufferId, {secondBuffer.data(), secondBuffer.size()});
+    scenario->upload(tensorId, {secondTensor.data(), secondTensor.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
+    scenario->run();
 
-    EXPECT_EQ(scenario.download(bufferId).data, secondBuffer);
-    EXPECT_EQ(scenario.download(tensorId).data, secondTensor);
+    EXPECT_EQ(scenario->download(bufferId).data, secondBuffer);
+    EXPECT_EQ(scenario->download(tensorId).data, secondTensor);
 }
 
 TEST(ScenarioInMemoryTransfer, InitializesResourcesWithoutSourcesThroughTypedUploadPath) {
     ScenarioSpec spec{scenarioJson};
     spec.useComputeFamilyQueue = true;
-    Scenario scenario{ScenarioOptions{}, spec};
+    auto scenario = buildScenario(spec);
 
-    const auto buffer = scenario.download(scenario.getBufferId("inBuffer"));
-    const auto tensor = scenario.download(scenario.getTensorId("inTensor"));
+    const auto buffer = scenario->download(scenario->getBufferId("inBuffer"));
+    const auto tensor = scenario->download(scenario->getTensorId("inTensor"));
 
     EXPECT_EQ(buffer.data, std::vector<char>(4, 0));
     EXPECT_EQ(tensor.data, std::vector<char>(4, 0));
@@ -112,10 +133,10 @@ TEST(ScenarioInMemoryTransfer, InitializesResourcesWithoutSourcesThroughTypedUpl
 TEST(ScenarioInMemoryTransfer, RejectsNonPositiveRepeatCount) {
     ScenarioSpec spec{scenarioJson};
     spec.useComputeFamilyQueue = true;
-    Scenario scenario{ScenarioOptions{}, spec};
+    auto scenario = buildScenario(spec);
 
     try {
-        scenario.run(0);
+        scenario->run(0);
         FAIL() << "Expected std::invalid_argument";
     } catch (const std::invalid_argument &error) {
         EXPECT_STREQ(error.what(), "Scenario repeat count must be greater than zero; received 0.");
@@ -125,7 +146,7 @@ TEST(ScenarioInMemoryTransfer, RejectsNonPositiveRepeatCount) {
 TEST(ScenarioInMemoryTransfer, RejectsUnknownTypedIds) {
     ScenarioSpec spec{scenarioJson};
     spec.useComputeFamilyQueue = true;
-    Scenario scenario{ScenarioOptions{}, spec};
+    auto scenario = buildScenario(spec);
 
     const std::vector<char> data(4);
     const auto expectError = [](const auto &operation, const char *expectedMessage) {
@@ -137,36 +158,35 @@ TEST(ScenarioInMemoryTransfer, RejectsUnknownTypedIds) {
         }
     };
 
-    expectError([&] { scenario.upload(BufferId{1}, {data.data(), data.size()}); },
+    expectError([&] { scenario->upload(BufferId{1}, {data.data(), data.size()}); },
                 "Scenario::upload: Buffer resource not found.");
-    expectError([&] { scenario.upload(TensorId{1}, {data.data(), data.size(), {1, 2, 2, 1}, vk::Format::eR8Sint}); },
+    expectError([&] { scenario->upload(TensorId{1}, {data.data(), data.size(), {1, 2, 2, 1}, vk::Format::eR8Sint}); },
                 "Scenario::upload: Tensor resource not found.");
-    expectError([&] { static_cast<void>(scenario.download(BufferId{1})); },
+    expectError([&] { static_cast<void>(scenario->download(BufferId{1})); },
                 "Scenario::download: Buffer resource not found.");
-    expectError([&] { static_cast<void>(scenario.download(TensorId{1})); },
+    expectError([&] { static_cast<void>(scenario->download(TensorId{1})); },
                 "Scenario::download: Tensor resource not found.");
 
-    expectError([&] { static_cast<void>(scenario.getBufferId("missing")); },
+    expectError([&] { static_cast<void>(scenario->getBufferId("missing")); },
                 "Scenario::getBufferId: resource UID 'missing' not found.");
-    expectError([&] { static_cast<void>(scenario.getTensorId("missing")); },
+    expectError([&] { static_cast<void>(scenario->getTensorId("missing")); },
                 "Scenario::getTensorId: resource UID 'missing' not found.");
-    expectError([&] { static_cast<void>(scenario.getBufferId("inTensor")); },
+    expectError([&] { static_cast<void>(scenario->getBufferId("inTensor")); },
                 "Scenario::getBufferId: resource UID 'inTensor' does not identify a Buffer resource.");
-    expectError([&] { static_cast<void>(scenario.getTensorId("inBuffer")); },
+    expectError([&] { static_cast<void>(scenario->getTensorId("inBuffer")); },
                 "Scenario::getTensorId: resource UID 'inBuffer' does not identify a Tensor resource.");
 }
 
 TEST(IScenario, SupportsTensorUploadAndDownload) {
     ScenarioSpec spec{scenarioJson};
     spec.useComputeFamilyQueue = true;
-    Scenario scenario{ScenarioOptions{}, spec};
-    IScenario &api = scenario;
+    auto api = buildScenario(spec);
 
-    const auto tensorId = api.getTensorId("inTensor");
+    const auto tensorId = api->getTensorId("inTensor");
     const std::vector<char> payload{1, 2, 3, 4};
-    api.upload(tensorId, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
+    api->upload(tensorId, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
 
-    const auto result = api.download(tensorId);
+    const auto result = api->download(tensorId);
     EXPECT_EQ(result.data, payload);
     EXPECT_EQ(result.shape, (std::vector<int64_t>{1, 2, 2, 1}));
     ASSERT_TRUE(result.format.has_value());
@@ -176,19 +196,18 @@ TEST(IScenario, SupportsTensorUploadAndDownload) {
 TEST(IScenario, SupportsRepeatedUploadRunDownload) {
     ScenarioSpec spec{scenarioJson};
     spec.useComputeFamilyQueue = true;
-    Scenario scenario{ScenarioOptions{}, spec};
-    IScenario &api = scenario;
-    const auto bufferId = api.getBufferId("inBuffer");
+    auto api = buildScenario(spec);
+    const auto bufferId = api->getBufferId("inBuffer");
 
     const std::vector<char> firstPayload{1, 2, 3, 4};
-    api.upload(bufferId, {firstPayload.data(), firstPayload.size()});
-    api.run();
-    EXPECT_EQ(api.download(bufferId).data, firstPayload);
+    api->upload(bufferId, {firstPayload.data(), firstPayload.size()});
+    api->run();
+    EXPECT_EQ(api->download(bufferId).data, firstPayload);
 
     const std::vector<char> secondPayload{5, 6, 7, 8};
-    api.upload(bufferId, {secondPayload.data(), secondPayload.size()});
-    api.run();
-    EXPECT_EQ(api.download(bufferId).data, secondPayload);
+    api->upload(bufferId, {secondPayload.data(), secondPayload.size()});
+    api->run();
+    EXPECT_EQ(api->download(bufferId).data, secondPayload);
 }
 
 TEST(IScenario, ExecutesCommandWithDifferentInputsAcrossRuns) {
@@ -201,27 +220,6 @@ TEST(IScenario, ExecutesCommandWithDifferentInputsAcrossRuns) {
             outputBuffer.values[gl_GlobalInvocationID.x] = inputBuffer.values[gl_GlobalInvocationID.x] + 1;
         }
     )";
-    constexpr std::string_view computeScenarioJson = R"(
-        {
-            "commands": [
-                {
-                    "dispatch_compute": {
-                        "bindings": [
-                            {"id": 0, "set": 0, "resource_ref": "input"},
-                            {"id": 1, "set": 0, "resource_ref": "output"}
-                        ],
-                        "rangeND": [4],
-                        "shader_ref": "increment"
-                    }
-                }
-            ],
-            "resources": [
-                {"shader": {"src": "increment.spv", "type": "SPIR-V", "uid": "increment"}},
-                {"buffer": {"uid": "input", "size": 16, "shader_access": "readonly"}},
-                {"buffer": {"uid": "output", "size": 16, "shader_access": "readwrite"}}
-            ]
-        }
-    )";
 
     TempFolder tempFolder("iscenario_compute_test");
     const auto shaderPath = tempFolder.relative("increment.spv");
@@ -229,35 +227,50 @@ TEST(IScenario, ExecutesCommandWithDifferentInputsAcrossRuns) {
     ASSERT_TRUE(spirv.first.empty()) << spirv.first;
     ASSERT_TRUE(GlslCompiler::get().save(spirv.second, shaderPath.string()));
 
-    ScenarioSpec spec{std::string{computeScenarioJson}, shaderPath.parent_path()};
-    Scenario scenario{ScenarioOptions{}, spec};
-    IScenario &api = scenario;
-    const auto inputId = api.getBufferId("input");
-    const auto outputId = api.getBufferId("output");
+    std::unique_ptr<IScenarioBuilder> builder = std::make_unique<ScenarioBuilder>();
+
+    ShaderInfo shaderInfo{};
+    shaderInfo.debugName = "increment";
+    shaderInfo.entry = "main";
+    shaderInfo.src = shaderPath.string();
+    shaderInfo.shaderType = ShaderType::SPIR_V;
+    shaderInfo.stage = ShaderStage::Compute;
+    const auto shaderId = builder->addShader(shaderInfo);
+    const auto inputId = builder->addBuffer(BufferInfo{"input", 16, 0});
+    const auto outputId = builder->addBuffer(BufferInfo{"output", 16, 0});
+
+    DispatchComputeData dispatch{shaderId};
+    dispatch.debugName = "increment";
+    dispatch.bindings = {{0, 0, inputId, std::nullopt, vk::DescriptorType::eStorageBuffer},
+                         {0, 1, outputId, std::nullopt, vk::DescriptorType::eStorageBuffer}};
+    dispatch.computeDispatch.gwcx = 4;
+    dispatch.computeDispatch.profileName = dispatch.debugName;
+    builder->addDispatchCompute(std::move(dispatch));
+
+    std::unique_ptr<IScenario> api = builder->build(ScenarioOptions{});
 
     const auto firstInput = asBytes(std::vector<uint32_t>{1, 2, 3, 4});
-    api.upload(inputId, {firstInput.data(), firstInput.size()});
-    api.run();
-    EXPECT_EQ(api.download(outputId).data, asBytes(std::vector<uint32_t>{2, 3, 4, 5}));
+    api->upload(inputId, {firstInput.data(), firstInput.size()});
+    api->run();
+    EXPECT_EQ(api->download(outputId).data, asBytes(std::vector<uint32_t>{2, 3, 4, 5}));
 
     const auto secondInput = asBytes(std::vector<uint32_t>{10, 20, 30, 40});
-    api.upload(inputId, {secondInput.data(), secondInput.size()});
-    api.run();
-    EXPECT_EQ(api.download(outputId).data, asBytes(std::vector<uint32_t>{11, 21, 31, 41}));
+    api->upload(inputId, {secondInput.data(), secondInput.size()});
+    api->run();
+    EXPECT_EQ(api->download(outputId).data, asBytes(std::vector<uint32_t>{11, 21, 31, 41}));
 }
 
 TEST(IScenario, RejectsUnknownTypedIds) {
     ScenarioSpec spec{scenarioJson};
     spec.useComputeFamilyQueue = true;
-    Scenario scenario{ScenarioOptions{}, spec};
-    IScenario &api = scenario;
+    auto api = buildScenario(spec);
     const std::vector<char> payload(4);
 
-    EXPECT_THROW(api.upload(BufferId{1}, {payload.data(), payload.size()}), std::runtime_error);
-    EXPECT_THROW(api.upload(TensorId{1}, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Sint}),
+    EXPECT_THROW(api->upload(BufferId{1}, {payload.data(), payload.size()}), std::runtime_error);
+    EXPECT_THROW(api->upload(TensorId{1}, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Sint}),
                  std::runtime_error);
-    EXPECT_THROW(api.upload(ImageId{0}, {}), std::runtime_error);
-    EXPECT_THROW(static_cast<void>(api.download(BufferId{1})), std::runtime_error);
-    EXPECT_THROW(static_cast<void>(api.download(TensorId{1})), std::runtime_error);
-    EXPECT_THROW(static_cast<void>(api.download(ImageId{0})), std::runtime_error);
+    EXPECT_THROW(api->upload(ImageId{0}, {}), std::runtime_error);
+    EXPECT_THROW(static_cast<void>(api->download(BufferId{1})), std::runtime_error);
+    EXPECT_THROW(static_cast<void>(api->download(TensorId{1})), std::runtime_error);
+    EXPECT_THROW(static_cast<void>(api->download(ImageId{0})), std::runtime_error);
 }


### PR DESCRIPTION
Add a public builder interface for registering typed resources and commands. Resource registration returns stable typed IDs that callers retain for subsequent upload and download operations.

Make ScenarioBuilder consume its build data and return a ready-to-run IScenario. Support both programmatic construction and the existing scenario.json path, and update main to construct scenarios through the new interface.

Change-Id: I0f63b51cb0d6eeb26b7ebd792e0c428022cefbbf