### PR TITLE
feat: Add infrastructure for Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 # Options
 #############################################################################
 option(SCENARIO_RUNNER_BUILD_TESTS "Build Scenario Runner unit tests" OFF)
+option(SCENARIO_RUNNER_BUILD_PYLIB "Build Scenario Runner Python bindings" OFF)
 option(SCENARIO_RUNNER_ENABLE_CCACHE "Enable CCACHE support" OFF)
 option(SCENARIO_RUNNER_ENABLE_RDOC "Build Scenario Runner w/ RDoc support enabled" OFF)
 option(SCENARIO_RUNNER_BUILD_DOCS "Build project documentation" OFF)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 
 ### Build, Packaging & Developer Experience
 
+- Added the optional pybind11-based `scenario_runner_py` module for Python clients.
 - Updated Scenario Runner to consume explicit VGF graph constant bindings.
 - Updated Scenario Runner `--version` output to report the package version and include git revision and dependency revision information.
 - Added KosmicKrisp support on Darwin.

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -1,0 +1,19 @@
+#
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+include(version)
+
+set(PYBIND11_PATH "PYBIND11-NOTFOUND" CACHE PATH "Path to Pybind11")
+set(pybind11_VERSION "unknown")
+
+if(EXISTS ${PYBIND11_PATH}/CMakeLists.txt)
+    if(NOT TARGET pybind11)
+        add_subdirectory(${PYBIND11_PATH} pybind11 EXCLUDE_FROM_ALL)
+    endif()
+
+    mlsdk_get_git_revision(${PYBIND11_PATH} pybind11_VERSION)
+else()
+    find_package(pybind11 REQUIRED CONFIG)
+endif()

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -47,6 +47,7 @@ class Builder:
         self.test_dir = pathlib.Path(self.build_dir) / "src" / "tests"
         self.threads = args.threads
         self.run_tests = args.test
+        self.build_pylib = args.build_pylib
         self.build_type = args.build_type
         self.target_platform = args.target_platform
         self.cmake_toolchain_for_android = args.cmake_toolchain_for_android
@@ -236,7 +237,10 @@ class Builder:
         if self.run_tests:
             cmake_setup_cmd.append("-DSCENARIO_RUNNER_BUILD_TESTS=ON")
             cmake_setup_cmd.append(f"-DGTEST_PATH={self.gtest_path}")
+
+        if self.build_pylib or self.run_tests:
             cmake_setup_cmd.append(f"-DPYBIND11_PATH={self.pybind11_path}")
+            cmake_setup_cmd.append("-DSCENARIO_RUNNER_BUILD_PYLIB=ON")
 
         if self.doc:
             cmake_setup_cmd.append("-DSCENARIO_RUNNER_BUILD_DOCS=ON")
@@ -588,6 +592,12 @@ def parse_arguments(argv=None):
         "-t",
         "--test",
         help="Run unit tests after build. Default: %(default)s",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--build-pylib",
+        help="Build Scenario Runner Python bindings. Default: %(default)s",
         action="store_true",
         default=False,
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,16 @@ endif()
 
 target_compile_options(ScenarioRunnerLib PRIVATE ${ML_SDK_SCENARIO_RUNNER_COMPILE_OPTIONS})
 
+if(SCENARIO_RUNNER_BUILD_PYLIB AND NOT ANDROID)
+    include(pybind11)
+    pybind11_add_module(scenario_runner_py
+        scenario_runner_py.cpp
+        scenario_py.cpp
+    )
+    target_compile_options(scenario_runner_py PRIVATE ${ML_SDK_SCENARIO_RUNNER_COMPILE_OPTIONS})
+    target_link_libraries(scenario_runner_py PRIVATE ScenarioRunnerLib pybind11::module)
+endif()
+
 add_subdirectory(tools)
 if(SCENARIO_RUNNER_EXPERIMENTAL_VGF_RUNTIME AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_subdirectory(vgf_runtime)

--- a/src/scenario_py.cpp
+++ b/src/scenario_py.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "iscenario.hpp"
+#include "scenario_options.hpp"
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
+
+#include <memory>
+#include <string>
+
+namespace py = pybind11;
+
+namespace mlsdk::scenariorunner {
+namespace {
+
+template <typename Id> void bindResourceId(py::module_ &m, const char *name) {
+    py::class_<Id>(m, name)
+        .def_property_readonly("value", &Id::value)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def("__hash__", [](Id id) { return std::hash<Id>{}(id); })
+        .def("__repr__", [name](Id id) { return std::string{name} + "(" + std::to_string(id.value()) + ")"; });
+}
+
+} // namespace
+} // namespace mlsdk::scenariorunner
+
+void pyInitIScenario(py::module_ &m) {
+    using namespace mlsdk::scenariorunner;
+
+    bindResourceId<BufferId>(m, "BufferId");
+    bindResourceId<ImageId>(m, "ImageId");
+    bindResourceId<TensorId>(m, "TensorId");
+    py::enum_<vk::NeuralAcceleratorStatisticsModeARM>(m, "NeuralAcceleratorStatisticsMode")
+        .value("Disabled", vk::NeuralAcceleratorStatisticsModeARM::eDisabled)
+        .value("Statistics0", vk::NeuralAcceleratorStatisticsModeARM::eStatistics0)
+        .value("Statistics1", vk::NeuralAcceleratorStatisticsModeARM::eStatistics1);
+
+    py::class_<ScenarioOptions>(m, "ScenarioOptions")
+        .def(py::init<>())
+        .def_readwrite("enable_pipeline_caching", &ScenarioOptions::enablePipelineCaching)
+        .def_readwrite("clear_pipeline_cache", &ScenarioOptions::clearPipelineCache)
+        .def_readwrite("fail_on_pipeline_cache_miss", &ScenarioOptions::failOnPipelineCacheMiss)
+        .def_readwrite("enable_gpu_debug_markers", &ScenarioOptions::enableGPUDebugMarkers)
+        .def_readwrite("capture_frame", &ScenarioOptions::captureFrame)
+        .def_readwrite("enable_robustness_features", &ScenarioOptions::enableRobustnessFeatures)
+        .def_readwrite("pipeline_cache_path", &ScenarioOptions::pipelineCachePath)
+        .def_readwrite("neural_debug_database_dump_dir", &ScenarioOptions::neuralDebugDatabaseDumpDir)
+        .def_readwrite("neural_statistics_dump_dir", &ScenarioOptions::neuralStatisticsDumpDir)
+        .def_readwrite("graph_profiling_dump_dir", &ScenarioOptions::graphProfilingDumpDir)
+        .def_readwrite("session_rams_dump_dir", &ScenarioOptions::sessionRAMsDumpDir)
+        .def_readwrite("perf_counters_path", &ScenarioOptions::perfCountersPath)
+        .def_readwrite("profiling_path", &ScenarioOptions::profilingPath)
+        .def_readwrite("neural_statistics_mode", &ScenarioOptions::neuralStatisticsMode)
+        .def_readwrite("disabled_extensions", &ScenarioOptions::disabledExtensions);
+
+    py::class_<IScenario, std::unique_ptr<IScenario>>(m, "IScenario")
+        .def("run", py::overload_cast<int, bool>(&IScenario::run), py::arg("repeat_count") = 1,
+             py::arg("dry_run") = false, py::call_guard<py::gil_scoped_release>())
+        .def("get_buffer_id", &IScenario::getBufferId)
+        .def("get_image_id", &IScenario::getImageId)
+        .def("get_tensor_id", &IScenario::getTensorId);
+}

--- a/src/scenario_runner_py.cpp
+++ b/src/scenario_runner_py.cpp
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+extern void pyInitIScenario(py::module_ &m);
+
+PYBIND11_MODULE(scenario_runner_py, m) { pyInitIScenario(m); }

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -592,6 +592,8 @@ def pytest_configure(config):
     if scenario_runner_build_path:
         vgf_pylib_path = Path(scenario_runner_build_path) / "vgf-lib" / "src"
         sys.path.append(str(vgf_pylib_path))
+        scenario_runner_pylib_path = Path(scenario_runner_build_path) / "src"
+        sys.path.append(str(scenario_runner_pylib_path))
 
     if config.getoption("--sanitizers") and platform.system() == "Windows":
         asan_dll_path = os.getenv("ASAN_DLL_PATH")


### PR DESCRIPTION
Add the build infrastructure required to develop Python bindings for Scenario Runner.

Add pybind11 as a dependency, introduce a CMake option for enabling the bindings, and update the build script to support building them. Include initial bindings to validate the setup.

Change-Id: I4f5a43e32fb752bb37607f2c1cf86a4227259d04