### PR TITLE
refactor: represent resource data as bytes

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -85,15 +85,15 @@ BufferData Buffer::download(const Context &ctx) const {
 
     BufferData bd;
     bd.data.resize(size());
-    const auto *mapped = static_cast<const char *>(_memoryManager->mapStagingBufferMemory(_memoryOffset, size()));
+    const auto *mapped = static_cast<const std::byte *>(_memoryManager->mapStagingBufferMemory(_memoryOffset, size()));
     std::memcpy(bd.data.data(), mapped, bd.data.size());
     return bd;
 }
 
 void Buffer::store(const Context &ctx, const std::string &filename) const {
     const auto bufferContents = download(ctx);
-    vgfutils::numpy::DataPtr data(bufferContents.data.data(), {static_cast<int64_t>(bufferContents.data.size())},
-                                  vgfutils::numpy::DType('i', 1));
+    vgfutils::numpy::DataPtr data(reinterpret_cast<const char *>(bufferContents.data.data()),
+                                  {static_cast<int64_t>(bufferContents.data.size())}, vgfutils::numpy::DType('i', 1));
     vgfutils::numpy::write(filename, data);
 }
 

--- a/src/resource_data.hpp
+++ b/src/resource_data.hpp
@@ -18,7 +18,7 @@ struct BufferDataView {
 };
 
 struct BufferData {
-    std::vector<char> data;
+    std::vector<std::byte> data;
 };
 
 struct TensorDataView {
@@ -29,7 +29,7 @@ struct TensorDataView {
 };
 
 struct TensorData {
-    std::vector<char> data;
+    std::vector<std::byte> data;
     std::vector<int64_t> shape;
     std::optional<vk::Format> format{std::nullopt};
 };

--- a/src/scenario_json_factory.cpp
+++ b/src/scenario_json_factory.cpp
@@ -66,7 +66,7 @@ ImageLoadResult loadData(const std::string &fileName, vk::Format dataType, const
 BufferData loadBufferData(const BufferDesc &desc) {
     BufferData bufferData;
     if (!desc.src.has_value()) {
-        bufferData.data.resize(desc.size, 0);
+        bufferData.data.resize(desc.size, std::byte{0});
         return bufferData;
     }
 
@@ -84,7 +84,7 @@ TensorData loadTensorData(const TensorDesc &desc) {
     if (!desc.src.has_value()) {
         const auto format = getVkFormatFromString(desc.format);
         const auto expectedSize = elementSizeFromVkFormat(format) * totalElementsFromShape(desc.dims);
-        tensorData.data.resize(expectedSize, 0);
+        tensorData.data.resize(expectedSize, std::byte{0});
         return tensorData;
     }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -196,17 +196,17 @@ TensorData Tensor::download(const Context &ctx) const {
     return tensorData;
 }
 
-std::vector<char> Tensor::getTensorData(const Context &ctx) const {
+std::vector<std::byte> Tensor::getTensorData(const Context &ctx) const {
     _memoryManager->downloadData(ctx, _memoryManager->getSubresourceOffset() + _memoryOffset, _size);
 
     const ScopeExit<void()> onScopeExitRun([&]() { _memoryManager->unmapStagingBufferMemory(); });
 
     // 1) map the GPU memory
-    const auto *mapped = static_cast<char *>(
+    const auto *mapped = static_cast<std::byte *>(
         _memoryManager->mapStagingBufferMemory(_memoryManager->getSubresourceOffset() + _memoryOffset, _size));
     const auto dSize = dataSize();
 
-    std::vector<char> out;
+    std::vector<std::byte> out;
     // 2) If padded/tiled (_size != dataSize) *and* a 4D tensor with strides,
     //    walk element-by-element using those strides to lay out the data correctly
     if (_size != dSize && _shape.size() == _strides.size() && _shape.size() == 4) {
@@ -240,7 +240,8 @@ std::vector<char> Tensor::getTensorData(const Context &ctx) const {
 
 void Tensor::store(const Context &ctx, const std::string &filename) const {
     const auto tensorData = download(ctx);
-    const vgfutils::numpy::DataPtr dataPtr(tensorData.data.data(), _rankConverted ? std::vector<int64_t>(0) : _shape,
+    const vgfutils::numpy::DataPtr dataPtr(reinterpret_cast<const char *>(tensorData.data.data()),
+                                           _rankConverted ? std::vector<int64_t>(0) : _shape,
                                            getDTypeFromVkFormat(dataType()));
     vgfutils::numpy::write(filename, dataPtr);
 }

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -89,7 +89,7 @@ class Tensor {
     bool _rankConverted{false};
     bool _descriptorBufferCaptureReplay{false};
 
-    std::vector<char> getTensorData(const Context &ctx) const;
+    std::vector<std::byte> getTensorData(const Context &ctx) const;
 };
 
 } // namespace mlsdk::scenariorunner

--- a/src/tests/buffer_tests.cpp
+++ b/src/tests/buffer_tests.cpp
@@ -8,10 +8,13 @@
 #include "data_manager.hpp"
 #include "resource_data.hpp"
 #include "scenario_options.hpp"
-#include <gtest/gtest.h>
 
-#include <numeric>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <vector>
+
+#include <gtest/gtest.h>
 
 using namespace mlsdk::scenariorunner;
 
@@ -32,7 +35,7 @@ TEST(BufferInMemoryTransfer, UploadThrowsOnSizeMismatch) {
 
     auto &buf = prepareBuffer(ctx, dm, BufferId{0}, /*sizeBytes*/ 16);
 
-    std::vector<char> small(8, static_cast<char>(0x7B));
+    std::vector<std::byte> small(8, std::byte{0x7B});
     BufferDataView view{small.data(), small.size()};
     EXPECT_THROW(buf.upload(ctx, view), std::runtime_error);
 }
@@ -44,19 +47,20 @@ TEST(BufferInMemoryTransfer, UploadSucceedsAndPersistsCopy) {
 
     auto &buf = prepareBuffer(ctx, dm, BufferId{0}, /*sizeBytes*/ 16);
 
-    std::vector<char> payload(16);
-    std::iota(payload.begin(), payload.end(), static_cast<char>(0));
+    std::vector<std::byte> payload(16);
+    uint8_t value = 0;
+    std::generate(payload.begin(), payload.end(), [&value] { return std::byte{value++}; });
     BufferDataView view{payload.data(), payload.size()};
     ASSERT_NO_THROW(buf.upload(ctx, view));
 
     // Mutate source to ensure Buffer keeps a copy, not an alias
-    std::fill(payload.begin(), payload.end(), static_cast<char>(0xAA));
+    std::fill(payload.begin(), payload.end(), std::byte{0xAA});
 
     const auto bufferData = buf.download(ctx);
     ASSERT_EQ(bufferData.data.size(), static_cast<size_t>(buf.size()));
 
     for (size_t i = 0; i < bufferData.data.size(); ++i) {
-        EXPECT_EQ(static_cast<unsigned char>(bufferData.data[i]), static_cast<unsigned char>(i))
+        EXPECT_EQ(std::to_integer<unsigned char>(bufferData.data[i]), static_cast<unsigned char>(i))
             << "mismatch at index " << i;
     }
 }
@@ -68,8 +72,9 @@ TEST(BufferInMemoryTransfer, DownloadReturnsUploadedData) {
 
     auto &buf = prepareBuffer(ctx, dm, BufferId{0}, /*sizeBytes*/ 12);
 
-    std::vector<char> payload(12);
-    std::iota(payload.begin(), payload.end(), static_cast<char>(0));
+    std::vector<std::byte> payload(12);
+    uint8_t value = 0;
+    std::generate(payload.begin(), payload.end(), [&value] { return std::byte{value++}; });
     BufferDataView view{payload.data(), payload.size()};
     buf.upload(ctx, view);
 

--- a/src/tests/scenario_tests.cpp
+++ b/src/tests/scenario_tests.cpp
@@ -49,8 +49,8 @@ const std::string scenarioJson = R"(
         }
     )";
 
-template <typename T> std::vector<char> asBytes(const std::vector<T> &values) {
-    std::vector<char> bytes(values.size() * sizeof(T));
+template <typename T> std::vector<std::byte> asBytes(const std::vector<T> &values) {
+    std::vector<std::byte> bytes(values.size() * sizeof(T));
     std::memcpy(bytes.data(), values.data(), bytes.size());
     return bytes;
 }
@@ -62,7 +62,7 @@ TEST(IScenarioBuilder, BuildsScenarioWithRetainedTypedHandles) {
     const auto bufferId = builder->addBuffer(BufferInfo{"in_memory_buffer", 4, 0});
 
     std::unique_ptr<IScenario> scenario = builder->build(ScenarioOptions{});
-    const std::vector<char> payload{1, 2, 3, 4};
+    const std::vector<std::byte> payload{std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
     scenario->upload(bufferId, {payload.data(), payload.size()});
     scenario->run();
 
@@ -100,7 +100,7 @@ TEST(IScenario, ScenarioSupportsVirtualDispatch) {
     std::unique_ptr<IScenario> api = ScenarioJsonFactory::make(ScenarioOptions{}, spec);
 
     const auto bufferId = api->getBufferId("inBuffer");
-    const std::vector<char> payload{1, 2, 3, 4};
+    const std::vector<std::byte> payload{std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
     api->upload(bufferId, {payload.data(), payload.size()});
     api->run();
 
@@ -158,7 +158,7 @@ TEST(ScenarioJsonFactory, BuiltScenarioOwnsJsonConstructionData) {
     }();
 
     const auto bufferId = api->getBufferId("inBuffer");
-    const std::vector<char> payload{1, 2, 3, 4};
+    const std::vector<std::byte> payload{std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
     api->upload(bufferId, {payload.data(), payload.size()});
     api->run();
 
@@ -173,8 +173,8 @@ TEST(ScenarioInMemoryTransfer, UploadsAndDownloadsByTypedIdAcrossRuns) {
     const auto bufferId = scenario->getBufferId("inBuffer");
     const auto tensorId = scenario->getTensorId("inTensor");
 
-    std::vector<char> firstBuffer{1, 2, 3, 4};
-    std::vector<char> firstTensor{5, 6, 7, 8};
+    std::vector<std::byte> firstBuffer{std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
+    std::vector<std::byte> firstTensor{std::byte{5}, std::byte{6}, std::byte{7}, std::byte{8}};
     scenario->upload(bufferId, {firstBuffer.data(), firstBuffer.size()});
     scenario->upload(tensorId, {firstTensor.data(), firstTensor.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
     scenario->run();
@@ -182,8 +182,8 @@ TEST(ScenarioInMemoryTransfer, UploadsAndDownloadsByTypedIdAcrossRuns) {
     EXPECT_EQ(scenario->download(bufferId).data, firstBuffer);
     EXPECT_EQ(scenario->download(tensorId).data, firstTensor);
 
-    std::vector<char> secondBuffer{9, 10, 11, 12};
-    std::vector<char> secondTensor{13, 14, 15, 16};
+    std::vector<std::byte> secondBuffer{std::byte{9}, std::byte{10}, std::byte{11}, std::byte{12}};
+    std::vector<std::byte> secondTensor{std::byte{13}, std::byte{14}, std::byte{15}, std::byte{16}};
     scenario->upload(bufferId, {secondBuffer.data(), secondBuffer.size()});
     scenario->upload(tensorId, {secondTensor.data(), secondTensor.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
     scenario->run();
@@ -200,8 +200,8 @@ TEST(ScenarioInMemoryTransfer, InitializesResourcesWithoutSourcesThroughTypedUpl
     const auto buffer = scenario->download(scenario->getBufferId("inBuffer"));
     const auto tensor = scenario->download(scenario->getTensorId("inTensor"));
 
-    EXPECT_EQ(buffer.data, std::vector<char>(4, 0));
-    EXPECT_EQ(tensor.data, std::vector<char>(4, 0));
+    EXPECT_EQ(buffer.data, std::vector<std::byte>(4));
+    EXPECT_EQ(tensor.data, std::vector<std::byte>(4));
     EXPECT_EQ(tensor.shape, (std::vector<int64_t>{1, 2, 2, 1}));
     ASSERT_TRUE(tensor.format.has_value());
     EXPECT_EQ(tensor.format.value(), vk::Format::eR8Sint);
@@ -260,7 +260,7 @@ TEST(IScenario, SupportsTensorUploadAndDownload) {
     auto api = ScenarioJsonFactory::make(ScenarioOptions{}, spec);
 
     const auto tensorId = api->getTensorId("inTensor");
-    const std::vector<char> payload{1, 2, 3, 4};
+    const std::vector<std::byte> payload{std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
     api->upload(tensorId, {payload.data(), payload.size(), {1, 2, 2, 1}, vk::Format::eR8Sint});
 
     const auto result = api->download(tensorId);
@@ -276,12 +276,12 @@ TEST(IScenario, SupportsRepeatedUploadRunDownload) {
     auto api = ScenarioJsonFactory::make(ScenarioOptions{}, spec);
     const auto bufferId = api->getBufferId("inBuffer");
 
-    const std::vector<char> firstPayload{1, 2, 3, 4};
+    const std::vector<std::byte> firstPayload{std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
     api->upload(bufferId, {firstPayload.data(), firstPayload.size()});
     api->run();
     EXPECT_EQ(api->download(bufferId).data, firstPayload);
 
-    const std::vector<char> secondPayload{5, 6, 7, 8};
+    const std::vector<std::byte> secondPayload{std::byte{5}, std::byte{6}, std::byte{7}, std::byte{8}};
     api->upload(bufferId, {secondPayload.data(), secondPayload.size()});
     api->run();
     EXPECT_EQ(api->download(bufferId).data, secondPayload);

--- a/src/tests/tensor_tests.cpp
+++ b/src/tests/tensor_tests.cpp
@@ -10,8 +10,10 @@
 #include "tensor.hpp"
 #include "utils.hpp"
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
-#include <numeric>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -36,6 +38,12 @@ size_t bytesFor(vk::Format format, const std::vector<int64_t> &shape) {
     return static_cast<size_t>(elementSizeFromVkFormat(format) * totalElementsFromShape(shape));
 }
 
+std::vector<std::byte> sequence(size_t size, uint8_t first = 0) {
+    std::vector<std::byte> result(size);
+    std::generate(result.begin(), result.end(), [&first] { return std::byte{first++}; });
+    return result;
+}
+
 TEST(TensorInMemoryTransfer, UploadThrowsOnShapeMismatch) {
     ScenarioOptions opts{};
     Context ctx{opts};
@@ -44,7 +52,7 @@ TEST(TensorInMemoryTransfer, UploadThrowsOnShapeMismatch) {
     const vk::Format fmt = vk::Format::eR8Uint;
 
     auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
-    std::vector<char> payload(bytesFor(fmt, shape), 0x3C);
+    std::vector<std::byte> payload(bytesFor(fmt, shape), std::byte{0x3C});
 
     const std::vector<int64_t> wrongShape{2, 3};
     TensorDataView view{payload.data(), payload.size(), {}, std::nullopt};
@@ -61,7 +69,7 @@ TEST(TensorInMemoryTransfer, UploadThrowsOnIncompatibleFormatWhenProvided) {
     const vk::Format fmt = vk::Format::eR8Uint;
 
     auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
-    std::vector<char> payload(bytesFor(fmt, shape), 0x7F);
+    std::vector<std::byte> payload(bytesFor(fmt, shape), std::byte{0x7F});
 
     TensorDataView view{payload.data(), payload.size(), {}, std::nullopt};
     view.shape = shape;
@@ -77,7 +85,7 @@ TEST(TensorInMemoryTransfer, UploadThrowsOnSizeMismatch) {
     const vk::Format fmt = vk::Format::eR8Uint;
 
     auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
-    std::vector<char> small(3, 0x11); // too small by 1 byte
+    std::vector<std::byte> small(3, std::byte{0x11}); // too small by 1 byte
 
     TensorDataView view{small.data(), small.size(), {}, std::nullopt};
     view.shape = shape;
@@ -92,14 +100,13 @@ TEST(TensorInMemoryTransfer, UploadSucceedsAndPersistsCopy_FormatOptional) {
     const vk::Format fmt = vk::Format::eR8Uint; // 6 bytes
 
     auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
-    std::vector<char> payload(bytesFor(fmt, shape));
-    std::iota(payload.begin(), payload.end(), static_cast<char>(1));
+    auto payload = sequence(bytesFor(fmt, shape), 1);
     TensorDataView view{payload.data(), payload.size(), {}, std::nullopt};
     view.shape = shape;
     ASSERT_NO_THROW(tensor.upload(ctx, view));
 
     // Mutate source to ensure copy semantics
-    std::fill(payload.begin(), payload.end(), static_cast<char>(0xAA));
+    std::fill(payload.begin(), payload.end(), std::byte{0xAA});
 
     const auto tensorData = tensor.download(ctx);
     ASSERT_EQ(tensorData.data.size(), payload.size());
@@ -107,7 +114,7 @@ TEST(TensorInMemoryTransfer, UploadSucceedsAndPersistsCopy_FormatOptional) {
     ASSERT_TRUE(tensorData.format.has_value());
     EXPECT_EQ(tensorData.format.value(), fmt);
     for (size_t i = 0; i < tensorData.data.size(); ++i) {
-        EXPECT_EQ(static_cast<unsigned char>(tensorData.data[i]), static_cast<unsigned char>(i + 1))
+        EXPECT_EQ(std::to_integer<unsigned char>(tensorData.data[i]), static_cast<unsigned char>(i + 1))
             << "mismatch at index " << i;
     }
 }
@@ -121,7 +128,7 @@ TEST(TensorInMemoryTransfer, UploadAcceptsRankConvertedEmptyShape) {
 
     auto &tensor = prepareTensor(ctx, dm, TensorId{0}, emptyShape, fmt);
 
-    std::vector<char> payload(1, static_cast<char>(0x5A));
+    std::vector<std::byte> payload(1, std::byte{0x5A});
     TensorDataView view{payload.data(), payload.size(), {}, std::nullopt};
     view.shape = emptyShape;
     ASSERT_NO_THROW(tensor.upload(ctx, view));
@@ -143,8 +150,7 @@ TEST(TensorInMemoryTransfer, DownloadReturnsUploadedData) {
     const vk::Format fmt = vk::Format::eR8Uint; // 6 bytes
 
     auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, fmt);
-    std::vector<char> payload(bytesFor(fmt, shape));
-    std::iota(payload.begin(), payload.end(), static_cast<char>(0));
+    auto payload = sequence(bytesFor(fmt, shape));
     TensorDataView view{payload.data(), payload.size(), {}, std::nullopt};
     view.shape = shape;
     view.format = fmt;
@@ -167,8 +173,7 @@ TEST(TensorInMemoryTransfer, UploadAndDownloadRespectMemoryOffset) {
     constexpr uint64_t memoryOffset = 4096;
 
     auto &tensor = prepareTensor(ctx, dm, TensorId{0}, shape, format, memoryOffset);
-    std::vector<char> payload(bytesFor(format, shape));
-    std::iota(payload.begin(), payload.end(), static_cast<char>(1));
+    auto payload = sequence(bytesFor(format, shape), 1);
 
     TensorDataView view{payload.data(), payload.size(), shape, format};
     ASSERT_NO_THROW(tensor.upload(ctx, view));
@@ -201,8 +206,7 @@ TEST(TensorInMemoryTransfer, UploadAndDownloadRespectImageSubresourceOffset) {
     tensor.setup(ctx, memoryManager);
     tensor.allocateMemory(ctx);
 
-    std::vector<char> payload(bytesFor(format, shape));
-    std::iota(payload.begin(), payload.end(), static_cast<char>(1));
+    auto payload = sequence(bytesFor(format, shape), 1);
     ASSERT_NO_THROW(tensor.upload(ctx, {payload.data(), payload.size(), shape, format}));
 
     const auto tensorData = tensor.download(ctx);


### PR DESCRIPTION
Use std::byte for downloaded buffer and tensor payloads, matching image data and making the binary nature of resource contents explicit. Update resource loading, storage, and tests for the byte-based representation.


Change-Id: I3c44d392f7bdd8d806bb8f5e070f52300126268f