### PR TITLE
refactor: Avoid default arguments on virtual function

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,7 @@ Checks: >
     cppcoreguidelines-rvalue-reference-param-not-moved,
     cppcoreguidelines-virtual-class-destructor,
     google-build-namespaces,
+    google-default-arguments,
     misc-definitions-in-headers,
     misc-static-assert,
     misc-unused-*,

--- a/src/iscenario.hpp
+++ b/src/iscenario.hpp
@@ -20,10 +20,13 @@ class IScenario {
   public:
     virtual ~IScenario() = default;
 
+    /// @brief Single execution of the scenario.
+    virtual void run() = 0;
+
     /// @brief Execute the scenario one or more times.
     /// @param repeatCount Number of executions; must be greater than zero.
     /// @param dryRun Skip workload execution and output-resource saving.
-    virtual void run(int repeatCount = 1, bool dryRun = false) = 0;
+    virtual void run(int repeatCount, bool dryRun) = 0;
 
     virtual BufferId getBufferId(std::string_view uid) const = 0;
     virtual ImageId getImageId(std::string_view uid) const = 0;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -789,6 +789,8 @@ const ShaderInfo &Scenario::getSubstitutionShader(const std::vector<ResolvedShad
     throw std::runtime_error("Could not perform shader substitution");
 }
 
+void Scenario::run() { run(1, false); }
+
 void Scenario::run(int repeatCount, bool dryRun) {
     if (repeatCount <= 0) {
         throw std::invalid_argument("Scenario repeat count must be greater than zero; received " +

--- a/src/scenario.hpp
+++ b/src/scenario.hpp
@@ -34,8 +34,11 @@ class Scenario : public IScenario {
     /// \brief Destructor
     ~Scenario() override = default;
 
+    /// \brief Single execution of the scenario.
+    void run() override;
+
     /// \brief Execute the scenario one or more times.
-    void run(int repeatCount = 1, bool dryRun = false) override;
+    void run(int repeatCount, bool dryRun) override;
 
     /// \brief Get a buffer resource ID from its UID
     BufferId getBufferId(std::string_view uid) const override;

--- a/src/tests/scenario_tests.cpp
+++ b/src/tests/scenario_tests.cpp
@@ -136,7 +136,7 @@ TEST(ScenarioInMemoryTransfer, RejectsNonPositiveRepeatCount) {
     auto scenario = buildScenario(spec);
 
     try {
-        scenario->run(0);
+        scenario->run(0, false);
         FAIL() << "Expected std::invalid_argument";
     } catch (const std::invalid_argument &error) {
         EXPECT_STREQ(error.what(), "Scenario repeat count must be greater than zero; received 0.");


### PR DESCRIPTION
Add clang-tidy rule for it.

Change-Id: Ibc314aaaae042ac259791aa8ba9c32968ae61fbb