### PR TITLE
chore: complete Python bindings for Scenario

### DIFF
--- a/src/scenario_py.cpp
+++ b/src/scenario_py.cpp
@@ -5,13 +5,19 @@
 
 #include "iscenario.hpp"
 #include "scenario_options.hpp"
+#include "utils.hpp"
+
+#include <pybind11/numpy.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl/filesystem.h>
 
+#include <cstdint>
+#include <cstring>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace py = pybind11;
 
@@ -25,6 +31,99 @@ template <typename Id> void bindResourceId(py::module_ &m, const char *name) {
         .def(py::self != py::self)
         .def("__hash__", [](Id id) { return std::hash<Id>{}(id); })
         .def("__repr__", [name](Id id) { return std::string{name} + "(" + std::to_string(id.value()) + ")"; });
+}
+
+py::buffer_info requireContiguousArray(const py::array &array) {
+    if ((array.flags() & py::array::c_style) == 0) {
+        throw py::value_error("Resource upload requires a C-contiguous NumPy array");
+    }
+    return array.request();
+}
+
+std::vector<int64_t> arrayShape(const py::buffer_info &buffer) {
+    std::vector<int64_t> shape;
+    shape.reserve(static_cast<size_t>(buffer.ndim));
+    for (const auto dimension : buffer.shape) {
+        shape.push_back(static_cast<int64_t>(dimension));
+    }
+    return shape;
+}
+
+size_t arraySizeBytes(const py::buffer_info &buffer) {
+    return static_cast<size_t>(buffer.size) * static_cast<size_t>(buffer.itemsize);
+}
+
+py::dtype numpyDType(vk::Format format, bool allowPackedFormat) {
+    vgfutils::numpy::DType dataType;
+    if (allowPackedFormat && numComponentsFromVkFormat(format) != 1) {
+        dataType = vgfutils::numpy::DType{'V', elementSizeFromVkFormat(format)};
+    } else {
+        dataType = getDTypeFromVkFormat(format);
+    }
+
+    std::string descriptor;
+    if (dataType.byteorder != '\0') {
+        descriptor.push_back(dataType.byteorder);
+    }
+    descriptor.push_back(dataType.kind);
+    descriptor += std::to_string(dataType.itemsize);
+    return py::dtype(descriptor);
+}
+
+std::vector<py::ssize_t> numpyShape(const std::vector<int64_t> &shape) {
+    std::vector<py::ssize_t> result;
+    result.reserve(shape.size());
+    for (const auto dimension : shape) {
+        if (dimension < 0) {
+            throw std::runtime_error("Resource download returned a negative dimension");
+        }
+        result.push_back(static_cast<py::ssize_t>(dimension));
+    }
+    return result;
+}
+
+py::array copyToArray(const std::vector<std::byte> &data, const std::vector<int64_t> &shape, const py::dtype &dtype) {
+    py::array array(dtype, numpyShape(shape));
+    if (static_cast<size_t>(array.nbytes()) != data.size()) {
+        throw std::runtime_error("Downloaded resource size does not match its shape and format");
+    }
+    std::memcpy(array.mutable_data(), data.data(), data.size());
+    return array;
+}
+
+py::array downloadBuffer(const IScenario &scenario, BufferId id) {
+    BufferData result;
+    {
+        py::gil_scoped_release release;
+        result = scenario.download(id);
+    }
+    py::array_t<uint8_t> array(static_cast<py::ssize_t>(result.data.size()));
+    std::memcpy(array.mutable_data(), result.data.data(), result.data.size());
+    return array;
+}
+
+py::array downloadTensor(const IScenario &scenario, TensorId id) {
+    TensorData result;
+    {
+        py::gil_scoped_release release;
+        result = scenario.download(id);
+    }
+    if (!result.format.has_value()) {
+        throw std::runtime_error("Downloaded tensor does not define a format");
+    }
+    return copyToArray(result.data, result.shape, numpyDType(result.format.value(), false));
+}
+
+py::array downloadImage(IScenario &scenario, ImageId id) {
+    ImageData result;
+    {
+        py::gil_scoped_release release;
+        result = scenario.download(id);
+    }
+    if (!result.format.has_value()) {
+        throw std::runtime_error("Downloaded image does not define a format");
+    }
+    return copyToArray(result.data, result.shape, numpyDType(result.format.value(), true));
 }
 
 } // namespace
@@ -60,9 +159,40 @@ void pyInitIScenario(py::module_ &m) {
         .def_readwrite("disabled_extensions", &ScenarioOptions::disabledExtensions);
 
     py::class_<IScenario, std::unique_ptr<IScenario>>(m, "IScenario")
-        .def("run", py::overload_cast<int, bool>(&IScenario::run), py::arg("repeat_count") = 1,
+        .def("run", py::overload_cast<int, bool>(&IScenario::run), py::kw_only(), py::arg("repeat_count") = 1,
              py::arg("dry_run") = false, py::call_guard<py::gil_scoped_release>())
         .def("get_buffer_id", &IScenario::getBufferId)
         .def("get_image_id", &IScenario::getImageId)
-        .def("get_tensor_id", &IScenario::getTensorId);
+        .def("get_tensor_id", &IScenario::getTensorId)
+        .def(
+            "upload",
+            [](IScenario &scenario, BufferId id, const py::array &array) {
+                const auto buffer = requireContiguousArray(array);
+                const BufferDataView view{buffer.ptr, arraySizeBytes(buffer)};
+                py::gil_scoped_release release;
+                scenario.upload(id, view);
+            },
+            py::arg("id"), py::arg("data"))
+        .def(
+            "upload",
+            [](IScenario &scenario, TensorId id, const py::array &array) {
+                const auto buffer = requireContiguousArray(array);
+                const TensorDataView view{buffer.ptr, arraySizeBytes(buffer), arrayShape(buffer)};
+                py::gil_scoped_release release;
+                scenario.upload(id, view);
+            },
+            py::arg("id"), py::arg("data"))
+        .def(
+            "upload",
+            [](IScenario &scenario, ImageId id, const py::array &array) {
+                const auto buffer = requireContiguousArray(array);
+                const ImageDataView view{buffer.ptr, arraySizeBytes(buffer), arrayShape(buffer), std::nullopt,
+                                         /*mipLevels=*/1};
+                py::gil_scoped_release release;
+                scenario.upload(id, view);
+            },
+            py::arg("id"), py::arg("data"))
+        .def("download", &downloadBuffer, py::arg("id"))
+        .def("download", &downloadTensor, py::arg("id"))
+        .def("download", &downloadImage, py::arg("id"));
 }

--- a/src/tests/test_scenario_bindings.py
+++ b/src/tests/test_scenario_bindings.py
@@ -23,3 +23,88 @@ def test_python_interfaces_and_builder_types():
 
     scenario = builder.build(options=options)
     assert isinstance(scenario, sr.IScenario)
+
+
+def test_numpy_image_upload_supports_single_mip():
+    builder = sr.ScenarioBuilder()
+    image_id = builder.add_image(
+        [1, 2, 2, 1],
+        sr.Format.R8Uint,
+        is_input=True,
+        is_sampled=True,
+        tiling=sr.Tiling.Linear,
+    )
+    scenario = builder.build()
+    image = np.array([1, 2, 3, 4], dtype=np.uint8).reshape(1, 2, 2, 1)
+
+    scenario.upload(image_id, image)
+    np.testing.assert_array_equal(scenario.download(image_id), image)
+
+    with pytest.raises(TypeError):
+        scenario.upload(image_id, image, mip_levels=2)
+
+
+def test_in_memory_scenario_builder_executes_compute(tmp_path, glsl_compiler):
+    shader_path = tmp_path / "increment.comp"
+    shader_path.write_text("""
+        #version 450
+        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+        layout(set = 0, binding = 0) readonly buffer Input { uint values[]; } input_buffer;
+        layout(set = 0, binding = 1) writeonly buffer Output { uint values[]; } output_buffer;
+        void main() {
+            uint index = gl_GlobalInvocationID.x;
+            output_buffer.values[index] = input_buffer.values[index] + 1;
+        }
+        """)
+    compiled_shader = tmp_path / "increment.spv"
+    glsl_compiler.run("--input", shader_path, "--output", compiled_shader)
+
+    builder = sr.ScenarioBuilder()
+
+    shader_info = sr.ShaderInfo()
+    shader_info.debug_name = "increment"
+    shader_info.entry = "main"
+    shader_info.src = str(compiled_shader)
+    shader_info.shader_type = sr.ShaderType.SpirV
+    shader_info.stage = sr.ShaderStage.Compute
+    shader_id = builder.add_shader(shader_info)
+
+    input_info = sr.BufferInfo()
+    input_info.debug_name = "input"
+    input_info.size = 16
+    input_id = builder.add_buffer(input_info)
+
+    output_info = sr.BufferInfo()
+    output_info.debug_name = "output"
+    output_info.size = 16
+    output_id = builder.add_buffer(output_info)
+
+    command = sr.DispatchComputeData(shader_id)
+    command.debug_name = "increment"
+    command.bindings = [
+        sr.TypedBinding(0, 0, input_id, sr.DescriptorType.StorageBuffer),
+        sr.TypedBinding(0, 1, output_id, sr.DescriptorType.StorageBuffer),
+    ]
+    dispatch = sr.ComputeDispatch()
+    dispatch.group_count_x = 4
+    dispatch.profile_name = command.debug_name
+    command.compute_dispatch = dispatch
+    builder.add_dispatch_compute(command)
+
+    assert isinstance(builder, sr.IScenarioBuilder)
+    scenario = builder.build()
+    assert isinstance(scenario, sr.IScenario)
+
+    first_input = np.array([1, 2, 3, 4], dtype=np.uint32)
+    scenario.upload(input_id, first_input)
+    scenario.run()
+    np.testing.assert_array_equal(
+        scenario.download(output_id).view(np.uint32), first_input + 1
+    )
+
+    second_input = np.array([10, 20, 30, 40], dtype=np.uint32)
+    scenario.upload(input_id, second_input)
+    scenario.run()
+    np.testing.assert_array_equal(
+        scenario.download(output_id).view(np.uint32), second_input + 1
+    )


### PR DESCRIPTION
Add NumPy adapters for typed buffer, tensor, and image upload and download operations, and validate repeated transfers and array conversion from Python.

Change-Id: I9b585e9052631bc8b81995ceca40dc656f3eadea